### PR TITLE
Replace funcSpace with oops standard functionSpace

### DIFF
--- a/src/orca-jedi/geometry/Geometry.h
+++ b/src/orca-jedi/geometry/Geometry.h
@@ -64,8 +64,6 @@ class Geometry : public util::Printable {
 
   const atlas::Grid & grid() const {return grid_;}
   const atlas::Mesh & mesh() const {return mesh_;}
-  const atlas::functionspace::NodeColumns & funcSpace() const
-    {return funcSpace_;}
   const std::string nemo_var_name(const std::string std_name) const;
   const bool variable_in_variable_type(std::string variable_name,
     std::string variable_type) const;

--- a/src/orca-jedi/interpolator/Interpolator.cc
+++ b/src/orca-jedi/interpolator/Interpolator.cc
@@ -73,7 +73,7 @@ namespace orcamodel {
       comm_(geom.getComm()),
       atlasObsFuncSpace_(std::move(atlasObsFuncSpaceFactory(lats, lons))),
       interpolator_(eckit::LocalConfiguration(conf, "atlas-interpolator"),
-                    geom.funcSpace(),
+                    geom.functionSpace(),
                     atlasObsFuncSpace_ ) {
     params_.validateAndDeserialize(conf);
     oops::Log::trace() << "orcamodel::Interpolator:: conf:" << conf

--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -159,7 +159,7 @@ void State::setupStateFields() {
     // add variable if it isn't already in stateFields
     std::vector<size_t> varSizes = geom_->variableSizes(vars_);
     if (!stateFields_.has(vars_[i])) {
-      stateFields_.add(geom_->funcSpace().createField<double>(
+      stateFields_.add(geom_->functionSpace().createField<double>(
            atlas::option::name(vars_[i]) |
            atlas::option::levels(varSizes[i])));
     }

--- a/src/orca-jedi/state/StateReadUtils.cc
+++ b/src/orca-jedi/state/StateReadUtils.cc
@@ -91,7 +91,7 @@ void readFieldsFromFile(
         field.metadata().set("missing_value_type", "approximately-equals");
         field.metadata().set("missing_value_epsilon", NEMO_FILL_TOL);
         // Add a halo exchange following read to fill out halo points
-        geom.funcSpace().haloExchange(field);
+        geom.functionSpace().haloExchange(field);
       }
     }
 


### PR DESCRIPTION
Tidy up the old function space following the change in https://github.com/MetOffice/orca-jedi/pull/21.

- [x] passes ctests
- [x] builds and runs under bb