### PR TITLE
Add contributors license agreement

### DIFF
--- a/CLA
+++ b/CLA
@@ -1,0 +1,11 @@
+Contributor Licence Agreement and Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+    The contribution was created in whole or in part by me and I have the right to submit it, either on my behalf or on behalf of my employer, under the terms and conditions as described by this file; or
+    The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate licence and I have the right or permission from the copyright owner under that licence to submit that work with modifications, whether created in whole or in part by me, under the terms and conditions as described by this file; or
+    The contribution was provided directly to me by some other person who certified it or I have not modified it.
+    I understand and agree that this project and the contribution are public and that a record of the contribution (including my name and email address) is retained for the full term of the copyright and may be redistributed consistent with this project or the licence(s) involved.
+    I, or my employer, grant to the UK Met Office and all recipients of this software a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright licence to reproduce, modify, prepare derivative works of, publicly display, publicly perform, sub-licence, and distribute this contribution and such modifications and derivative works consistent with this project or the licence(s) involved or other appropriate open source licence(s) specified by the project and approved by the Open Source Initiative (OSI)
+    If I become aware of anything that would make any of the above inaccurate, in any way, I will let the UK Met Office know as soon as I become aware.
+

--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ OOPS_TRACE=true
 ## Authors
 
 The current lead maintainer is [@twsearle](https://github.com/twsearle) along with a large amount of help from Met Office contributors (see the "Contributors" page on github).
+## Contributing
+
+By contributing you agree to the Contributors License Agreement (CLA) contained in the root directory of the project. Please review this, and if you are able to make a contribution make an issue or pull request for your proposed change. All pull requests should conform to the working practises and be linked to an issue, unless a minor bug fix.
 
 ## Working practices
 
-Please see the [JEDI working principles](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/working-practices/index.html) for current working practises. There are also templates for issues and PRs should you wish to contribute.
+Please see the [JEDI working principles](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/working-practices/index.html) for current working practises.


### PR DESCRIPTION
## Description

Add the contributors license agreement as required by Information Asset management:
https://metoffice.sharepoint.com/sites/ScienceInformationAssetsCommsSite/SitePages/FAQ.aspx

## Issue(s) addressed

Part of #61

## Impact

None