### PR TITLE
bugfix: geoVaLs vector ordering for profiles

### DIFF
--- a/src/tests/orca-jedi/test_interpolator.cc
+++ b/src/tests/orca-jedi/test_interpolator.cc
@@ -122,9 +122,9 @@ CASE("test basic interpolator") {
                                        state, mask, vals);
 
     double missing_value = util::missingValue(vals[0]);
-    std::vector<double> testvals = {18.488888892, 17.9419381132, missing_value,
-                                    missing_value, missing_value, missing_value,
-                                    18.1592999503, 17.75000288, missing_value};
+    std::vector<double> testvals = {18.488888892, missing_value, 18.1592999503,
+                                    17.9419381132, missing_value, 17.75000288,
+                                    missing_value, missing_value, missing_value};
 
     for (int i=0; i < testvals.size(); ++i) {
       std::cout << "vals[" << i << "] " << std::setprecision(12) << vals[i]

--- a/src/tests/testoutput/test_hofx3d_nc_potm.ref
+++ b/src/tests/testoutput/test_hofx3d_nc_potm.ref
@@ -7,6 +7,6 @@ Test     :         sea_water_potential_temperature_background_error: 3.54309e-04
 Test     :         depth: 2.05581e-01
 
 Test     : H(x): 
-Test     : Sea Temperature nobs= 7 Min=17.8889, Max=18.1944, RMS=18.0641
+Test     : Sea Temperature nobs= 6 Min=1.80417e+01, Max=1.81944e+01, RMS=1.81181e+01
 
 Test     : End H(x)


### PR DESCRIPTION
## Description
The "results" vector that contains the GeoVaLs data output by the interpolator was defined in the wrong order. This is only an issue if there is more than one level in the data, as there is for profile data.

The ordering should be by variable, z-level, and then horizontal location, with the location varying the fastest. So for the example of profile of 2 observations with two observed variables, the corresponding geovals from a 3 level background field would look like this:
 
<img width="463" alt="GeoVals ordering" src="https://user-images.githubusercontent.com/14909402/187751752-606fa366-6bb6-45b1-ad9a-0cc8bd019d49.png">

## Testing
  * The ctests have been adjusted here and in [nemo-feedback #18](https://github.com/MetOffice/nemo-feedback/pull/18) to reflect this change.
  * The geoVaLs were saved to file for some example data using the GOMSaver filter and double checked.