### PR TITLE
Reset to use single OMP process in tests

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ ecbuild_add_test( TARGET test_orcamodel_hofx3D_sst
                   COMMAND orcamodel_hofx3D.x )
 
 ecbuild_add_test( TARGET test_orcamodel_hofx_sst
-                  OMP 2
+                  OMP 1
                   ARGS testinput/hofx_nc_sst.yaml
                   COMMAND orcamodel_hofx.x )
 


### PR DESCRIPTION
## Description

OpenMP parallisation is leading to test result differences under the cray-with-intel-libraries build. It is unclear why this is happening, but seeing as we can't reproduce using the other builds and this build will not be available on the new HPC, I am removing the test for OMP for now.

## Issue(s) addressed

Resolves #50 

## Impact

Fixes nightly test failures from orca-jedi.

## Testing

- [x] I have [run mo-bundle to check integration](http://fcm1/cylc-review/taskjobs/tsearle/?suite=bb_mo_test_oj50) with the rest of JEDI and run the unit tests under all environments
