### PR TITLE
Remove initial State configuration in tests with PseudoModel configuration

### DIFF
--- a/src/tests/testinput/hofx_nc_ice.yaml
+++ b/src/tests/testinput/hofx_nc_ice.yaml
@@ -31,10 +31,6 @@ model :
   name: PseudoModel
   tstep: P1D
   states:
-    - date: 2021-06-28T23:00:00Z
-      nemo field file: Data/orca2_t_nemo.nc
-      variance field file: orca-jedi/src/tests/Data/orca2_t_bkg_var.nc
-      state variables: [ ice_area_fraction ]
     - date: 2021-06-29T23:00:00Z
       nemo field file: Data/orca2_t_nemo.nc
       variance field file: Data/orca2_t_bkg_var.nc

--- a/src/tests/testinput/hofx_nc_ssh.yaml
+++ b/src/tests/testinput/hofx_nc_ssh.yaml
@@ -27,14 +27,10 @@ model :
   name: PseudoModel
   tstep: P1D
   states:
-    - date: 2021-06-28T23:00:00Z
-      nemo field file: Data/orca2_t_nemo.nc
-      variance field file: Data/orca2_t_bkg_var.nc
-      state variables: &state_variables [ sea_surface_height_anomaly ]
     - date: 2021-06-29T23:00:00Z
       nemo field file: Data/orca2_t_nemo.nc
       variance field file: Data/orca2_t_bkg_var.nc
-      state variables: *state_variables
+      state variables: &state_variables [ sea_surface_height_anomaly ]
     - date: 2021-06-30T23:00:00Z
       nemo field file: Data/orca2_t_nemo.nc
       variance field file: Data/orca2_t_bkg_var.nc

--- a/src/tests/testinput/hofx_nc_ssh_checkerboard.yaml
+++ b/src/tests/testinput/hofx_nc_ssh_checkerboard.yaml
@@ -25,14 +25,10 @@ model :
   name: PseudoModel
   tstep: P1D
   states:
-    - date: 2021-06-28T23:00:00Z
-      nemo field file: Data/orca2_t_nemo.nc
-      variance field file: Data/orca2_t_bkg_var.nc
-      state variables: &state_variables [ sea_surface_height_anomaly ]
     - date: 2021-06-29T23:00:00Z
       nemo field file: Data/orca2_t_nemo.nc
       variance field file: Data/orca2_t_bkg_var.nc
-      state variables: *state_variables
+      state variables: &state_variables [ sea_surface_height_anomaly ]
     - date: 2021-06-30T23:00:00Z
       nemo field file: Data/orca2_t_nemo.nc
       variance field file: Data/orca2_t_bkg_var.nc

--- a/src/tests/testinput/hofx_nc_sst.yaml
+++ b/src/tests/testinput/hofx_nc_sst.yaml
@@ -31,14 +31,10 @@ model :
   name: PseudoModel
   tstep: P1D
   states:
-    - date: 2021-06-28T23:00:00Z
-      nemo field file: Data/orca2_t_nemo.nc
-      variance field file: Data/orca2_t_bkg_var.nc
-      state variables: &state_variables [ sea_surface_temperature ]
     - date: 2021-06-29T23:00:00Z
       nemo field file: Data/orca2_t_nemo.nc
       variance field file: Data/orca2_t_bkg_var.nc
-      state variables: *state_variables
+      state variables: &state_variables [ sea_surface_temperature ]
     - date: 2021-06-30T23:00:00Z
       nemo field file: Data/orca2_t_nemo.nc
       variance field file: Data/orca2_t_bkg_var.nc


### PR DESCRIPTION
## Description

A coordinate PR to ensure `orca-jedi` tests pass if [this `oops` PR](https://github.com/JCSDA-internal/oops/pull/2522) is merged. Leaving in draft for now since the `oops` one is.

## Issue(s) addressed

Resolves #<issue_number>

## Dependencies

https://github.com/JCSDA-internal/oops/pull/2522

## Impact

None.

## Checklist

- [ ] I have updated the unit tests to cover the change
- [ ] ~New functions are documented briefly via Doxygen comments in the code~
- [ ] I have linted my code using cpplint
- [ ] I have run the unit tests
- [ ] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments
