### PR TITLE
Feature: new state constructor

### DIFF
--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -102,11 +102,10 @@ State::State(const Geometry & resol, const State & other)
 
 State::State(const oops::Variables & variables, const State & other)
   : State(other) {
-    eckit::LocalConfiguration change_config;
-    VariableChange change(change_config, geom_);
-    change.changeVar(*this, variables);
-    Log::trace() << "State(ORCA)::State created with variable change." << std::endl;
-  }
+  eckit::LocalConfiguration change_config;
+  VariableChange change(change_config, geom_);
+  change.changeVar(*this, variables);
+  Log::trace() << "State(ORCA)::State created with variable change." << std::endl;
 }
 
 State::State(const State & other)
@@ -305,5 +304,4 @@ double State::norm(const std::string & field_name) const {
 
   return 0;
 }
-
 }  // namespace orcamodel

--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -103,9 +103,9 @@ State::State(const Geometry & resol, const State & other)
 State::State(const oops::Variables & variables, const State & other)
   : State(other) {
   eckit::LocalConfiguration change_config;
-  VariableChange change(change_config, geom_);
+  VariableChange change(change_config, *geom_);
   change.changeVar(*this, variables);
-  Log::trace() << "State(ORCA)::State created with variable change." << std::endl;
+  oops::Log::trace() << "State(ORCA)::State created with variable change." << std::endl;
 }
 
 State::State(const State & other)
@@ -123,18 +123,20 @@ State::~State() {
 
 void State::subsetFieldSet(const oops::Variables & variables) {
   atlas::FieldSet subset;
-  for (auto & variable : variables) {
+  for (int iVar = 0; iVar < variables.size(); iVar++) {
+    auto variable = variables[iVar];
     if (!stateFields_.has(variable)) {
       throw eckit::BadValue("State(ORCA)::subsetFieldSet '"
-          + variable.name() + "' does not appear in superset.");
+          + variable + "' does not appear in superset.");
     }
-    subset.add(stateFields_[variable.name()]);
+    subset.add(stateFields_[variable]);
   }
 
   stateFields_.clear();
 
-  for (auto & variable : variables) {
-    stateFields_.add(subset[variable.name()]);
+  for (int iVar = 0; iVar < variables.size(); iVar++) {
+    auto variable = variables[iVar];
+    stateFields_.add(subset[variable]);
   }
   vars_ = variables;
 }

--- a/src/orca-jedi/state/State.h
+++ b/src/orca-jedi/state/State.h
@@ -61,6 +61,7 @@ class State : public util::Printable,
         const eckit::Configuration &);
   State(const Geometry &, const State &);
   State(const State &);
+  State(const oops::Variables &, const State &);
   virtual ~State();
 
   State & operator=(const State &);
@@ -99,6 +100,7 @@ class State : public util::Printable,
 
   const atlas::FieldSet & stateFields() const {return stateFields_;}
   atlas::FieldSet & stateFields() {return stateFields_;}
+  void subsetFieldSet(const oops::Variables & variables);
 
   const oops::Variables & variables() const {return vars_;}
   oops::Variables & variables() {return vars_;}

--- a/src/orca-jedi/variablechanges/VariableChange.h
+++ b/src/orca-jedi/variablechanges/VariableChange.h
@@ -31,7 +31,10 @@ class VariableChange: public util::Printable,
   }
   VariableChange(const VariableChangeParameters &, const Geometry &) {}
   VariableChange(const eckit::Configuration &, const Geometry &) {}
-  void changeVar(State &, const oops::Variables &) const {}
+  void changeVar(State & state, const oops::Variables & variables) const {
+    state.subsetFieldSet(variables);
+  }
+
   void changeVarInverse(State &, const oops::Variables &) const {}
 
  private:

--- a/src/tests/orca-jedi/test_state.cc
+++ b/src/tests/orca-jedi/test_state.cc
@@ -74,6 +74,17 @@ CASE("test basic state") {
     State state(geometry, oops_vars, datetime);
   }
 
+  SECTION("test subset copy constructor") {
+    oops::Variables oops_vars({"sea_ice_area_fraction", "sea_surface_foundation_temperature"},
+        channels);
+    util::DateTime datetime("2021-06-30T00:00:00Z");
+    State state(geometry, oops_vars, datetime);
+
+    State state_copy(state, {{"sea_ice_area_fraction"}, channels)});
+
+    EXPECT_THROWS_AS(State(state, {{"sea_ice_area_fraction"}, channels)}, eckit::BadValue);
+  }
+
   SECTION("test constructor from config analytic initialisation") {
     state_config.set("nemo field file", "../Data/orca2_t_nemo.nc");
     state_config.set("analytic initialisation", true);

--- a/src/tests/orca-jedi/test_state.cc
+++ b/src/tests/orca-jedi/test_state.cc
@@ -80,9 +80,10 @@ CASE("test basic state") {
     util::DateTime datetime("2021-06-30T00:00:00Z");
     State state(geometry, oops_vars, datetime);
 
-    State state_copy(state, {{"sea_ice_area_fraction"}, channels)});
+    State state_copy(oops::Variables({"sea_ice_area_fraction"}, channels), state);
 
-    EXPECT_THROWS_AS(State(state, {{"sea_ice_area_fraction"}, channels)}, eckit::BadValue);
+    EXPECT_THROWS_AS(State(oops::Variables({"NOT_IN_SRC_STATE"}, channels), state),
+        eckit::BadValue);
   }
 
   SECTION("test constructor from config analytic initialisation") {


### PR DESCRIPTION
## Description

This change adds a new constructor for the `State` class to copy a state with a reduced set of variables. This `State` is constructed via a new `VariableChange` method, with as simple as possible an implementation whilst being correct.

## Issue(s) addressed

Resolves #75 

## Impact

Required by:

- JCSDA-internal/oops/pull/2498

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [ ] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments
