### PR TITLE
Fix cmake warning.

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -13,6 +13,6 @@ if (HAVE_ORCA_JEDI_DOCS)
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Generating API documentation with Doxygen"
         VERBATIM )
-else (DOXYGEN_FOUND)
+else (HAVE_ORCA_JEDI_DOCS)
   message("Doxygen need to be installed to generate the doxygen documentation")
-endif (DOXYGEN_FOUND)
+endif (HAVE_ORCA_JEDI_DOCS)


### PR DESCRIPTION
## Description

Currently there is a cmake warning:

CMake Warning (dev) in orca-jedi/docs/CMakeLists.txt:
  A logical block opening on the line

    /home/h01/david.davies/cylc-run/OrcaJediWarning/share/mo-bundle/orca-jedi/docs/CMakeLists.txt:1 (if)

  closes on the line

    /home/h01/david.davies/cylc-run/OrcaJediWarning/share/mo-bundle/orca-jedi/docs/CMakeLists.txt:18 (endif)

  with mis-matching arguments.

This PR fixes it.