### PR TITLE
Read volume vars from file

### DIFF
--- a/src/orca-jedi/nemo_io/NemoFieldReader.h
+++ b/src/orca-jedi/nemo_io/NemoFieldReader.h
@@ -33,6 +33,8 @@ class NemoFieldReader : private util::ObjectCounter<NemoFieldReader> {
   size_t read_dim_size(const std::string& name) const;
   size_t get_nearest_datetime_index(const util::DateTime& datetime) const;
   template<typename T> T read_fillvalue(const std::string& name) const;
+  template<typename T> std::vector<T> read_volume_var(
+      const std::string& varname, const size_t t_indx, const size_t nlevels) const;
   template<typename T> std::vector<T> read_var_slice(const std::string& varname,
       const size_t t_indx, const size_t z_indx) const;
   template<typename T> std::vector<T> read_vertical_var(const std::string& varname,

--- a/src/orca-jedi/nemo_io/ReadServer.cc
+++ b/src/orca-jedi/nemo_io/ReadServer.cc
@@ -31,11 +31,11 @@ ReadServer::ReadServer(std::shared_ptr<eckit::Timer> eckit_timer,
 /// \param t_index Index of the time slice.
 /// \param z_index Index of the vertical slice.
 /// \param buffer Vector to store the data.
-template<class T> void ReadServer::read_var_on_root(const std::string& var_name,
+template<class T> void ReadServer::read_var_slice_on_root(const std::string& var_name,
               const size_t t_index,
               const size_t z_index,
               std::vector<T>& buffer) const {
-  oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::read_var_on_root "
+  oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::read_var_slice_on_root "
     << var_name << std::endl;
   size_t size = index_glbarray_.nx_halo_WE * index_glbarray_.ny_halo_NS;
   if (myrank == mpiroot) {
@@ -44,13 +44,40 @@ template<class T> void ReadServer::read_var_on_root(const std::string& var_name,
     buffer.resize(size);
   }
 }
-template void ReadServer::read_var_on_root<double>(const std::string& var_name,
+template void ReadServer::read_var_slice_on_root<double>(const std::string& var_name,
               const size_t t_index,
               const size_t z_index,
               std::vector<double>& buffer) const;
-template void ReadServer::read_var_on_root<float>(const std::string& var_name,
+template void ReadServer::read_var_slice_on_root<float>(const std::string& var_name,
               const size_t t_index,
               const size_t z_index,
+              std::vector<float>& buffer) const;
+
+/// \brief Read in a 3D slice of variable data on the root processor only
+/// \param var_name
+/// \param t_index Index of the time slice.
+/// \param n_levels Number of levels to read in from the time slice.
+/// \param buffer Vector to store the data.
+template<class T> void ReadServer::read_volume_var_on_root(const std::string& var_name,
+              const size_t t_index,
+              const size_t n_levels,
+              std::vector<T>& buffer) const {
+  oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::read_volume_var_on_root "
+    << var_name << std::endl;
+  size_t size = n_levels * index_glbarray_.nx_halo_WE * index_glbarray_.ny_halo_NS;
+  if (myrank == mpiroot) {
+    buffer = reader_->read_volume_var<T>(var_name, t_index, n_levels);
+  } else {
+    buffer.resize(size);
+  }
+}
+template void ReadServer::read_volume_var_on_root<double>(const std::string& var_name,
+              const size_t t_index,
+              const size_t n_levels,
+              std::vector<double>& buffer) const;
+template void ReadServer::read_volume_var_on_root<float>(const std::string& var_name,
+              const size_t t_index,
+              const size_t n_levels,
               std::vector<float>& buffer) const;
 
 /// \brief Read 1D vertical variable data on the root processor only
@@ -76,31 +103,31 @@ template void ReadServer::read_vertical_var_on_root<float>(const std::string& va
 
 /// \brief Move data from a buffer into an atlas arrayView.
 /// \param buffer Vector of data to read
-/// \param z_index Index of the vertical slice.
 /// \param field_view View into the atlas field to store the data.
 template<class T> void ReadServer::fill_field(const std::vector<T>& buffer,
-              const size_t z_index,
       atlas::array::ArrayView<T, 2>& field_view) const {
-    oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::fill_field" << std::endl;
-    auto ghost = atlas::array::make_view<int32_t, 1>(this->mesh_.nodes().ghost());
-    auto ij = atlas::array::make_view<int32_t, 2>(this->mesh_.nodes().field("ij"));
-    const size_t num_nodes = field_view.shape(0);
-    // "ReadServer buffer size does not equal the number of horizontal nodes in the field_view"
-    assert(num_nodes <= buffer.size());
-    atlas_omp_parallel_for(size_t inode = 0; inode < num_nodes; ++inode) {
+  oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::fill_field" << std::endl;
+  auto ghost = atlas::array::make_view<int32_t, 1>(this->mesh_.nodes().ghost());
+  auto ij = atlas::array::make_view<int32_t, 2>(this->mesh_.nodes().field("ij"));
+  const size_t num_nodes = field_view.shape(0);
+  const size_t slice_size = index_glbarray_.nx_halo_WE * index_glbarray_.ny_halo_NS;
+  const size_t n_levels = field_view.shape(1);
+  // "ReadServer buffer size does not equal the number of nodes in the field_view"
+  assert(num_nodes*n_levels <= buffer.size());
+  atlas_omp_parallel_for(size_t ilevel = 0; ilevel < n_levels; ++ilevel) {
+    for (size_t inode = 0; inode < num_nodes; ++inode) {
       if (ghost(inode)) continue;
-      const int64_t ibuf = index_glbarray_(ij(inode, 0), ij(inode, 1));
-      field_view(inode, z_index) = buffer[ibuf];
+      const int64_t ibuf = ilevel*slice_size + index_glbarray_(ij(inode, 0), ij(inode, 1));
+      field_view(inode, ilevel) = buffer[ibuf];
     }
+  }
 }
 
 template void ReadServer::fill_field<double>(
       const std::vector<double>& buffer,
-      const size_t z_index,
       atlas::array::ArrayView<double, 2>& field_view) const;
 template void ReadServer::fill_field<float>(
       const std::vector<float>& buffer,
-      const size_t z_index,
       atlas::array::ArrayView<float, 2>& field_view) const;
 
 /// \brief Move vertical data from a buffer into an atlas arrayView.
@@ -108,24 +135,24 @@ template void ReadServer::fill_field<float>(
 /// \param field_view View into the atlas field to store the data.
 template<class T> void ReadServer::fill_vertical_field(const std::vector<T>& buffer,
       atlas::array::ArrayView<T, 2>& field_view) const {
-    oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::fill_vertical_field "<< std::endl;
-    auto ghost = atlas::array::make_view<int32_t, 1>(this->mesh_.nodes().ghost());
-    const size_t num_nodes = field_view.shape(0);
-    const size_t num_levels = field_view.shape(1);
-    // "ReadServer buffer size does not equal the number of levels in the field_view"
-    assert(num_levels <= buffer.size());
+  oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::fill_vertical_field "<< std::endl;
+  auto ghost = atlas::array::make_view<int32_t, 1>(this->mesh_.nodes().ghost());
+  const size_t num_nodes = field_view.shape(0);
+  const size_t num_levels = field_view.shape(1);
+  // "ReadServer buffer size does not equal the number of levels in the field_view"
+  assert(num_levels <= buffer.size());
 
-    // even for 1D depths, store the data in an atlas 3D field - inefficient but flexible
-    // NOTE: Use thread-private levels data to reduce OMP cache misses
-    atlas_omp_parallel {
-      const std::vector<T> buffer_TP = buffer;
-      atlas_omp_for(size_t inode = 0; inode < num_nodes; ++inode) {
-        for (size_t k = 0; k < num_levels; ++k) {
-          if (ghost(inode)) continue;
-          field_view(inode, k) = buffer_TP[k];
-        }
+  // even for 1D depths, store the data in an atlas 3D field - inefficient but flexible
+  // NOTE: Use thread-private levels data to reduce OMP cache misses
+  atlas_omp_parallel {
+    const std::vector<T> buffer_TP = buffer;
+    atlas_omp_for(size_t inode = 0; inode < num_nodes; ++inode) {
+      for (size_t k = 0; k < num_levels; ++k) {
+        if (ghost(inode)) continue;
+        field_view(inode, k) = buffer_TP[k];
       }
     }
+  }
 }
 
 template void ReadServer::fill_vertical_field<double>(
@@ -144,24 +171,24 @@ template<class T> void ReadServer::read_var(const std::string& var_name,
     atlas::array::ArrayView<T, 2>& field_view) {
   oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::read_var "
     << var_name << std::endl;
-
   size_t n_levels = field_view.shape(1);
-  size_t size = index_glbarray_.nx_halo_WE * index_glbarray_.ny_halo_NS;
+  size_t size = n_levels * index_glbarray_.nx_halo_WE * index_glbarray_.ny_halo_NS;
 
   std::vector<T> buffer;
-  // For each level
-  for (size_t iLev = 0; iLev < n_levels; iLev++) {
-    // read the data for that level onto the root processor
-    this->read_var_on_root<T>(var_name, t_index, iLev, buffer);
-
-    assert(buffer.size() == size);
-    // mpi distribute that data out to all processors
-    atlas::mpi::comm().broadcast(&buffer.front(), size, mpiroot);
-
-    // each processor fills out its field_view from the buffer
-    this->fill_field<T>(buffer, iLev, field_view);
-    log_status();
+  // read the data for that level onto the root processor
+  if (n_levels == 1) {
+    this->read_var_slice_on_root<T>(var_name, t_index, 0, buffer);
+  } else {
+    this->read_volume_var_on_root<T>(var_name, t_index, n_levels, buffer);
   }
+
+  assert(buffer.size() == size);
+  // mpi distribute that data out to all processors
+  atlas::mpi::comm().broadcast(&buffer.front(), size, mpiroot);
+
+  // each processor fills out its field_view from the buffer
+  this->fill_field<T>(buffer, field_view);
+  log_status();
 }
 
 template void ReadServer::read_var<double>(

--- a/src/orca-jedi/nemo_io/ReadServer.h
+++ b/src/orca-jedi/nemo_io/ReadServer.h
@@ -46,16 +46,19 @@ void log_status() const {
       << static_cast<double>(eckit::system::ResourceUsage().maxResidentSetSize()) / 1.0e+9
       << " Gb" << std::endl;
 }
-  template<class T> void read_var_on_root(const std::string& var_name,
+  template<class T> void read_var_slice_on_root(const std::string& var_name,
       const size_t t_index,
       const size_t z_index,
+      std::vector<T>& buffer) const;
+  template<class T> void read_volume_var_on_root(const std::string& var_name,
+      const size_t t_index,
+      const size_t n_levels,
       std::vector<T>& buffer) const;
   template<class T> void read_vertical_var_on_root(const std::string& var_name,
       const size_t n_levels,
       std::vector<T>& buffer) const;
   template<class T> void fill_field(const std::vector<T>& buffer,
-      const size_t z_index,
-      atlas::array::ArrayView<T, 2>& field_view) const;
+        atlas::array::ArrayView<T, 2>& field_view) const;
   template<class T> void fill_vertical_field(const std::vector<T>& buffer,
       atlas::array::ArrayView<T, 2>& field_view) const;
   const size_t mpiroot = 0;

--- a/src/tests/orca-jedi/test_nemo_io_field_reader.cc
+++ b/src/tests/orca-jedi/test_nemo_io_field_reader.cc
@@ -93,6 +93,28 @@ CASE("test read_var_slice reads vector") {
   EXPECT_EQUAL(data[5], 171);
 }
 
+CASE("test read_volume_var reads vector") {
+  eckit::PathName test_data_path("../Data/simple_nemo.nc");
+
+  int nx = 3; int ny = 2; int nz = 2; int nt = 3;
+
+  NemoFieldReader field_reader(test_data_path);
+  std::vector<double> data = field_reader.read_volume_var<double>("votemper", 1, nz);
+
+  for (int i = 0; i < nx; ++i) {
+    for (int j = 0; j < ny; ++j) {
+      for (int k = 0; k < nz; ++k) {
+        double test_val = 2000 + (k + 1)*100 + (j + 1)*10 + i + 1;
+        std::cout << "data[" << k << "*" << nx << "*" << ny << "+"
+                             << j << "*" << nx << "+"
+                             << i << "] ";
+        std::cout << data[k*nx*ny+j*nx+i] << " ~ " << test_val << std::endl;
+        EXPECT_EQUAL(data[k*nx*ny+j*nx+i], test_val);
+      }
+    }
+  }
+}
+
 }  // namespace test
 }  // namespace orcamodel
 

--- a/src/tests/orca-jedi/test_nemo_io_read_server.cc
+++ b/src/tests/orca-jedi/test_nemo_io_read_server.cc
@@ -94,7 +94,7 @@ CASE("test MPI distributed reads field array view") {
 
       auto ghost = atlas::array::make_view<int32_t, 1>(mesh.nodes().ghost());
       std::vector<double> raw_data;
-      for (int k =0; k <3; k++) {
+      for (int k = 0; k < 3; k++) {
         raw_data = field_reader.read_var_slice<double>("votemper", 0, k);
         for (int i = 0; i < field_view.shape(0); ++i) {
           double raw_value = raw_data[orca_index(ij(i, 0), ij(i, 1))];


### PR DESCRIPTION
## Description

We resolved #70 by reducing the memory usage of each process. Unfortunately, we found that the program spent most of its time in IO. This change reads the entirety of a volume variable in one go to reduce the number of file reads, rather than reading and broadcasting one horizontal level at a time.

## Dependencies

## Impact

The second cycle of the global ocean runs in MetOffice/sith/pull/271 should hopefully complete.

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] New functions are documented briefly via Doxygen comments in the code
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [x] I have run [mo-bundle](http://fcm1/cylc-review/taskjobs/tsearle/?suite=mobb-oj83) to check integration with the rest of JEDI and run the unit tests under all environments
 - [x] [ostia configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj83_spice_ostia)
 - [x] [ocnd configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj83_spice_ocnd)
 - [x] [gl_ocn configuration on spice](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj83_spice_gl_ocn)
 - [x] [ostia configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj83_xc_ostia)
 - [x] [ocnd configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj83_xc_ocnd)
 - [x] [gl_ocn configuration on xc](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_oj83_xc_gl_ocn)

