### PR TITLE
bugfix: remove state variables from all "Model" classes

### DIFF
--- a/src/orca-jedi/model/Model.h
+++ b/src/orca-jedi/model/Model.h
@@ -46,8 +46,6 @@ class OrcaModelParameters : public oops::ModelParametersBase {
   /// Model time step
   oops::RequiredParameter<util::Duration> tstep{"tstep", this};
   /// Model variables
-  oops::RequiredParameter<oops::Variables> stateVariables{"state variables",
-    "List of model variables", this};
   oops::RequiredParameter<std::vector<OrcaStateParameters>> states{
     "states",
     "List of configuration options used to initialize the" +
@@ -70,15 +68,14 @@ class Model: public oops::interface::ModelBase<OrcaModelTraits>,
   static const std::string classname() {return "orcamodel::Model";}
 
   Model(const Geometry & geom, const eckit::Configuration & conf)
-    : tstep_(conf.getString("tstep")), geom_(geom),
-    vars_(conf, "state variables") {
+    : tstep_(conf.getString("tstep")), geom_(geom) {
     parameters_.validateAndDeserialize(conf);
     checkTimeStep();
   }
 
   Model(const Geometry & geom, const Parameters_ & params)
-    : parameters_(params), tstep_(params.tstep.value()), geom_(geom),
-      vars_(params.stateVariables.value()) {
+    : parameters_(params), tstep_(params.tstep.value()), geom_(geom)
+       {
     oops::Log::trace() << classname() << "constructor begin" << std::endl;
     checkTimeStep();
     oops::Log::trace() << classname() << "constructor end" << std::endl;
@@ -98,7 +95,6 @@ class Model: public oops::interface::ModelBase<OrcaModelTraits>,
 
 /// Utilities
   const util::Duration & timeResolution() const {return tstep_;}
-  const oops::Variables & variables() const {return vars_;}
 
  private:
   void checkTimeStep() {
@@ -121,7 +117,6 @@ class Model: public oops::interface::ModelBase<OrcaModelTraits>,
   util::Duration tstep_;
   Parameters_ parameters_;
   const Geometry geom_;
-  const oops::Variables vars_;
 };
 // -----------------------------------------------------------------------------
 

--- a/src/tests/testinput/basic.yaml
+++ b/src/tests/testinput/basic.yaml
@@ -14,7 +14,6 @@ initial condition :
 model :
   name: PseudoModel
   tstep: P2D
-  state variables: [ ice_area_fraction ]
   states:
     - date: '2018-04-15T00:00:00Z'
       fcstime: 1

--- a/src/tests/testinput/hofx_nc_ice.yaml
+++ b/src/tests/testinput/hofx_nc_ice.yaml
@@ -27,20 +27,19 @@ initial condition :
 model :
   name: PseudoModel
   tstep: P1D
-  state variables: &state_variables [ ice_area_fraction ]
   states:
     - date: 2021-06-28T23:00:00Z
       nemo field file: Data/orca2_t_nemo.nc
       variance field file: orca-jedi/src/tests/Data/orca2_t_bkg_var.nc
-      state variables: *state_variables
+      state variables: [ ice_area_fraction ]
     - date: 2021-06-29T23:00:00Z
       nemo field file: Data/orca2_t_nemo.nc
       variance field file: Data/orca2_t_bkg_var.nc
-      state variables: *state_variables
+      state variables: [ ice_area_fraction ]
     - date: 2021-06-30T23:00:00Z
       nemo field file: Data/orca2_t_nemo.nc
       variance field file: Data/orca2_t_bkg_var.nc
-      state variables: *state_variables
+      state variables: [ ice_area_fraction ]
 observations:
   observers:
   - obs space:

--- a/src/tests/testinput/hofx_nc_sst.yaml
+++ b/src/tests/testinput/hofx_nc_sst.yaml
@@ -27,12 +27,11 @@ initial condition :
 model :
   name: PseudoModel
   tstep: P1D
-  state variables: &state_variables [ sea_surface_temperature ]
   states:
     - date: 2021-06-28T23:00:00Z
       nemo field file: Data/orca2_t_nemo.nc
       variance field file: Data/orca2_t_bkg_var.nc
-      state variables: *state_variables
+      state variables: &state_variables [ sea_surface_temperature ]
     - date: 2021-06-29T23:00:00Z
       nemo field file: Data/orca2_t_nemo.nc
       variance field file: Data/orca2_t_bkg_var.nc

--- a/src/tests/testinput/hofx_odb_ice.yaml
+++ b/src/tests/testinput/hofx_odb_ice.yaml
@@ -27,12 +27,11 @@ initial condition :
 model :
   name: PseudoModel
   tstep: P1D
-  state variables: &state_variables [ ice_area_fraction ]
   states:
     - date: 2021-06-28T23:00:00Z
       nemo field file: orca-jedi/src/tests/Data/orca2_t_nemo.nc
       variance field file: orca-jedi/src/tests/Data/orca2_t_bkg_var.nc
-      state variables: *state_variables
+      state variables: &state_variables [ ice_area_fraction ]
     - date: 2021-06-29T23:00:00Z
       nemo field file: orca-jedi/src/tests/Data/orca2_t_nemo.nc
       variance field file: orca-jedi/src/tests/Data/orca2_t_bkg_var.nc

--- a/src/tests/testinput/ostia_seaice_obs.yaml
+++ b/src/tests/testinput/ostia_seaice_obs.yaml
@@ -24,7 +24,6 @@ initial condition :
 model :
   name: PseudoModel
   tstep: P3D
-  state variables: [ ice_area_fraction ]
   states:
     - date: 2021-06-29T21:00:00Z
       nemo field file: /data/users/tsearle/jopa_ostia_start_data/ops_bg_full.nc


### PR DESCRIPTION
Bugfix to handle runtime errors from: https://github.com/JCSDA-internal/oops/pull/2258

Removes all references to `state variables` from configuration and dummy Model class.

Tests:

 * [cylc-review](http://fcm1/cylc-review/taskjobs/tsearle?&suite=bb_orca_only_test&cycles=1) 
