### PR TITLE
Improve error clarity when retrieving non-existent model variable

### DIFF
--- a/src/orca-jedi/geometry/Geometry.cc
+++ b/src/orca-jedi/geometry/Geometry.cc
@@ -153,8 +153,11 @@ std::vector<std::string> Geometry::variableNemoSpaces(
     }
     if (varNemoSpaces[i] == "") {
       std::stringstream err_stream;
-      err_stream << "orcamodel::Geometry::variableSizes variable name \" ";
-      err_stream << "\" " << vars[i] << " not recognised. " << std::endl;
+      err_stream << "orcamodel::Geometry::variableSizes variable name \"";
+      err_stream << vars[i] << "\" not available in the state. ";
+      err_stream << "Either add this state variable to the model ";
+      err_stream << "configuration or remove the corresponding obs variable";
+      err_stream << " from the filters configuration." << std::endl;
       throw eckit::BadValue(err_stream.str(), Here());
     }
   }


### PR DESCRIPTION
Re-word and elaborate on the error text in `Geometry::VariableSizes`. This error can occur when either the variable has not been specified in the model section, or one of the filters is requesting the non-existent variable corresponding to an obs variable.