### PR TITLE
Tolerances to account for compiler differences

### DIFF
--- a/src/tests/testinput/hofx_nc_ssh.yaml
+++ b/src/tests/testinput/hofx_nc_ssh.yaml
@@ -74,4 +74,4 @@ observations:
       PGE threshold: 0.5
 test:
   reference filename: testoutput/test_hofx_nc_ssh.ref
-  float relative tolerance: 5.0e-6 # tolerance for MPI sum-order related differences
+  float absolute tolerance: 5.0e-7 # tolerance for MPI sum-order related differences


### PR DESCRIPTION
## Description

The intel compiler was showing small differences on only the SSH MPI ctest when testing a new atlas-orca change in ecmwf/atlas-orca/pull/15. This change adds a small tolerance to this test so that it will pass on all compilers.

## Impact

Test change only

## Checklist

- [x] I have run the unit tests
- [x] I have [run mo-bundle](http://fcm1/cylc-review/cycles/tsearle/?suite=bb_mo_test_all_oj59) to check integration with the rest of JEDI and run the unit tests under all environments
