### PR TITLE
refactor: Separate the control flow to handle the atlas::Field datatypes from application logic

### DIFF
--- a/src/orca-jedi/interpolator/Interpolator.cc
+++ b/src/orca-jedi/interpolator/Interpolator.cc
@@ -117,17 +117,15 @@ namespace orcamodel {
 
     auto res_iter = result.begin();
     for (size_t jvar=0; jvar < nvars; ++jvar) {
-      switch (state.geometry()->fieldPrecision(vars[jvar])) {
-        case FieldDType::Double:
-          executeInterpolation<double>(vars[jvar], varSizes[jvar], state, res_iter);
-          break;
-        case FieldDType::Float:
-          executeInterpolation<float>(vars[jvar], varSizes[jvar], state, res_iter);
-          break;
-        default:
-          throw eckit::BadParameter("orcamodel::Interpolator::apply '"
-              + vars[jvar] + "' field type not recognised This line should never run!");
-      }
+      const auto execute = [&](auto typeVal) {
+        using T = decltype(typeVal);
+        executeInterpolation<T>(vars[jvar], varSizes[jvar], state, res_iter);
+      };
+
+      ApplyForFieldType(execute,
+                        state.geometry()->fieldPrecision(vars[jvar]),
+                        eckit::BadParameter("orcamodel::Interpolator::apply '"
+                          + vars[jvar] + "' field type not recognised"));
     }
     assert(result.size() == nvals);
     oops::Log::trace() << "orcamodel::Interpolator::apply done "

--- a/src/orca-jedi/state/StateIOUtils.cc
+++ b/src/orca-jedi/state/StateIOUtils.cc
@@ -69,19 +69,15 @@ void readFieldsFromFile(
                               variable_type)
                          << std::endl;
       if (geom.variable_in_variable_type(fieldName, variable_type)) {
-        switch (geom.fieldPrecision(fieldName)) {
-          case FieldDType::Double:
-            populateField<double>(nemoName, varCoordTypeMap[fieldName],
-                                  time_indx, nemo_reader, field);
-            break;
-          case FieldDType::Float:
-            populateField<float>(nemoName, varCoordTypeMap[fieldName],
-                                 time_indx, nemo_reader, field);
-            break;
-          default:
-            throw eckit::BadParameter("State(ORCA)::readFieldsFromFile '"
-                + nemoName + "' This line should never run!");
-        }
+        const auto populate = [&](auto typeVal) {
+          using T = decltype(typeVal);
+          populateField<T>(nemoName, varCoordTypeMap[fieldName],
+                                time_indx, nemo_reader, field);
+        };
+        ApplyForFieldType(populate,
+                          geom.fieldPrecision(fieldName),
+                          eckit::BadParameter("State(ORCA)::readFieldsFromFile '"
+                            + nemoName + "' field type not recognised"));
         // Add a halo exchange following read to fill out halo points
         geom.functionSpace().haloExchange(field);
         geom.log_status();

--- a/src/orca-jedi/utilities/Types.h
+++ b/src/orca-jedi/utilities/Types.h
@@ -4,12 +4,26 @@
 
 #pragma once
 
+#include<exception>
+
 namespace orcamodel {
 
-/// Enum type for obs variable data types
+//// \brief Enum type for obs variable data types
 enum class FieldDType {
     Float,
     Double
 };
+
+/// \brief Apply a function for a given FieldDType
+template<typename Functor>
+void ApplyForFieldType(const Functor& functor, FieldDType field_type, std::exception on_fail) {
+  if (field_type == FieldDType::Float) {
+    functor(float{});
+  } else if (field_type == FieldDType::Double) {
+    functor(double{});
+  } else {
+    throw on_fail;
+  }
+}
 
 }  // namespace orcamodel


### PR DESCRIPTION
## Description

This refactor separates the control flow to handle the various atlas Field types from operations on the fields.

Thanks very much to @odlomax for explaining how to do this!

## Issue(s) addressed

Resolves #80 

## Impact

None expected

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] New functions are documented briefly via Doxygen comments in the code
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [x] I have [run mo-bundle](http:/fcm1/cylc-review/taskjobs/tsearle/?suite=mobb-oj81) to check integration with the rest of JEDI and run the unit tests under all environments
