### PR TITLE
Add use of atlas float fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ JEDI model interface interface for the NEMO ocean model configurations on ORCA g
 
 ## Description
 
-_orca-jedi_ includes executables to calculate model values at observation locations and to perform quality control. _orca-jedi_ is a JEDI "psuedomodel", meaning that rather than interfacing directly with NEMO or NEMOVAR, the model state is derived from input files. Further applications may be developed based on _orca-jedi_ in the future. (These would be implementations of JEDI OOPS apps, such as for observation generation applications, and various DA applications).
+_orca-jedi_ includes executables to calculate model values at observation locations and to perform quality control. _orca-jedi_ is a JEDI "pseudo-model", meaning that rather than interfacing directly with NEMO or NEMOVAR, the model state is derived from input files. Further applications may be developed based on _orca-jedi_ in the future. (These would be implementations of JEDI OOPS apps, such as for observation generation applications, and various DA applications).
 
 ## Getting Started
 

--- a/examples/hofx3d_nc_orca1_checker_ice_mpi.yaml
+++ b/examples/hofx3d_nc_orca1_checker_ice_mpi.yaml
@@ -34,7 +34,7 @@ observations:
       time interpolation: linear
       atlas-interpolator:
         type: unstructured-bilinear-lonlat
-        non_linear: missing-if-all-missing
+        non_linear: missing-if-all-missing-real32
         max_fraction_elems_to_try: 0.0
     obs operator:
       name: Identity

--- a/examples/hofx3d_odb_prof_example.yaml
+++ b/examples/hofx3d_odb_prof_example.yaml
@@ -42,7 +42,7 @@ observations:
     get values:
       atlas-interpolator:
         type: unstructured-bilinear-lonlat
-        non_linear: missing-if-all-missing
+        non_linear: missing-if-all-missing-real32
     obs operator:
       name: VertInterp
       observation alias file: testinput/test_name_map.yaml

--- a/examples/hofx_nc_ice_mpi.yaml
+++ b/examples/hofx_nc_ice_mpi.yaml
@@ -57,7 +57,7 @@ observations:
       time interpolation: linear
       atlas-interpolator:
         type: unstructured-bilinear-lonlat
-        non_linear: missing-if-all-missing
+        non_linear: missing-if-all-missing-real32
         max_fraction_elems_to_try: 0.0
     obs operator:
       name: Composite

--- a/src/orca-jedi/geometry/Geometry.h
+++ b/src/orca-jedi/geometry/Geometry.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "atlas/field/Field.h"
 #include "atlas/field/FieldSet.h"
@@ -20,6 +21,7 @@
 #include "atlas/runtime/Log.h"
 
 #include "eckit/mpi/Comm.h"
+#include "eckit/log/Timer.h"
 
 #include "oops/base/Variables.h"
 #include "oops/util/ObjectCounter.h"
@@ -27,12 +29,12 @@
 #include "oops/util/Printable.h"
 
 #include "orca-jedi/geometry/GeometryParameters.h"
+#include "orca-jedi/utilities/Types.h"
 
 namespace atlas {
   class Field;
   class FieldSet;
   class Mesh;
-
 }
 
 namespace orcamodel {
@@ -65,6 +67,9 @@ class Geometry : public util::Printable {
   bool levelsAreTopDown() const {return true;}
   std::string distributionType() const {
       return params_.partitioner.value();}
+  FieldDType fieldPrecision(std::string variable_name) const;
+  std::shared_ptr<eckit::Timer> timer() const {return eckit_timer_;}
+  void log_status() const;
 
  private:
   void print(std::ostream &) const;
@@ -77,6 +82,7 @@ class Geometry : public util::Printable {
   atlas::Mesh mesh_;
   atlas::functionspace::NodeColumns funcSpace_;
   atlas::FieldSet nofields_;
+  std::shared_ptr<eckit::Timer> eckit_timer_;
 };
 // -----------------------------------------------------------------------------
 

--- a/src/orca-jedi/geometry/GeometryParameterTraitsFieldDType.cc
+++ b/src/orca-jedi/geometry/GeometryParameterTraitsFieldDType.cc
@@ -1,0 +1,13 @@
+/*
+ * (C) British Crown Copyright 2024 Met Office
+ */
+
+#include "orca-jedi/geometry/GeometryParameterTraitsFieldDType.h"
+
+namespace orcamodel {
+
+constexpr char FieldDTypeParameterTraitsHelper::enumTypeName[];
+constexpr util::NamedEnumerator<FieldDType>
+  FieldDTypeParameterTraitsHelper::namedValues[];
+
+}  // namespace orcamodel

--- a/src/orca-jedi/geometry/GeometryParameterTraitsFieldDType.h
+++ b/src/orca-jedi/geometry/GeometryParameterTraitsFieldDType.h
@@ -1,0 +1,37 @@
+/*
+ * (C) British Crown Copyright 2024 Met Office
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "eckit/exception/Exceptions.h"
+#include "oops/util/parameters/ParameterTraits.h"
+
+#include "orca-jedi/utilities/Types.h"
+
+namespace orcamodel {
+
+/// Helps with the conversion of FieldDType values to/from strings.
+struct FieldDTypeParameterTraitsHelper {
+  typedef FieldDType EnumType;
+  static constexpr char enumTypeName[] = "FieldDType";
+  static constexpr util::NamedEnumerator<EnumType> namedValues[] = {
+    { EnumType::Float, "float" },
+    { EnumType::Double, "double" }
+  };
+};
+
+}  // namespace orcamodel
+
+namespace oops {
+
+/// Specialization of ParameterTraits for FieldDType.
+template <>
+struct ParameterTraits<orcamodel::FieldDType> :
+    public EnumParameterTraits<orcamodel::FieldDTypeParameterTraitsHelper>
+{};
+
+}  // namespace oops

--- a/src/orca-jedi/geometry/GeometryParameters.h
+++ b/src/orca-jedi/geometry/GeometryParameters.h
@@ -13,7 +13,8 @@
 #include "oops/base/ParameterTraitsVariables.h"
 #include "oops/util/parameters/Parameter.h"
 #include "oops/util/parameters/RequiredParameter.h"
-#include "oops/util/parameters/OptionalParameter.h"
+#include "orca-jedi/geometry/GeometryParameterTraitsFieldDType.h"
+#include "orca-jedi/utilities/Types.h"
 
 namespace orcamodel {
 
@@ -24,7 +25,14 @@ class NemoFieldParameters : public oops::Parameters {
   oops::RequiredParameter<std::string> name {"name", this};
   oops::RequiredParameter<std::string> nemoName {"nemo field name", this};
   oops::RequiredParameter<std::string> modelSpace {"model space", this};
-  oops::OptionalParameter<std::string> variableType {"variable type", this};
+  oops::Parameter<std::string> variableType {"variable type",
+    "type of variable (default is 'background' other option is 'background variance')",
+    "background",
+    this};
+  oops::Parameter<FieldDType> fieldPrecision{"field precision",
+    "Precision to store atlas fields (float (default) or double).",
+    FieldDType::Float,
+    this};
 };
 
 class OrcaGeometryParameters : public oops::Parameters {

--- a/src/orca-jedi/interpolator/Interpolator.cc
+++ b/src/orca-jedi/interpolator/Interpolator.cc
@@ -2,6 +2,7 @@
  * (C) British Crown Copyright 2024 Met Office
  */
 
+#include <cstddef>
 #include <fstream>
 #include <memory>
 #include <ostream>
@@ -111,33 +112,68 @@ namespace orcamodel {
       nvals += nlocs_ * varSizes[jvar];
       oops::Log::debug() << " varSizes[" << jvar << "] = " << varSizes[jvar];
     }
-    result.resize(nvals);
     oops::Log::debug() << " nvals = " << nvals << std::endl;
+    result.resize(nvals);
 
-    std::size_t out_idx = 0;
+    auto res_iter = result.begin();
     for (size_t jvar=0; jvar < nvars; ++jvar) {
-      auto gv_varname = vars[jvar];
-      atlas::Field tgt_field = atlasObsFuncSpace_.createField<double>(
-          atlas::option::name(gv_varname) |
-          atlas::option::levels(varSizes[jvar]));
-      interpolator_.execute(state.stateFields()[gv_varname], tgt_field);
-      auto field_view = atlas::array::make_view<double, 2>(tgt_field);
-      atlas::field::MissingValue mv(state.stateFields()[gv_varname]);
-      bool has_mv = static_cast<bool>(mv);
-      for (std::size_t klev=0; klev < varSizes[jvar]; ++klev) {
-        for (std::size_t iloc=0; iloc < nlocs_; iloc++) {
-          if (has_mv && mv(field_view(iloc, klev))) {
-            result[out_idx] = util::missingValue<double>();
-          } else {
-            result[out_idx] = field_view(iloc, klev);
-          }
-          ++out_idx;
-        }
+      switch (state.geometry()->fieldPrecision(vars[jvar])) {
+        case FieldDType::Double:
+          executeInterpolation<double>(vars[jvar], varSizes[jvar], state, res_iter);
+          break;
+        case FieldDType::Float:
+          executeInterpolation<float>(vars[jvar], varSizes[jvar], state, res_iter);
+          break;
+        default:
+          throw eckit::BadParameter("orcamodel::Interpolator::apply '"
+              + vars[jvar] + "' field type not recognised This line should never run!");
       }
+      state.geometry()->log_status();
     }
+    assert(result.size() == nvals);
     oops::Log::trace() << "orcamodel::Interpolator::apply done "
                        << std::endl;
   }
+
+  /// \brief Execute the atlas interpolation on a single field.
+  /// \param gv_varname The GeoVaLs variable name of the source field.
+  /// \param var_size The number of observation locations in the interpolant.
+  /// \param state The state object containing the model state.
+  /// \param iter Reference to the interator into the output vector.
+  template<class T> void Interpolator::executeInterpolation(
+      const std::string& gv_varname,
+      size_t var_size,
+      const State& state,
+      std::vector<double>::iterator& iter) const {
+    atlas::Field tgt_field = atlasObsFuncSpace_.createField<T>(
+        atlas::option::name(gv_varname) |
+        atlas::option::levels(var_size));
+    interpolator_.execute(state.stateFields()[gv_varname], tgt_field);
+    auto field_view = atlas::array::make_view<T, 2>(tgt_field);
+    atlas::field::MissingValue mv(state.stateFields()[gv_varname]);
+    bool has_mv = static_cast<bool>(mv);
+    for (std::size_t klev=0; klev < var_size; ++klev) {
+      for (std::size_t iloc=0; iloc < nlocs_; iloc++) {
+        if (has_mv && mv(field_view(iloc, klev))) {
+          *iter = util::missingValue<double>();
+        } else {
+          *iter = static_cast<double>(field_view(iloc, klev));
+        }
+        ++iter;
+      }
+    }
+  }
+
+  template void Interpolator::executeInterpolation<double>(
+      const std::string& gv_varname,
+      size_t var_size,
+      const State& state,
+      std::vector<double>::iterator& iter) const;
+  template void Interpolator::executeInterpolation<float>(
+      const std::string& gv_varname,
+      size_t var_size,
+      const State& state,
+      std::vector<double>::iterator& iter) const;
 
   void Interpolator::print(std::ostream & os) const {
     os << "orcamodel::Interpolator: " << std::endl;

--- a/src/orca-jedi/interpolator/Interpolator.cc
+++ b/src/orca-jedi/interpolator/Interpolator.cc
@@ -128,7 +128,6 @@ namespace orcamodel {
           throw eckit::BadParameter("orcamodel::Interpolator::apply '"
               + vars[jvar] + "' field type not recognised This line should never run!");
       }
-      state.geometry()->log_status();
     }
     assert(result.size() == nvals);
     oops::Log::trace() << "orcamodel::Interpolator::apply done "

--- a/src/orca-jedi/interpolator/Interpolator.h
+++ b/src/orca-jedi/interpolator/Interpolator.h
@@ -70,6 +70,11 @@ class Interpolator : public util::Printable,
   }
 
  private:
+  template<class T> void executeInterpolation(
+      const std::string& gv_varname,
+      size_t var_size,
+      const State& state,
+      std::vector<double>::iterator& result) const;
   void print(std::ostream &) const override;
   int64_t nlocs_;
   atlas::functionspace::PointCloud atlasObsFuncSpace_;

--- a/src/orca-jedi/nemo_io/NemoFieldReader.cc
+++ b/src/orca-jedi/nemo_io/NemoFieldReader.cc
@@ -16,7 +16,6 @@
 #include "atlas/parallel/omp/omp.h"
 
 #include "eckit/exception/Exceptions.h"
-#include "eckit/system/ResourceUsage.h"
 
 #include "oops/util/Logger.h"
 #include "oops/util/Duration.h"
@@ -354,10 +353,6 @@ std::vector<double> NemoFieldReader::read_var_slice(const std::string& varname,
     }
 
     size_t n_dims = nc_var.getDimCount();
-  oops::Log::trace() << "orcamodel:: read var slice " << varname << " "
-      << z_indx << " before memory: "
-      << static_cast<double>(eckit::system::ResourceUsage().maxResidentSetSize()) / 1.0e+6
-      << " Mb" << std::endl;
     std::vector<size_t> starts;
     std::vector<size_t> counts;
     if (n_dims == 4) {
@@ -394,11 +389,6 @@ std::vector<double> NemoFieldReader::read_var_slice(const std::string& varname,
                    << nc_type_name << " not supported.";
         throw eckit::BadValue(err_stream.str(), Here());
     }
-
-    oops::Log::trace() << "orcamodel:: read var slice " << varname << " "
-        << z_indx << " after vec mem " << var_data.capacity()*sizeof(double) / 1.0e+6 << " memory: "
-        << static_cast<double>(eckit::system::ResourceUsage().maxResidentSetSize()) / 1.0e+6
-        << " Mb" << std::endl;
 
     return var_data;
   } catch(netCDF::exceptions::NcException& e)

--- a/src/orca-jedi/nemo_io/NemoFieldReader.h
+++ b/src/orca-jedi/nemo_io/NemoFieldReader.h
@@ -33,9 +33,9 @@ class NemoFieldReader : private util::ObjectCounter<NemoFieldReader> {
   size_t read_dim_size(const std::string& name) const;
   size_t get_nearest_datetime_index(const util::DateTime& datetime) const;
   template<typename T> T read_fillvalue(const std::string& name) const;
-  std::vector<double> read_var_slice(const std::string& varname,
+  template<typename T> std::vector<T> read_var_slice(const std::string& varname,
       const size_t t_indx, const size_t z_indx) const;
-  std::vector<double> read_vertical_var(const std::string& varname,
+  template<typename T> std::vector<T> read_vertical_var(const std::string& varname,
       const size_t nlevels) const;
 
  private:

--- a/src/orca-jedi/nemo_io/ReadServer.cc
+++ b/src/orca-jedi/nemo_io/ReadServer.cc
@@ -5,17 +5,22 @@
 
 
 #include "orca-jedi/nemo_io/ReadServer.h"
+
 #include <string>
 #include <vector>
 #include <memory>
 
+#include "oops/util/Logger.h"
+#include "atlas/parallel/omp/omp.h"
 #include "eckit/exception/Exceptions.h"
 
 namespace orcamodel {
 
-ReadServer::ReadServer(const eckit::PathName& file_path, const atlas::Mesh& mesh) :
+ReadServer::ReadServer(std::shared_ptr<eckit::Timer> eckit_timer,
+  const eckit::PathName& file_path, const atlas::Mesh& mesh) :
   mesh_(mesh),
-  index_glbarray_(atlas::OrcaGrid(mesh.grid())) {
+  index_glbarray_(atlas::OrcaGrid(mesh.grid())),
+  eckit_timer_(eckit_timer) {
   if (myrank == mpiroot) {
     reader_ = std::make_unique<NemoFieldReader>(file_path);
   }
@@ -30,6 +35,8 @@ void ReadServer::read_var_on_root(const std::string& var_name,
               const size_t t_index,
               const size_t z_index,
               std::vector<double>& buffer) const {
+  oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::read_var_on_root "
+    << var_name << std::endl;
   size_t size = index_glbarray_.nx_halo_WE * index_glbarray_.ny_halo_NS;
   if (myrank == mpiroot) {
     buffer = reader_->read_var_slice(var_name, t_index, z_index);
@@ -57,48 +64,87 @@ void ReadServer::read_vertical_var_on_root(const std::string& var_name,
 /// \param buffer Vector of data to read
 /// \param z_index Index of the vertical slice.
 /// \param field_view View into the atlas field to store the data.
-void ReadServer::fill_field(const std::vector<double>& buffer,
+template<class T> void ReadServer::fill_field(const std::vector<double>& buffer,
               const size_t z_index,
-      atlas::array::ArrayView<double, 2>& field_view) const {
+      atlas::array::ArrayView<T, 2>& field_view) const {
+    oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::fill_field" << std::endl;
     auto ghost = atlas::array::make_view<int32_t, 1>(this->mesh_.nodes().ghost());
     auto ij = atlas::array::make_view<int32_t, 2>(this->mesh_.nodes().field("ij"));
-    const size_t numNodes = field_view.shape(0);
+    const size_t num_nodes = field_view.shape(0);
     // "ReadServer buffer size does not equal the number of horizontal nodes in the field_view"
-    assert(numNodes <= buffer.size());
-    for (size_t inode = 0; inode < numNodes; ++inode) {
+    assert(num_nodes <= buffer.size());
+    log_status();
+    oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::fill_field filling..."
+                       << std::endl;
+    atlas_omp_parallel_for(size_t inode = 0; inode < num_nodes; ++inode) {
       if (ghost(inode)) continue;
       const int64_t ibuf = index_glbarray_(ij(inode, 0), ij(inode, 1));
-      field_view(inode, z_index) = buffer[ibuf];
+      field_view(inode, z_index) = static_cast<T>(buffer[ibuf]);
     }
+    log_status();
 }
+
+template void ReadServer::fill_field<int>(
+      const std::vector<double>& buffer,
+      const size_t z_index,
+      atlas::array::ArrayView<int, 2>& field_view) const;
+template void ReadServer::fill_field<float>(
+      const std::vector<double>& buffer,
+      const size_t z_index,
+      atlas::array::ArrayView<float, 2>& field_view) const;
+template void ReadServer::fill_field<double>(
+      const std::vector<double>& buffer,
+      const size_t z_index,
+      atlas::array::ArrayView<double, 2>& field_view) const;
 
 /// \brief Move vertical data from a buffer into an atlas arrayView.
 /// \param buffer Vector of data to read
 /// \param field_view View into the atlas field to store the data.
-void ReadServer::fill_vertical_field(const std::vector<double>& buffer,
-      atlas::array::ArrayView<double, 2>& field_view) const {
+template<class T> void ReadServer::fill_vertical_field(const std::vector<double>& buffer,
+      atlas::array::ArrayView<T, 2>& field_view) const {
+    oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::fill_vertical_field "<< std::endl;
     auto ghost = atlas::array::make_view<int32_t, 1>(this->mesh_.nodes().ghost());
     const size_t num_nodes = field_view.shape(0);
     const size_t num_levels = field_view.shape(1);
     // "ReadServer buffer size does not equal the number of levels in the field_view"
     assert(num_levels <= buffer.size());
 
+    log_status();
+    oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::fill_vertical_field filling..."
+                       << std::endl;
     // even for 1D depths, store the data in an atlas 3D field - inefficient but flexible
-    for (size_t inode = 0; inode < num_nodes; ++inode) {
-      for (size_t k = 0; k < num_levels; ++k) {
-        if (ghost(inode)) continue;
-        field_view(inode, k) = buffer[k];
+    // NOTE: Use thread-private levels data to reduce OMP cache misses
+    atlas_omp_parallel {
+      const std::vector<double> buffer_TP = buffer;
+      atlas_omp_for(size_t inode = 0; inode < num_nodes; ++inode) {
+        for (size_t k = 0; k < num_levels; ++k) {
+          if (ghost(inode)) continue;
+          field_view(inode, k) = static_cast<T>(buffer_TP[k]);
+        }
       }
     }
+    log_status();
 }
+
+template void ReadServer::fill_vertical_field<int>(
+      const std::vector<double>& buffer,
+      atlas::array::ArrayView<int, 2>& field_view) const;
+template void ReadServer::fill_vertical_field<float>(
+      const std::vector<double>& buffer,
+      atlas::array::ArrayView<float, 2>& field_view) const;
+template void ReadServer::fill_vertical_field<double>(
+      const std::vector<double>& buffer,
+      atlas::array::ArrayView<double, 2>& field_view) const;
 
 /// \brief Read a NetCDF variable into an atlas field.
 /// \param var_name The netCDF name of the variable to read.
 /// \param t_index The time index for the data to read.
 /// \param field_view View into the atlas field to store the data.
-void ReadServer::read_var(const std::string& var_name,
+template<class T> void ReadServer::read_var(const std::string& var_name,
     const size_t t_index,
-    atlas::array::ArrayView<double, 2>& field_view) {
+    atlas::array::ArrayView<T, 2>& field_view) {
+  oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::read_var "
+    << var_name << std::endl;
 
   size_t n_levels = field_view.shape(1);
   size_t size = index_glbarray_.nx_halo_WE * index_glbarray_.ny_halo_NS;
@@ -106,25 +152,43 @@ void ReadServer::read_var(const std::string& var_name,
   std::vector<double> buffer;
   // For each level
   for (size_t iLev = 0; iLev < n_levels; iLev++) {
+    log_status();
     // read the data for that level onto the root processor
     this->read_var_on_root(var_name, t_index, iLev, buffer);
 
+    assert(buffer.size() == size);
+    log_status();
     // mpi distribute that data out to all processors
     atlas::mpi::comm().broadcast(&buffer.front(), size, mpiroot);
 
+    log_status();
     // each processor fills out its field_view from the buffer
     this->fill_field(buffer, iLev, field_view);
   }
 }
 
+template void ReadServer::read_var<int>(
+    const std::string& var_name,
+    const size_t t_index,
+    atlas::array::ArrayView<int, 2>& field_view);
+template void ReadServer::read_var<double>(
+    const std::string& var_name,
+    const size_t t_index,
+    atlas::array::ArrayView<double, 2>& field_view);
+template void ReadServer::read_var<float>(
+    const std::string& var_name,
+    const size_t t_index,
+    atlas::array::ArrayView<float, 2>& field_view);
+
 /// \brief Read a vertical variable into an atlas field.
 /// \param var_name The netCDF name of the variable to read.
 /// \param field_view View into the atlas field to store the data.
-void ReadServer::read_vertical_var(const std::string& var_name,
-    atlas::array::ArrayView<double, 2>& field_view) {
+template<class T> void ReadServer::read_vertical_var(const std::string& var_name,
+    atlas::array::ArrayView<T, 2>& field_view) {
+  oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::read_vertical_var "
+    << var_name << std::endl;
 
   size_t n_levels = field_view.shape(1);
-  size_t size = index_glbarray_.nx_halo_WE * index_glbarray_.ny_halo_NS;
 
   std::vector<double> buffer;
 
@@ -132,11 +196,21 @@ void ReadServer::read_vertical_var(const std::string& var_name,
   this->read_vertical_var_on_root(var_name, n_levels, buffer);
 
   // mpi distribute that data out to all processors
-  atlas::mpi::comm().broadcast(&buffer.front(), size, mpiroot);
+  atlas::mpi::comm().broadcast(&buffer.front(), n_levels, mpiroot);
 
   // each processor fills out its field_view from the buffer
   this->fill_vertical_field(buffer, field_view);
 }
+
+template void ReadServer::read_vertical_var<int>(
+    const std::string& var_name,
+    atlas::array::ArrayView<int, 2>& field_view);
+template void ReadServer::read_vertical_var<double>(
+    const std::string& var_name,
+    atlas::array::ArrayView<double, 2>& field_view);
+template void ReadServer::read_vertical_var<float>(
+    const std::string& var_name,
+    atlas::array::ArrayView<float, 2>& field_view);
 
 /// \brief Find the nearest datetime index to a datetime on the MPI root only.
 /// \param datetime Search for the index of the time slice in the file nearest this datetime.

--- a/src/orca-jedi/nemo_io/ReadServer.h
+++ b/src/orca-jedi/nemo_io/ReadServer.h
@@ -46,17 +46,17 @@ void log_status() const {
       << static_cast<double>(eckit::system::ResourceUsage().maxResidentSetSize()) / 1.0e+9
       << " Gb" << std::endl;
 }
-  void read_var_on_root(const std::string& var_name,
+  template<class T> void read_var_on_root(const std::string& var_name,
       const size_t t_index,
       const size_t z_index,
-      std::vector<double>& buffer) const;
-  void read_vertical_var_on_root(const std::string& var_name,
+      std::vector<T>& buffer) const;
+  template<class T> void read_vertical_var_on_root(const std::string& var_name,
       const size_t n_levels,
-      std::vector<double>& buffer) const;
-  template<class T> void fill_field(const std::vector<double>& buffer,
+      std::vector<T>& buffer) const;
+  template<class T> void fill_field(const std::vector<T>& buffer,
       const size_t z_index,
       atlas::array::ArrayView<T, 2>& field_view) const;
-  template<class T> void fill_vertical_field(const std::vector<double>& buffer,
+  template<class T> void fill_vertical_field(const std::vector<T>& buffer,
       atlas::array::ArrayView<T, 2>& field_view) const;
   const size_t mpiroot = 0;
   const size_t myrank = atlas::mpi::rank();

--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -73,7 +73,6 @@ State::State(const Geometry & geom,
                      << std::endl;
   geom_->log_status();
   setupStateFields();
-  geom_->log_status();
 
   if (params_.analyticInit.value().value_or(false)) {
     this->analytic_init(*geom_);
@@ -240,6 +239,7 @@ void State::write(const eckit::Configuration & config) const {
 
 void State::print(std::ostream & os) const {
   oops::Log::trace() << "State(ORCA)::print starting" << std::endl;
+  geom_->log_status();
 
   os << std::endl << " Model state valid at time: " << validTime() << std::endl;
   os << std::string(4, ' ') << vars_ <<  std::endl;

--- a/src/orca-jedi/state/State.h
+++ b/src/orca-jedi/state/State.h
@@ -76,7 +76,7 @@ class State : public util::Printable,
   void analytic_init(const Geometry &);
   void write(const OrcaStateParameters &) const;
   void write(const eckit::Configuration &) const;
-  double norm(const std::string & field_name) const;
+  template<class T> double norm(const std::string & field_name) const;
   const util::DateTime & validTime() const {return time_;}
   util::DateTime & validTime() {return time_;}
 

--- a/src/orca-jedi/state/StateIOUtils.h
+++ b/src/orca-jedi/state/StateIOUtils.h
@@ -12,6 +12,8 @@
 #include "orca-jedi/geometry/Geometry.h"
 #include "orca-jedi/state/State.h"
 #include "orca-jedi/state/StateParameters.h"
+#include "orca-jedi/utilities/Types.h"
+#include "orca-jedi/nemo_io/ReadServer.h"
 
 namespace orcamodel {
 
@@ -26,5 +28,11 @@ void writeFieldsToFile(
   const Geometry & geom,
   const util::DateTime & valid_date,
   const atlas::FieldSet & fs);
+template<class T> void populateField(
+  const std::string & nemo_name,
+  const std::string & coord_type,
+  size_t time_indx,
+  ReadServer & nemo_reader,
+  atlas::Field & field);
 
 }  // namespace orcamodel

--- a/src/orca-jedi/utilities/Types.h
+++ b/src/orca-jedi/utilities/Types.h
@@ -1,0 +1,15 @@
+/*
+ * (C) British Crown Copyright 2024 Met Office
+ */
+
+#pragma once
+
+namespace orcamodel {
+
+/// Enum type for obs variable data types
+enum class FieldDType {
+    Float,
+    Double
+};
+
+}  // namespace orcamodel

--- a/src/tests/orca-jedi/test_interpolator.cc
+++ b/src/tests/orca-jedi/test_interpolator.cc
@@ -56,7 +56,7 @@ CASE("test basic interpolator") {
 
   eckit::LocalConfiguration interp_conf;
   interp_conf.set("type", "unstructured-bilinear-lonlat");
-  interp_conf.set("non_linear", "missing-if-all-missing");
+  interp_conf.set("non_linear", "missing-if-all-missing-real32");
   eckit::LocalConfiguration interpolator_conf;
   interpolator_conf.set("atlas-interpolator", interp_conf);
 
@@ -104,7 +104,7 @@ CASE("test basic interpolator") {
         "sea_surface_foundation_temperature"}), state, mask, vals);
 
     double missing_value = util::missingValue<double>();
-    std::vector<double> testvals = {1, missing_value, 0, 18.488888892,
+    std::vector<double> testvals = {1, missing_value, 0, 18.4888916016,
                                     missing_value, 18.1592999503};
 
     for (size_t i=0; i < testvals.size(); ++i) {
@@ -121,8 +121,8 @@ CASE("test basic interpolator") {
 
     double missing_value = util::missingValue<double>();
     std::vector<double> testvals = {
-      18.488888892, missing_value, 18.1592999503,
-      17.9419381132, missing_value, 17.75000288,
+      18.4888916016, missing_value, 18.1592999503,
+      17.9419364929, missing_value, 17.75000288,
       missing_value, missing_value, missing_value};
 
     for (size_t i=0; i < testvals.size(); ++i) {

--- a/src/tests/orca-jedi/test_nemo_io_field_reader.cc
+++ b/src/tests/orca-jedi/test_nemo_io_field_reader.cc
@@ -87,7 +87,7 @@ CASE("test read_var_slice reads vector") {
   eckit::PathName test_data_path("../Data/simple_nemo.nc");
 
   NemoFieldReader field_reader(test_data_path);
-  std::vector<double> data = field_reader.read_var_slice("iiceconc", 1, 0);
+  std::vector<double> data = field_reader.read_var_slice<double>("iiceconc", 1, 0);
 
   EXPECT_EQUAL(data[0], 121);
   EXPECT_EQUAL(data[5], 171);

--- a/src/tests/orca-jedi/test_nemo_io_field_writer.cc
+++ b/src/tests/orca-jedi/test_nemo_io_field_writer.cc
@@ -88,7 +88,7 @@ CASE("test parallel serially distributed write field array views") {
   SECTION("surface field matches with data in memory") {
     if (rank == 0) {
       NemoFieldReader field_reader(test_data_path);
-      std::vector<double> data = field_reader.read_var_slice("iiceconc", 0, 0);
+      std::vector<double> data = field_reader.read_var_slice<double>("iiceconc", 0, 0);
       for (atlas::idx_t iNode = 0; iNode < ice_fv.shape(0); ++iNode) {
         if (ghost(iNode)) continue;
         EXPECT_EQUAL(data[iNode], ice_fv(iNode, 0));
@@ -99,7 +99,7 @@ CASE("test parallel serially distributed write field array views") {
   SECTION("depth field matches with data in memory") {
     if (rank == 0) {
       NemoFieldReader field_reader(test_data_path);
-      auto vert_levels = field_reader.read_vertical_var("z", 3);
+      auto vert_levels = field_reader.read_vertical_var<double>("z", 3);
 
       EXPECT_EQUAL(vert_levels[0], 1);
       EXPECT_EQUAL(vert_levels[1], 2);
@@ -111,19 +111,19 @@ CASE("test parallel serially distributed write field array views") {
   SECTION("volume field matches with data in memory") {
     if (rank == 0) {
       NemoFieldReader field_reader(test_data_path);
-      std::vector<double> data = field_reader.read_var_slice("votemper", 0, 0);
+      std::vector<double> data = field_reader.read_var_slice<double>("votemper", 0, 0);
       for (size_t iNode = 0; iNode < data.size(); ++iNode) {
         if (ghost(iNode)) continue;
         EXPECT_EQUAL(data[iNode], temp_fv(iNode, 0));
       }
       data.clear();
-      data = field_reader.read_var_slice("votemper", 0, 1);
+      data = field_reader.read_var_slice<double>("votemper", 0, 1);
       for (size_t iNode = 0; iNode < data.size(); ++iNode) {
         if (ghost(iNode)) continue;
         EXPECT_EQUAL(data[iNode], temp_fv(iNode, 1));
       }
       data.clear();
-      data = field_reader.read_var_slice("votemper", 0, 2);
+      data = field_reader.read_var_slice<double>("votemper", 0, 2);
       for (size_t iNode = 0; iNode < data.size(); ++iNode) {
         if (ghost(iNode)) continue;
         EXPECT_EQUAL(data[iNode], temp_fv(iNode, 2));

--- a/src/tests/orca-jedi/test_nemo_io_read_server.cc
+++ b/src/tests/orca-jedi/test_nemo_io_read_server.cc
@@ -59,7 +59,10 @@ CASE("test MPI distributed reads field array view") {
           atlas::option::levels(1)));
     auto field_view = atlas::array::make_view<double, 2>(field);
 
-    ReadServer read_server(test_data_path, mesh);
+    auto eckit_timer = std::make_shared<eckit::Timer>(
+      "Geometry(ORCA): ", oops::Log::trace());
+    eckit_timer->start();
+    ReadServer read_server(eckit_timer, test_data_path, mesh);
     read_server.read_var("iiceconc", 0, field_view);
 
     auto ij = atlas::array::make_view<int32_t, 2>(mesh.nodes().field("ij"));

--- a/src/tests/orca-jedi/test_nemo_io_read_server.cc
+++ b/src/tests/orca-jedi/test_nemo_io_read_server.cc
@@ -51,7 +51,7 @@ CASE("test MPI distributed reads field array view") {
     std::vector<double> raw_data;
     {
       NemoFieldReader field_reader(test_data_path);
-      raw_data = field_reader.read_var_slice("iiceconc", 0, 0);
+      raw_data = field_reader.read_var_slice<double>("iiceconc", 0, 0);
     }
 
     atlas::Field field(funcSpace.createField<double>(
@@ -63,7 +63,7 @@ CASE("test MPI distributed reads field array view") {
       "Geometry(ORCA): ", oops::Log::trace());
     eckit_timer->start();
     ReadServer read_server(eckit_timer, test_data_path, mesh);
-    read_server.read_var("iiceconc", 0, field_view);
+    read_server.read_var<double>("iiceconc", 0, field_view);
 
     auto ij = atlas::array::make_view<int32_t, 2>(mesh.nodes().field("ij"));
 
@@ -88,14 +88,14 @@ CASE("test MPI distributed reads field array view") {
       auto field_view = atlas::array::make_view<double, 2>(field);
 
       NemoFieldReader field_reader(test_data_path);
-      read_server.read_var("votemper", 0, field_view);
+      read_server.read_var<double>("votemper", 0, field_view);
 
       auto ij = atlas::array::make_view<int32_t, 2>(mesh.nodes().field("ij"));
 
       auto ghost = atlas::array::make_view<int32_t, 1>(mesh.nodes().ghost());
       std::vector<double> raw_data;
       for (int k =0; k <3; k++) {
-        raw_data = field_reader.read_var_slice("votemper", 0, k);
+        raw_data = field_reader.read_var_slice<double>("votemper", 0, k);
         for (int i = 0; i < field_view.shape(0); ++i) {
           double raw_value = raw_data[orca_index(ij(i, 0), ij(i, 1))];
           if (ghost(i)) continue;
@@ -117,7 +117,7 @@ CASE("test MPI distributed reads field array view") {
             atlas::option::levels(3)));
       auto field_view = atlas::array::make_view<double, 2>(field);
 
-      read_server.read_vertical_var("nav_lev", field_view);
+      read_server.read_vertical_var<double>("nav_lev", field_view);
 
       auto ij = atlas::array::make_view<int32_t, 2>(mesh.nodes().field("ij"));
 

--- a/src/tests/orca-jedi/test_state.cc
+++ b/src/tests/orca-jedi/test_state.cc
@@ -32,16 +32,20 @@ CASE("test basic state") {
 
   std::vector<eckit::LocalConfiguration> nemo_var_mappings(4);
   nemo_var_mappings[0].set("name", "sea_ice_area_fraction")
+    .set("field precision", "double")
     .set("nemo field name", "iiceconc")
     .set("model space", "surface");
   nemo_var_mappings[1].set("name", "sea_ice_area_fraction_error")
+    .set("field precision", "double")
     .set("nemo field name", "sic_tot_var")
     .set("model space", "surface")
     .set("variable type", "background variance");
   nemo_var_mappings[2].set("name", "sea_surface_foundation_temperature")
+    .set("field precision", "double")
     .set("nemo field name", "votemper")
     .set("model space", "surface");
   nemo_var_mappings[3].set("name", "sea_water_potential_temperature")
+    .set("field precision", "double")
     .set("nemo field name", "votemper")
     .set("model space", "volume");
   config.set("nemo variables", nemo_var_mappings);
@@ -91,7 +95,7 @@ CASE("test basic state") {
     state_config.set("analytic initialisation", true);
     params.validateAndDeserialize(state_config);
     State state(geometry, params);
-    EXPECT_EQUAL(state.norm("sea_ice_area_fraction"), 0);
+    EXPECT_EQUAL(state.norm<double>("sea_ice_area_fraction"), 0);
   }
 
   state_config.set("nemo field file", "../Data/orca2_t_nemo.nc");
@@ -104,17 +108,17 @@ CASE("test basic state") {
     bool has_missing = state.stateFields()["sea_ice_area_fraction"].metadata()
       .has("missing_value");
     EXPECT_EQUAL(true, has_missing);
-    std::cout << std::setprecision(8) << state.norm("sea_ice_area_fraction")
+    std::cout << std::setprecision(8) << state.norm<double>("sea_ice_area_fraction")
               << std::setprecision(8) << iceNorm << std::endl;
-    EXPECT(std::abs(state.norm("sea_ice_area_fraction") - iceNorm) < 1e-6);
+    EXPECT(std::abs(state.norm<double>("sea_ice_area_fraction") - iceNorm) < 1e-6);
   }
   SECTION("test state read") {
     state.read(params);
-    EXPECT(std::abs(state.norm("sea_ice_area_fraction") - iceNorm) < 1e-6);
+    EXPECT(std::abs(state.norm<double>("sea_ice_area_fraction") - iceNorm) < 1e-6);
   }
   SECTION("test stateCopy") {
     State stateCopy(state);
-    EXPECT(std::abs(stateCopy.norm("sea_ice_area_fraction") - iceNorm) < 1e-6);
+    EXPECT(std::abs(stateCopy.norm<double>("sea_ice_area_fraction") - iceNorm) < 1e-6);
   }
   SECTION("test state write") {
     state.write(params);

--- a/src/tests/testinput/hofx3d_nc_potm.yaml
+++ b/src/tests/testinput/hofx3d_nc_potm.yaml
@@ -43,7 +43,7 @@ observations:
     get values:
       atlas-interpolator:
         type: unstructured-bilinear-lonlat
-        non_linear: missing-if-all-missing
+        non_linear: missing-if-all-missing-real32
     obs operator:
       name: VertInterp
       variables:

--- a/src/tests/testinput/hofx3d_nc_prof_2vars.yaml
+++ b/src/tests/testinput/hofx3d_nc_prof_2vars.yaml
@@ -55,7 +55,7 @@ observations:
     get values:
       atlas-interpolator:
         type: unstructured-bilinear-lonlat
-        non_linear: missing-if-all-missing
+        non_linear: missing-if-all-missing-real32
     obs operator:
       name: VertInterp
       variables:

--- a/src/tests/testinput/hofx3d_nc_sst.yaml
+++ b/src/tests/testinput/hofx3d_nc_sst.yaml
@@ -42,7 +42,7 @@ observations:
     get values:
       atlas-interpolator:
         type: finite-element
-        non_linear: missing-if-all-missing
+        non_linear: missing-if-all-missing-real32
     obs operator:
       name: Composite
       components:

--- a/src/tests/testinput/hofx_nc_ice.yaml
+++ b/src/tests/testinput/hofx_nc_ice.yaml
@@ -60,7 +60,7 @@ observations:
       time interpolation: linear
       atlas-interpolator:
         type: unstructured-bilinear-lonlat
-        non_linear: missing-if-all-missing
+        non_linear: missing-if-all-missing-real32
         max_fraction_elems_to_try: 0.0
     obs operator:
       name: Composite

--- a/src/tests/testinput/hofx_nc_ssh.yaml
+++ b/src/tests/testinput/hofx_nc_ssh.yaml
@@ -55,7 +55,7 @@ observations:
     get values:
       atlas-interpolator:
         type: unstructured-bilinear-lonlat
-        non_linear: missing-if-all-missing
+        non_linear: missing-if-all-missing-real32
     obs operator:
       name: Composite
       components:

--- a/src/tests/testinput/hofx_nc_ssh_checkerboard.yaml
+++ b/src/tests/testinput/hofx_nc_ssh_checkerboard.yaml
@@ -53,7 +53,7 @@ observations:
     get values:
       atlas-interpolator:
         type: unstructured-bilinear-lonlat
-        non_linear: missing-if-all-missing
+        non_linear: missing-if-all-missing-real32
     obs operator:
       name: Composite
       components:

--- a/src/tests/testinput/hofx_nc_sst.yaml
+++ b/src/tests/testinput/hofx_nc_sst.yaml
@@ -59,7 +59,7 @@ observations:
     get values:
       atlas-interpolator:
         type: unstructured-bilinear-lonlat
-        non_linear: missing-if-all-missing
+        non_linear: missing-if-all-missing-real32
     obs operator:
       name: Composite
       components:

--- a/src/tests/testinput/hofx_odb_ice.yaml
+++ b/src/tests/testinput/hofx_odb_ice.yaml
@@ -62,7 +62,7 @@ observations:
       time interpolation: linear
       atlas-interpolator:
         type: unstructured-bilinear-lonlat
-        non_linear: missing-if-all-missing
+        non_linear: missing-if-all-missing-real32
         max_fraction_elems_to_try: 0.0
     obs operator:
       name: Composite

--- a/src/tests/testinput/ostia_seaice_obs_hofx3d.yaml
+++ b/src/tests/testinput/ostia_seaice_obs_hofx3d.yaml
@@ -41,7 +41,7 @@ observations:
     get values:
       atlas-interpolator:
         type: "finite-element"
-        non_linear: missing-if-all-missing
+        non_linear: missing-if-all-missing-real32
     obs operator:
       name: Composite
       components:


### PR DESCRIPTION
## Description

Memory limitations on the HPC mean that it is difficult to fit the larger models with lots of variables into memory.

This change adds a configuration option to specify either float or double for the atlas fields. The default is also updated to float, which ought to approximately half memory use by orca-jedi. I have included additional logging to the trace output stream to track the memory usage over run time.

This change also includes making the reading of nemo data more robust to the underlying type of the netcdf data. There is probably a better way of managing this in future changes. Either using the type in the nemo file to determine the type of the atlas field, or avoiding reading all data in from the file -> std::vector<double> buffer to mpi broadcast data to other processes -> filling the atlas field with specified type. 

However, due to limitations in `atlas::interpolation::NonLinear`, all fields must be the same type, and the configuration of missing values adjustment to the weights must include the fortran label of the type after the name (e.g "-real32"). An atlas change is required to allow one run, one interpolator, with two fields of different type.

For now, in this change, I am keeping separate the concepts of the netcdf type of the nemo file variable and the atlas field datatype. Changes to the types used inside a run are controlled for now in two places:
1. via "geometry:nemo variables: - {field precision: double, ...}"
2. which when set to float and using missing values as part of interpolation requires specifying "get values: atlas-interpolator: non_linear: <missing-val-kind>-real32"

## Issues

Fixes #78

## Dependencies

Mutually dependent on merge of MetOffice/jjdocs/pull/128

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] New functions are documented briefly via Doxygen comments in the code
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [x] I have run [mo-bundle](http://fcm1/cylc-review/taskjobs/tsearle/?suite=mobb-oj79) to check integration with the rest of JEDI and run the unit tests under all environments

## Testing

Tested using adjusted apps from [jjdocs/feature/atlas-field-float-precision](https://github.com/MetOffice/jjdocs/tree/feature/atlas-field-float-precision) and the [MPI sith branch](https://github.com/MetOffice/sith/pull/271)

 - [x] [ostia configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79-271_spice_ostia)
 - [x] [ocnd configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79-271_spice_ocnd)
 - [x] [ocnd_eorca12 configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79-271_spice_ocnd_eorca12)
 - [ ] [gl_ocn configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79-271_spice_gl_ocn)
 - [x] [ostia configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79-271_xc_ostia)
 - [x] [ocnd configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79-271_xc_ocnd)
 - [ ] [ocnd_eorca12 configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79-271_xc_ocnd_eorca12)
 - [x] [gl_ocn configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79-271_xc_gl_ocn)

Tests using the jjdocs branch and the develop branch of sith:
- [x] [ostia configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79_spice_ostia)
- [x] [ocnd configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79_spice_ocnd)
- [x] [gl_ocn configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79_spice_gl_ocn)
- [x] [ostia configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79_xc_ostia)
- [x] [ocnd configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79_xc_ocnd)
- [x] [gl_ocn configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj79_xc_gl_ocn)


