### PR TITLE
upgrade to the new OOPS missing values

### DIFF
--- a/src/orca-jedi/interpolator/Interpolator.cc
+++ b/src/orca-jedi/interpolator/Interpolator.cc
@@ -130,7 +130,7 @@ namespace orcamodel {
       for (std::size_t klev=0; klev < varSizes[jvar]; ++klev) {
         for (std::size_t iloc=0; iloc < nlocs_; iloc++) {
           if (has_mv && mv(field_view(iloc, klev))) {
-            result[out_idx] = util::missingValue(result[out_idx]);
+            result[out_idx] = util::missingValue<double>();
           } else {
             result[out_idx] = field_view(iloc, klev);
           }

--- a/src/tests/orca-jedi/test_interpolator.cc
+++ b/src/tests/orca-jedi/test_interpolator.cc
@@ -105,7 +105,7 @@ CASE("test basic interpolator") {
     interpolator.apply(oops::Variables({"sea_ice_area_fraction",
         "sea_surface_foundation_temperature"}), state, mask, vals);
 
-    double missing_value = util::missingValue(vals[0]);
+    double missing_value = util::missingValue<double>();
     std::vector<double> testvals = {1, missing_value, 0, 18.488888892,
                                     missing_value, 18.1592999503};
 
@@ -121,7 +121,7 @@ CASE("test basic interpolator") {
     interpolator.apply(oops::Variables({"sea_water_potential_temperature"}),
                                        state, mask, vals);
 
-    double missing_value = util::missingValue(vals[0]);
+    double missing_value = util::missingValue<double>();
     std::vector<double> testvals = {
       18.488888892, missing_value, 18.1592999503,
       17.9419381132, missing_value, 17.75000288,


### PR DESCRIPTION
## Description

This is an upgrade to remove the deprecated form of OOPS missing values, and to use the newer, nicer templated version. The PR for the removal of the old functionality is in JCSDA-internal/oops/pull/2423 however this change does not require a coordinated merge as the templated version is already working.

## Issue(s) addressed

Resolves #57 

No expected impact on downstream repositories or workflows.

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] I have run the unit tests
- [x] I have [run mo-bundle](http://fcm1/cylc-review/cycles/tsearle/?suite=bb_orca_only_test_oj58) to check integration with the rest of JEDI and run the unit tests under all environments
