### PR TITLE
Only declare exception when thrown

### DIFF
--- a/src/orca-jedi/interpolator/Interpolator.cc
+++ b/src/orca-jedi/interpolator/Interpolator.cc
@@ -124,8 +124,8 @@ namespace orcamodel {
 
       ApplyForFieldType(execute,
                         state.geometry()->fieldPrecision(vars[jvar]),
-                        eckit::BadParameter("orcamodel::Interpolator::apply '"
-                          + vars[jvar] + "' field type not recognised"));
+                        std::string("orcamodel::Interpolator::apply '")
+                          + vars[jvar] + "' field type not recognised");
     }
     assert(result.size() == nvals);
     oops::Log::trace() << "orcamodel::Interpolator::apply done "

--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -213,8 +213,8 @@ void State::setupStateFields() {
       };
       ApplyForFieldType(addField,
                         geom_->fieldPrecision(vars_[i]),
-                        eckit::BadParameter("State(ORCA)::setupStateFields "
-                          + vars_[i] + "' field type not recognised"));
+                        std::string("State(ORCA)::setupStateFields ")
+                        + vars_[i] + "' field type not recognised");
       geom_->log_status();
     }
   }
@@ -249,8 +249,8 @@ void State::print(std::ostream & os) const {
 
     ApplyForFieldType(addField,
                       geom_->fieldPrecision(fieldName),
-                      eckit::BadParameter("State(ORCA)::print '"
-                        + fieldName + "' field type not recognised"));
+                      std::string("State(ORCA)::print '")
+                      + fieldName + "' field type not recognised");
 
     os << std::string(8, ' ') << fieldName << ": " << std::setprecision(5)
        << norm_val << std::endl;
@@ -283,8 +283,8 @@ void State::zero() {
 
     ApplyForFieldType(zeroField,
                       geom_->fieldPrecision(fieldName),
-                      eckit::BadParameter("State(ORCA)::zero '"
-                        + fieldName + "' field type not recognised"));
+                      std::string("State(ORCA)::zero '")
+                      + fieldName + "' field type not recognised");
   }
 
   oops::Log::trace() << "State(ORCA)::zero done" << std::endl;

--- a/src/orca-jedi/state/StateIOUtils.cc
+++ b/src/orca-jedi/state/StateIOUtils.cc
@@ -76,8 +76,8 @@ void readFieldsFromFile(
         };
         ApplyForFieldType(populate,
                           geom.fieldPrecision(fieldName),
-                          eckit::BadParameter("State(ORCA)::readFieldsFromFile '"
-                            + nemoName + "' field type not recognised"));
+                          std::string("State(ORCA)::readFieldsFromFile '")
+                            + nemoName + "' field type not recognised");
         // Add a halo exchange following read to fill out halo points
         geom.functionSpace().haloExchange(field);
         geom.log_status();

--- a/src/orca-jedi/utilities/Types.h
+++ b/src/orca-jedi/utilities/Types.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include<exception>
+#include "eckit/exception/Exceptions.h"
 
 namespace orcamodel {
 
@@ -16,13 +16,13 @@ enum class FieldDType {
 
 /// \brief Apply a function for a given FieldDType
 template<typename Functor>
-void ApplyForFieldType(const Functor& functor, FieldDType field_type, std::exception on_fail) {
+void ApplyForFieldType(const Functor& functor, FieldDType field_type, const std::string& error_message) {
   if (field_type == FieldDType::Float) {
     functor(float{});
   } else if (field_type == FieldDType::Double) {
     functor(double{});
   } else {
-    throw on_fail;
+    throw eckit::BadParameter(error_message);
   }
 }
 

--- a/src/orca-jedi/utilities/Types.h
+++ b/src/orca-jedi/utilities/Types.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "eckit/exception/Exceptions.h"
 
 namespace orcamodel {
@@ -16,7 +18,8 @@ enum class FieldDType {
 
 /// \brief Apply a function for a given FieldDType
 template<typename Functor>
-void ApplyForFieldType(const Functor& functor, FieldDType field_type, const std::string& error_message) {
+void ApplyForFieldType(const Functor& functor, FieldDType field_type,
+     const std::string& error_message) {
   if (field_type == FieldDType::Float) {
     functor(float{});
   } else if (field_type == FieldDType::Double) {


### PR DESCRIPTION
## Description

When an eckit exception is declared it writes to standard out. This change moves the declaration so that it only happens when the exception is thrown, reducing spurious output in the log files.

### Testing

 - [x] I have [run mo-bundle](http://fcm1/cylc-review/taskjobs/tsearle/?suite=mobb-ojbugfix) to check integration with the rest of JEDI and run the unit tests under all environments
 - [x] [ostia configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_ojbugfix_spice_ostia)
 - [x] [ocnd configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_ojbugfix_spice_ocnd)
 - [x] [ocnd_eorca12 configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_ojbugfix_spice_ocnd_eorca12)
 - [x] [gl_ocn configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_ojbugfix_spice_gl_ocn)
 - [x] [ostia configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_ojbugfix_xc_ostia)
 - [x] [ocnd configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_ojbugfix_xc_ocnd)
 - [x] [ocnd_eorca12 configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_ojbugfix_xc_ocnd_eorca12)
 - [x] [gl_ocn configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_ojbugfix_xc_gl_ocn)
