### PR TITLE
Add parallel write of atlas fields on the root processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 compile_commands.json
+*.vscode*

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "array": "cpp"
+    }
+}

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "array": "cpp"
-    }
-}

--- a/src/orca-jedi/CMakeLists.txt
+++ b/src/orca-jedi/CMakeLists.txt
@@ -30,7 +30,11 @@ nemo_io/NemoFieldWriter.cc
 nemo_io/OrcaIndex.h
 nemo_io/ReadServer.h
 nemo_io/ReadServer.cc
+nemo_io/WriteServer.h
+nemo_io/WriteServer.cc
 utilities/OrcaModelTraits.h
+utilities/Types.h
+utilities/Types.cc
 variablechanges/VariableChangeParameters.h
 variablechanges/VariableChange.h
 )

--- a/src/orca-jedi/interpolator/Interpolator.cc
+++ b/src/orca-jedi/interpolator/Interpolator.cc
@@ -127,7 +127,7 @@ namespace orcamodel {
                         std::string("orcamodel::Interpolator::apply '")
                           + vars[jvar] + "' field type not recognised");
     }
-    assert(result.size() == nvals);
+    ASSERT(result.size() == nvals);
     oops::Log::trace() << "orcamodel::Interpolator::apply done "
                        << std::endl;
   }

--- a/src/orca-jedi/nemo_io/NemoFieldWriter.cc
+++ b/src/orca-jedi/nemo_io/NemoFieldWriter.cc
@@ -30,11 +30,11 @@ NemoFieldWriter::NemoFieldWriter(const eckit::PathName& filename,
     size_t nx, size_t ny,
     const std::vector<double>& depths) :
       datetimes_(datetimes)
+    , depths_(depths)
+    , nLevels_(depths.size())
     , nTimes_(datetimes.size())
     , nx_(nx)
     , ny_(ny)
-    , depths_(depths)
-    , nLevels_(depths.size())
     , dimension_variables_present_(false) {
     bool new_file;
     if (!filename.exists() || atlas::mpi::rank() == 0) {

--- a/src/orca-jedi/nemo_io/NemoFieldWriter.cc
+++ b/src/orca-jedi/nemo_io/NemoFieldWriter.cc
@@ -11,9 +11,12 @@
 #include <sstream>
 #include <fstream>
 
+#include "orca-jedi/utilities/Types.h"
+
 #include "eckit/exception/Exceptions.h"
 
 #include "oops/util/Duration.h"
+#include "oops/util/Logger.h"
 
 #include "atlas/runtime/Log.h"
 #include "atlas/field.h"
@@ -23,14 +26,16 @@
 namespace orcamodel {
 
 NemoFieldWriter::NemoFieldWriter(const eckit::PathName& filename,
-    const atlas::Mesh& mesh, const std::vector<util::DateTime> datetimes,
-    const std::vector<double> depths)
-    : mesh_(mesh)
-    , orcaGrid_(mesh.grid())
-    , datetimes_(datetimes)
+    const std::vector<util::DateTime>& datetimes,
+    size_t nx, size_t ny,
+    const std::vector<double>& depths) :
+      datetimes_(datetimes)
     , nTimes_(datetimes.size())
+    , nx_(nx)
+    , ny_(ny)
     , depths_(depths)
-    , nLevels_(depths.size()) {
+    , nLevels_(depths.size())
+    , dimension_variables_present_(false) {
     bool new_file;
     if (!filename.exists() || atlas::mpi::rank() == 0) {
       ncFile = std::make_unique<netCDF::NcFile>(filename.fullName().asString(),
@@ -46,63 +51,51 @@ NemoFieldWriter::NemoFieldWriter(const eckit::PathName& filename,
             + filename + " not found or created");
     }
 
-    if (!orcaGrid_)
-       throw eckit::BadValue(std::string("orcamodel::NemoFieldWriter:: ")
-           + "only writes orca grid data");
-
-    ny_orca_halo_ = orcaGrid_.ny() + orcaGrid_.haloNorth();
-    iy_glb_max_ = orcaGrid_.ny() + orcaGrid_.haloNorth() - 1;
-    iy_glb_min_ = -orcaGrid_.haloSouth();
-    ix_glb_max_ = orcaGrid_.nx() + orcaGrid_.haloEast() - 1;
-    ix_glb_min_ = -orcaGrid_.haloWest();
-    nx_halo_WE_ = orcaGrid_.nx() + orcaGrid_.haloEast() + orcaGrid_.haloWest();
-    ny_halo_NS_ = orcaGrid_.ny() + orcaGrid_.haloNorth()
-                  + orcaGrid_.haloSouth();
-    glbarray_offset_  = -(nx_halo_WE_ * iy_glb_min_) - ix_glb_min_;
-    glbarray_jstride_ = nx_halo_WE_;
-
     if (new_file) {
       setup_dimensions();
     }
-    write_dimensions();
+
+    auto navLatVar = ncFile->getVar("nav_lat");
+    auto navLonVar = ncFile->getVar("nav_lon");
+    auto tVar = ncFile->getVar("t");
+    auto zVar = ncFile->getVar("z");
+    if (navLatVar.isNull() || navLonVar.isNull() || tVar.isNull() || zVar.isNull()) {
+      dimension_variables_present_ = false;
+    } else {
+      dimension_variables_present_ = true;
+    }
 }
 
 
 void NemoFieldWriter::setup_dimensions() {
-    size_t nx = nx_halo_WE_;
-    size_t ny = ny_halo_NS_;
-    auto nxDim = ncFile->addDim("x", nx);
-    auto nyDim = ncFile->addDim("y", ny);
+    oops::Log::trace() << "orcamodel::NemoFieldWriter::setup_dimensions" << std::endl;
+    auto nxDim = ncFile->addDim("x", nx_);
+    auto nyDim = ncFile->addDim("y", ny_);
     auto nzDim = ncFile->addDim("z", nLevels_);
     auto ntDim = ncFile->addDim("t", nTimes_);
-    auto latVar = ncFile->addVar("nav_lat", netCDF::ncDouble, {nyDim, nxDim});
-    auto lonVar = ncFile->addVar("nav_lon", netCDF::ncDouble, {nyDim, nxDim});
-    auto levVar = ncFile->addVar("z", netCDF::ncDouble, {nzDim});
-    auto timeVar = ncFile->addVar("t", netCDF::ncInt, {ntDim});
 }
 
-void NemoFieldWriter::write_dimensions() {
-    auto lonlat_view = atlas::array::make_view<double, 2>(
-        mesh_.nodes().lonlat());
-    auto ghost = atlas::array::make_view<int32_t, 1>(mesh_.nodes().ghost());
-    auto ij = atlas::array::make_view<int32_t, 2>(mesh_.nodes().field("ij"));
+void NemoFieldWriter::write_dimensions(const std::vector<double>& lats,
+                                       const std::vector<double>& lons) {
+    oops::Log::trace() << "orcamodel::NemoFieldWriter::write_dimensions" << std::endl;
 
-    auto navLatVar = ncFile->getVar("nav_lat");
-    auto navLonVar = ncFile->getVar("nav_lon");
-    for (size_t inode = 0; inode < mesh_.nodes().size(); ++inode) {
-        const int i = ij(inode, 0) + orcaGrid_.haloWest();
-        const int j = ij(inode, 1) + orcaGrid_.haloSouth();
-        ATLAS_ASSERT(i >= 0 && i < nx_halo_WE_);
-        ATLAS_ASSERT(j >= 0 && j < ny_halo_NS_,
-            "when j is " + std::to_string(j) + " and ny_halo_NS_ "
-            + std::to_string(ny_halo_NS_) );
-        std::vector<size_t> f_indices{static_cast<size_t>(j),
-                                      static_cast<size_t>(i)};
-        navLonVar.putVar(f_indices, lonlat_view(inode, 0));
-        navLatVar.putVar(f_indices, lonlat_view(inode, 1));
+    auto nxDim = ncFile->getDim("x");
+    auto nyDim = ncFile->getDim("y");
+    auto nzDim = ncFile->getDim("z");
+    auto ntDim = ncFile->getDim("t");
+
+    auto navLatVar = ncFile->addVar("nav_lat", netCDF::ncDouble, {nyDim, nxDim});
+    auto navLonVar = ncFile->addVar("nav_lon", netCDF::ncDouble, {nyDim, nxDim});
+    if ((lons.size() != nx_*ny_) || (lats.size() != nx_*ny_)) {
+        throw eckit::BadValue(
+            std::string("orcamodel::NemoFieldWriter::write_dimensions")
+            + " dimensions sizes do not match lat/lon buffer sizes",
+          Here());
     }
+    navLonVar.putVar({0, 0}, {ny_, nx_}, lons.data());
+    navLatVar.putVar({0, 0}, {ny_, nx_}, lats.data());
 
-    auto timeVar = ncFile->getVar("t");
+    auto timeVar = ncFile->addVar("t", netCDF::ncInt, {ntDim});
     const std::string seconds_since = "seconds since ";
     std::string units_string = "seconds since 1970-01-01 00:00:00";
     timeVar.putAtt("units", units_string);
@@ -116,48 +109,33 @@ void NemoFieldWriter::write_dimensions() {
         timeVar.putVar({iTime}, seconds_since_epoch);
     }
 
-    auto levVar = ncFile->getVar("z");
+    auto levVar = ncFile->addVar("z", netCDF::ncDouble, {nzDim});
     for (size_t iLevel = 0; iLevel < nLevels_; ++iLevel) {
         levVar.putVar({iLevel}, depths_[iLevel]);
     }
+    dimension_variables_present_ = true;
 }
-
-void NemoFieldWriter::add_double_variable(std::string& varname) {
-    ncFile->addVar(varname, netCDF::ncDouble,
-        (ncFile->getDim("t"), ncFile->getDim("y"), ncFile->getDim("x")));
-}
-
-void NemoFieldWriter::write_surf_var(std::string varname,
-    atlas::array::ArrayView<double, 2>& field_view, size_t iTime) {
+template <typename T> void NemoFieldWriter::write_surf_var(std::string varname,
+    const std::vector<T>& var_data, size_t iTime) {
+    oops::Log::trace() << "orcamodel::NemoFieldWriter::write_surf_var" << std::endl;
     try {
-        auto ghost = atlas::array::make_view<int32_t, 1>(mesh_.nodes().ghost());
-        auto ij = atlas::array::make_view<int32_t, 2>(
-            mesh_.nodes().field("ij"));
+        if (!dimension_variables_present_) {
+          throw eckit::BadValue(
+              std::string("orcamodel::NemoFieldWriter::write_surf_var")
+              + " can't write '" + varname + "' as the dimensions have not yet been constructed",
+            Here());
+        }
 
         auto ncVar = ncFile->getVar(varname);
         if (ncVar.isNull()) {
           auto nxDim = ncFile->getDim("x");
           auto nyDim = ncFile->getDim("y");
           auto ntDim = ncFile->getDim("t");
-          ncVar = ncFile->addVar(varname, netCDF::ncDouble,
-              {ntDim, nyDim, nxDim});
+          ncVar = ncFile->addVar(varname, NetCDFTypeMap<T>::ncType, {ntDim, nyDim, nxDim});
+          ncVar.setFill(true, static_cast<T>(NemoFieldWriter::fillValue));
         }
 
-        auto field_indices = [&](int jLat, int iLon)
-        {
-          return std::vector<size_t>{static_cast<size_t>(iTime),
-                                     static_cast<size_t>(jLat),
-                                     static_cast<size_t>(iLon)};
-        };
-
-        for (size_t inode = 0; inode < mesh_.nodes().size(); ++inode) {
-            // if (ghost(inode)) continue;
-            const int i = ij(inode, 0) + orcaGrid_.haloWest();
-            const int j = ij(inode, 1) + orcaGrid_.haloSouth();
-            ATLAS_ASSERT(i >= 0 && i < nx_halo_WE_);
-            ATLAS_ASSERT(j >= 0 && j < ny_halo_NS_);
-            ncVar.putVar(field_indices(j, i), field_view(inode, 0));
-        }
+        ncVar.putVar({iTime, 0, 0}, {1, ny_, nx_}, var_data.data());
     }
     catch (netCDF::exceptions::NcException& e) {
         throw eckit::FailedLibraryCall("NetCDF",
@@ -165,12 +143,21 @@ void NemoFieldWriter::write_surf_var(std::string varname,
     }
 }
 
-void NemoFieldWriter::write_vol_var(std::string varname,
-    atlas::array::ArrayView<double, 2>& field_view, size_t iTime) {
+template void NemoFieldWriter::write_surf_var<double>(std::string varname,
+    const std::vector<double>& var_data, size_t iTime);
+template void NemoFieldWriter::write_surf_var<float>(std::string varname,
+    const std::vector<float>& var_data, size_t iTime);
+
+template <typename T> void NemoFieldWriter::write_vol_var(std::string varname,
+    const std::vector<T>& var_data, size_t iTime) {
+    oops::Log::trace() << "orcamodel::NemoFieldWriter::write_vol_var" << std::endl;
     try {
-        auto ghost = atlas::array::make_view<int32_t, 1>(mesh_.nodes().ghost());
-        auto ij = atlas::array::make_view<int32_t, 2>(
-            mesh_.nodes().field("ij"));
+        if (!dimension_variables_present_) {
+          throw eckit::BadValue(
+              std::string("orcamodel::NemoFieldWriter::write_vol_var")
+              + " can't write '" + varname + "' as the dimensions have not yet been constructed",
+            Here());
+        }
 
         auto ncVar = ncFile->getVar(varname);
         if (ncVar.isNull()) {
@@ -178,30 +165,21 @@ void NemoFieldWriter::write_vol_var(std::string varname,
           auto nyDim = ncFile->getDim("y");
           auto nzDim = ncFile->getDim("z");
           auto ntDim = ncFile->getDim("t");
-          ncVar = ncFile->addVar(varname, netCDF::ncDouble,
+          ncVar = ncFile->addVar(varname, NetCDFTypeMap<T>::ncType,
               {ntDim, nzDim, nyDim, nxDim});
+          ncVar.setFill(true, static_cast<T>(NemoFieldWriter::fillValue));
         }
 
-        auto field_indices = [&](int iLev, int jLat, int iLon)
-        {
-          return std::vector<size_t>{static_cast<size_t>(iTime),
-                                     static_cast<size_t>(iLev),
-                                     static_cast<size_t>(jLat),
-                                     static_cast<size_t>(iLon)};
-        };
-
-        for (size_t k = 0; k < nLevels_; ++k) {
-            for (size_t inode = 0; inode < mesh_.nodes().size(); ++inode) {
-                // if (ghost(inode)) continue;
-                const int i = ij(inode, 0) + orcaGrid_.haloWest();
-                const int j = ij(inode, 1) + orcaGrid_.haloSouth();
-                ncVar.putVar(field_indices(k, j, i), field_view(inode, k));
-            }
-        }
+        ncVar.putVar({iTime, 0, 0, 0}, {1, nLevels_, ny_, nx_}, var_data.data());
     }
     catch (netCDF::exceptions::NcException& e) {
         throw eckit::FailedLibraryCall("NetCDF",
             "orcamodel::NemoFieldWriter::write_vol_var", e.what(), Here());
     }
 }
+
+template void NemoFieldWriter::write_vol_var<double>(std::string varname,
+    const std::vector<double>& var_data, size_t iTime);
+template void NemoFieldWriter::write_vol_var<float>(std::string varname,
+    const std::vector<float>& var_data, size_t iTime);
 }  // namespace orcamodel

--- a/src/orca-jedi/nemo_io/NemoFieldWriter.h
+++ b/src/orca-jedi/nemo_io/NemoFieldWriter.h
@@ -16,53 +16,37 @@
 
 #include "oops/util/DateTime.h"
 
-#include "atlas/array/ArrayView.h"
-#include "atlas/field.h"
-#include "atlas/mesh.h"
 #include "atlas/runtime/Exception.h"
-#include "atlas/util/Point.h"
-#include "atlas-orca/grid/OrcaGrid.h"
 
 namespace orcamodel {
 
 class NemoFieldWriter {
  public:
-    NemoFieldWriter(const eckit::PathName& filename, const atlas::Mesh& mesh,
-                    const std::vector<util::DateTime> datetimes,
-                    const std::vector<double> depths);
-    void setup_dimensions();
-    void write_dimensions();
-    void add_double_variable(std::string& varname);
+    static constexpr double fillValue{1.0e+20};
+    static const std::string classname() {return "orcamodel::NemoFieldWriter";}
 
-    void write_surf_var(std::string varname,
-        atlas::array::ArrayView<double, 2>& field_view, size_t iTime);
-    void write_vol_var(std::string varname,
-        atlas::array::ArrayView<double, 2>& field_view, size_t iTime);
+    NemoFieldWriter(const eckit::PathName& filename,
+                    const std::vector<util::DateTime>& datetimes,
+                    size_t nx, size_t ny,
+                    const std::vector<double>& depths);
+    void write_dimensions(const std::vector<double>& lats,
+                          const std::vector<double>& lons);
+    template <typename T> void write_surf_var(std::string varname,
+        const std::vector<T>& var_data, size_t iTime);
+    template <typename T> void write_vol_var(std::string varname,
+        const std::vector<T>& var_data, size_t iTime);
 
  private:
+    void setup_dimensions();
     NemoFieldWriter(): ncFile() {}
-    const inline int index_glbarray(int i, int j) {
-            ATLAS_ASSERT(i <= ix_glb_max_);
-            ATLAS_ASSERT(j <= iy_glb_max_);
-            return glbarray_offset_ + j * glbarray_jstride_ + i;
-    }
-
     std::unique_ptr<netCDF::NcFile> ncFile = nullptr;
-    atlas::Mesh mesh_;
-    atlas::OrcaGrid orcaGrid_;
     std::vector<util::DateTime> datetimes_;
     std::vector<double> depths_;
     size_t nLevels_{1};
     size_t nTimes_{1};
-    int ny_orca_halo_{-1};
-    int iy_glb_max_{-1};
-    int iy_glb_min_{-1};
-    int ix_glb_max_{-1};
-    int ix_glb_min_{-1};
-    int nx_halo_WE_{-1};
-    int ny_halo_NS_{-1};
-    int glbarray_offset_{-1};
-    int glbarray_jstride_{-1};
+    size_t nx_{0};
+    size_t ny_{0};
+    bool dimension_variables_present_{true};
 };
 }  // namespace orcamodel
 

--- a/src/orca-jedi/nemo_io/OrcaIndex.h
+++ b/src/orca-jedi/nemo_io/OrcaIndex.h
@@ -26,7 +26,6 @@ namespace orcamodel {
 struct OrcaIndexToBufferIndex {
  private:
   atlas::OrcaGrid orcaGrid_;
-  atlas::Mesh mesh_;
   int32_t ix_glb_max;
   int32_t iy_glb_max;
   int32_t glbarray_offset;
@@ -38,7 +37,7 @@ struct OrcaIndexToBufferIndex {
   size_t nx() const {return nx_;}
   size_t ny() const {return ny_;}
 
-  explicit OrcaIndexToBufferIndex(const atlas::Mesh& mesh) : orcaGrid_(mesh.grid()), mesh_(mesh) {
+  explicit OrcaIndexToBufferIndex(const atlas::Mesh& mesh) : orcaGrid_(mesh.grid()) {
     iy_glb_max = orcaGrid_.ny() + orcaGrid_.haloNorth() - 1;
     ix_glb_max = orcaGrid_.nx() + orcaGrid_.haloEast() - 1;
 
@@ -62,16 +61,6 @@ struct OrcaIndexToBufferIndex {
       ATLAS_ASSERT(j <= iy_glb_max,
           std::to_string(j) + " > " + std::to_string(iy_glb_max));
       return glbarray_offset + j * glbarray_jstride + i;
-  }
-
-  /// \brief buffer Index of buffer index corresponding to mesh inode
-  /// \param inode
-  /// \return index of a matching 1D array
-  int64_t operator()(const size_t inode) const {
-    auto ij = atlas::array::make_view<int32_t, 2>(mesh_.nodes().field("ij"));
-    const size_t i = ij(inode, 0) + orcaGrid_.haloWest();
-    const size_t j = ij(inode, 1) + orcaGrid_.haloSouth();
-    return j*nx_ + i;
   }
 };
 

--- a/src/orca-jedi/nemo_io/OrcaIndex.h
+++ b/src/orca-jedi/nemo_io/OrcaIndex.h
@@ -8,51 +8,71 @@
 #include <sstream>
 #include <limits>
 #include <map>
+#include <utility>
+#include <string>
+#include <memory>
 
 #include "eckit/exception/Exceptions.h"
 
 #include "oops/util/Logger.h"
 
+#include "atlas/mesh.h"
 #include "atlas-orca/grid/OrcaGrid.h"
 
 namespace orcamodel {
 
-/// \brief Indexer into a 1D array of an ORCA model field, match each point to the corresponding
-///        point in the atlas-orca ij space.
-struct OrcaIndex {
-    int32_t ix_glb_max;
-    int32_t iy_glb_max;
-    int32_t glbarray_offset;
-    int32_t glbarray_jstride;
-    int32_t nx_halo_WE;
-    int32_t ny_halo_NS;
+/// \brief Indexer from the orca netcdf i, j field to an index of a 1D buffer
+///        of orca data.
+struct OrcaIndexToBufferIndex {
+ private:
+  atlas::OrcaGrid orcaGrid_;
+  atlas::Mesh mesh_;
+  int32_t ix_glb_max;
+  int32_t iy_glb_max;
+  int32_t glbarray_offset;
+  int32_t glbarray_jstride;
+  size_t nx_;
+  size_t ny_;
 
-    explicit OrcaIndex(const atlas::OrcaGrid& orcaGrid) {
-        iy_glb_max = orcaGrid.ny() + orcaGrid.haloNorth() - 1;
-        ix_glb_max = orcaGrid.nx() + orcaGrid.haloEast() - 1;
+ public:
+  size_t nx() const {return nx_;}
+  size_t ny() const {return ny_;}
 
-        nx_halo_WE = orcaGrid.nx() + orcaGrid.haloEast() + orcaGrid.haloWest();
-        ny_halo_NS = orcaGrid.ny() + orcaGrid.haloNorth()
-          + orcaGrid.haloSouth();
+  explicit OrcaIndexToBufferIndex(const atlas::Mesh& mesh) : orcaGrid_(mesh.grid()), mesh_(mesh) {
+    iy_glb_max = orcaGrid_.ny() + orcaGrid_.haloNorth() - 1;
+    ix_glb_max = orcaGrid_.nx() + orcaGrid_.haloEast() - 1;
 
-        // vector of local indices: necessary for remote indices of ghost nodes
-        int iy_glb_min = -orcaGrid.haloSouth();
-        int ix_glb_min = -orcaGrid.haloWest();
-        glbarray_offset  = -(nx_halo_WE * iy_glb_min) - ix_glb_min;
-        glbarray_jstride = nx_halo_WE;
-    }
+    nx_ = orcaGrid_.nx() + orcaGrid_.haloWest() + orcaGrid_.haloEast();
+    ny_ = orcaGrid_.ny() + orcaGrid_.haloSouth() + orcaGrid_.haloNorth();
 
-    /// \brief Index of a 1D array corresponding to point i, j
-    /// \param i
-    /// \param j
-    /// \return index of a matching 1D array
-    int64_t operator()(const int i, const int j) const {
-        ATLAS_ASSERT(i <= ix_glb_max,
-            std::to_string(i) + " > " + std::to_string(ix_glb_max));
-        ATLAS_ASSERT(j <= iy_glb_max,
-            std::to_string(j) + " > " + std::to_string(iy_glb_max));
-        return glbarray_offset + j * glbarray_jstride + i;
-    }
+    // vector of local indices: necessary for remote indices of ghost nodes
+    int iy_glb_min = -orcaGrid_.haloSouth();
+    int ix_glb_min = -orcaGrid_.haloWest();
+    glbarray_offset  = -(nx_ * iy_glb_min) - ix_glb_min;
+    glbarray_jstride = nx_;
+  }
+
+  /// \brief Index of a 1D array corresponding to point i, j
+  /// \param i
+  /// \param j
+  /// \return index of a matching 1D array
+  int64_t operator()(const int i, const int j) const {
+      ATLAS_ASSERT(i <= ix_glb_max,
+          std::to_string(i) + " > " + std::to_string(ix_glb_max));
+      ATLAS_ASSERT(j <= iy_glb_max,
+          std::to_string(j) + " > " + std::to_string(iy_glb_max));
+      return glbarray_offset + j * glbarray_jstride + i;
+  }
+
+  /// \brief buffer Index of buffer index corresponding to mesh inode
+  /// \param inode
+  /// \return index of a matching 1D array
+  int64_t operator()(const size_t inode) const {
+    auto ij = atlas::array::make_view<int32_t, 2>(mesh_.nodes().field("ij"));
+    const size_t i = ij(inode, 0) + orcaGrid_.haloWest();
+    const size_t j = ij(inode, 1) + orcaGrid_.haloSouth();
+    return j*nx_ + i;
+  }
 };
 
 }  // namespace orcamodel

--- a/src/orca-jedi/nemo_io/ReadServer.h
+++ b/src/orca-jedi/nemo_io/ReadServer.h
@@ -61,7 +61,7 @@ void log_status() const {
   const size_t mpiroot = 0;
   const size_t myrank = atlas::mpi::rank();
   const atlas::Mesh& mesh_;
-  const OrcaIndex index_glbarray_;
+  const OrcaIndexToBufferIndex orca_buffer_indices_;
   std::unique_ptr<NemoFieldReader> reader_;
   std::shared_ptr<eckit::Timer> eckit_timer_;
 };

--- a/src/orca-jedi/nemo_io/WriteServer.cc
+++ b/src/orca-jedi/nemo_io/WriteServer.cc
@@ -68,10 +68,10 @@ template std::vector<float> WriteServer::sort_buffer<float>(
     const std::vector<float> & buffer) const;
 
 /// \brief Gather field_view data from all processes to a buffer on the server root process
-/// \param field_view Field data to write to the file.
-/// \param i_level    level index for the data.
-/// \param start      start index for the destination buffer.
-/// \return buffer    vector of data to write.
+/// \param field_view     Field data to write to the file.
+/// \param i_level        level index for the data.
+/// \param missingValue   missing value object for matching masked data.
+/// \return buffer        vector of data to write.
 template<class T> std::vector<T> WriteServer::gather_field_on_root(
   const atlas::array::ArrayView<T, 2>& field_view, const size_t i_level,
   const atlas::field::MissingValue& missingValue) const {

--- a/src/orca-jedi/nemo_io/WriteServer.cc
+++ b/src/orca-jedi/nemo_io/WriteServer.cc
@@ -68,10 +68,10 @@ template std::vector<float> WriteServer::sort_buffer<float>(
     const std::vector<float> & buffer) const;
 
 /// \brief Gather field_view data from all processes to a buffer on the server root process
-/// \param field_view     Field data to write to the file.
-/// \param i_level        level index for the data.
-/// \param missingValue   missing value object for matching masked data.
-/// \return buffer        vector of data to write.
+/// \param field_view   Field data to write to the file.
+/// \param i_level      level index for the data.
+/// \param missingValue missing value object for matching masked data.
+/// \return buffer      vector of data to write.
 template<class T> std::vector<T> WriteServer::gather_field_on_root(
   const atlas::array::ArrayView<T, 2>& field_view, const size_t i_level,
   const atlas::field::MissingValue& missingValue) const {
@@ -125,9 +125,10 @@ template std::vector<float> WriteServer::gather_field_on_root<float>(
   const atlas::field::MissingValue& missingValue) const;
 
 /// \brief  Write a 3D field at a given time index to a file.
-/// \param var_name   Name of the variable in the file.
-/// \param t_index    Time index in the file to write.
-/// \param field_view Field data to write to the file.
+/// \param var_name     Name of the variable in the file.
+/// \param t_index      Time index in the file to write.
+/// \param missingValue missing value object for matching masked data.
+/// \param field_view   Field data to write to the file.
 template<class T> void WriteServer::write_vol_var(const std::string& var_name,
     const size_t t_index,
     const atlas::field::MissingValue& missingValue,
@@ -167,9 +168,10 @@ template void WriteServer::write_vol_var<float>(const std::string& var_name,
     const atlas::array::ArrayView<float, 2>& field_view);
 
 /// \brief  Write a 2D field at a given time index to a file.
-/// \param var_name   Name of the variable in the file.
-/// \param t_index    Time index in the file to write.
-/// \param field_view Field data to write to the file.
+/// \param var_name     Name of the variable in the file.
+/// \param t_index      Time index in the file to write.
+/// \param missingValue missing value object for matching masked data.
+/// \param field_view   Field data to write to the file.
 template<class T> void WriteServer::write_surf_var(const std::string& var_name,
     const size_t t_index, const atlas::field::MissingValue& missingValue,
     const atlas::array::ArrayView<T, 2>& field_view) {

--- a/src/orca-jedi/nemo_io/WriteServer.cc
+++ b/src/orca-jedi/nemo_io/WriteServer.cc
@@ -1,0 +1,269 @@
+/*
+ * (C) British Crown Copyright 2024 Met Office
+ */
+
+#include "orca-jedi/nemo_io/WriteServer.h"
+
+#include<algorithm>
+
+#include "atlas-orca/grid/OrcaGrid.h"
+
+
+namespace orcamodel {
+
+/// \brief  Write a 3D field at a given time index to a file on the root process.
+/// \param var_name   Name of the variable in the file.
+/// \param t_index    Time index in the file to write.
+/// \param buffer     vector of data to write.
+template<class T> void WriteServer::write_vol_var_on_root(const std::string& var_name,
+    const size_t t_index,
+    const std::vector<T>& buffer) {
+  oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::write_vol_var_on_root "
+                     << std::endl;
+  if (myrank == mpiroot) {
+    writer_->write_vol_var<T>(var_name, buffer, t_index);
+  }
+}
+template void WriteServer::write_vol_var_on_root<double>(const std::string& var_name,
+    const size_t t_index, const std::vector<double>& buffer);
+template void WriteServer::write_vol_var_on_root<float>(const std::string& var_name,
+    const size_t t_index, const std::vector<float>& buffer);
+
+/// \brief  Write a 2D field at a given time index to a file on the root process.
+/// \param var_name   Name of the variable in the file.
+/// \param t_index    Time index in the file to write.
+/// \param buffer     vector of data to write.
+template<class T> void WriteServer::write_surf_var_on_root(const std::string& var_name,
+    const size_t t_index,
+    const std::vector<T>& buffer) {
+  oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::write_surf_var_on_root "
+                     << std::endl;
+  if (myrank == mpiroot) {
+    writer_->write_surf_var<T>(var_name, buffer, t_index);
+  }
+}
+template void WriteServer::write_surf_var_on_root<double>(const std::string& var_name,
+    const size_t t_index, const std::vector<double>& buffer);
+template void WriteServer::write_surf_var_on_root<float>(const std::string& var_name,
+    const size_t t_index, const std::vector<float>& buffer);
+
+/// \brief sort the data into the correct order for the NetCDF file
+/// \param  buffer        .
+/// \return sorted_buffer vector of data to write.
+template<class T> std::vector<T> WriteServer::sort_buffer(
+  const std::vector<T> & buffer) const {
+  oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::sort_buffer "
+                     << std::endl;
+  std::vector<T> sorted_buffer(orca_indices_.nx() * orca_indices_.ny());
+  for (size_t i_buf = 0; i_buf < buffer.size(); ++i_buf) {
+    const size_t source_index = unsorted_buffer_indices_[i_buf];
+    ASSERT(source_index < sorted_buffer.size());
+    sorted_buffer[source_index] = buffer[i_buf];
+  }
+  return sorted_buffer;
+}
+template std::vector<double> WriteServer::sort_buffer<double>(
+    const std::vector<double> & buffer) const;
+template std::vector<float> WriteServer::sort_buffer<float>(
+    const std::vector<float> & buffer) const;
+
+/// \brief Gather field_view data from all processes to a buffer on the server root process
+/// \param field_view Field data to write to the file.
+/// \param i_level    level index for the data.
+/// \param start      start index for the destination buffer.
+/// \return buffer    vector of data to write.
+template<class T> std::vector<T> WriteServer::gather_field_on_root(
+  const atlas::array::ArrayView<T, 2>& field_view, const size_t i_level,
+  const atlas::field::MissingValue& missingValue) const {
+  oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::gather_field_on_root "
+                     << std::endl;
+
+  std::vector<T> local_buffer;
+  size_t size = orca_indices_.nx() * orca_indices_.ny();
+  const bool has_mv = static_cast<bool>(missingValue);
+
+  // handle the serial data case
+  if (is_serial_) {
+    if (myrank == mpiroot) {
+      for (atlas::idx_t i_node = 0; i_node < mesh_.nodes().size(); ++i_node) {
+        if (has_mv && missingValue(field_view(i_node, i_level))) {
+          local_buffer.emplace_back(NemoFieldWriter::fillValue);
+        } else {
+          local_buffer.emplace_back(field_view(i_node, i_level));
+        }
+      }
+      ASSERT(local_buffer.size() == size);
+    }
+    return local_buffer;
+  }
+
+  // handle the distributed data case
+  for (atlas::idx_t i_node = 0; i_node < mesh_.nodes().size(); ++i_node) {
+    if (has_mv && missingValue(field_view(i_node, i_level))) {
+      local_buffer.emplace_back(NemoFieldWriter::fillValue);
+    } else {
+      local_buffer.emplace_back(field_view(i_node, i_level));
+    }
+  }
+
+  std::vector<T> unsorted_buffer(recvcnt_);
+  atlas::mpi::comm().gatherv(&local_buffer.front(), local_buffer.size(),
+                             &unsorted_buffer.front(), &recvcounts_.front(),
+                             &recvdispls_.front(), mpiroot);
+
+  if (myrank == mpiroot) {
+    return this->sort_buffer<T>(unsorted_buffer);
+  }
+
+  return std::vector<T>();
+}
+template std::vector<double> WriteServer::gather_field_on_root<double>(
+  const atlas::array::ArrayView<double, 2>& field_view, const size_t i_level,
+  const atlas::field::MissingValue& missingValue) const;
+template std::vector<float> WriteServer::gather_field_on_root<float>(
+  const atlas::array::ArrayView<float, 2>& field_view, const size_t i_level,
+  const atlas::field::MissingValue& missingValue) const;
+
+/// \brief  Write a 3D field at a given time index to a file.
+/// \param var_name   Name of the variable in the file.
+/// \param t_index    Time index in the file to write.
+/// \param field_view Field data to write to the file.
+template<class T> void WriteServer::write_vol_var(const std::string& var_name,
+    const size_t t_index,
+    const atlas::field::MissingValue& missingValue,
+    const atlas::array::ArrayView<T, 2>& field_view) {
+  oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::write_vol_var "
+                     << var_name << std::endl;
+  std::vector<T> buffer;
+  size_t size = orca_indices_.nx() * orca_indices_.ny();
+  if (myrank == mpiroot) {
+    buffer.resize(n_levels_*size);
+  }
+  // For each level
+  for (size_t iLev = 0; iLev < n_levels_; iLev++) {
+    // gather data for this level onto the root processor.
+    const size_t start = iLev*size;
+    const std::vector<T> local_buffer = this->gather_field_on_root<T>(field_view, iLev,
+                                                                      missingValue);
+    if (myrank == mpiroot) {
+      ASSERT(local_buffer.size() == size);
+      ASSERT(buffer.begin() + start + size <= buffer.end());
+      std::copy(local_buffer.begin(), local_buffer.end(), buffer.begin()+start);
+    }
+    log_status();
+  }
+  if (myrank == mpiroot) {
+    ASSERT(buffer.size() == n_levels_*size);
+  }
+  // write field from the buffer to variable
+  this->write_vol_var_on_root<T>(var_name, t_index, buffer);
+  log_status();
+}
+template void WriteServer::write_vol_var<double>(const std::string& var_name,
+    const size_t t_index, const atlas::field::MissingValue& missingValue,
+    const atlas::array::ArrayView<double, 2>& field_view);
+template void WriteServer::write_vol_var<float>(const std::string& var_name,
+    const size_t t_index, const atlas::field::MissingValue& missingValue,
+    const atlas::array::ArrayView<float, 2>& field_view);
+
+/// \brief  Write a 2D field at a given time index to a file.
+/// \param var_name   Name of the variable in the file.
+/// \param t_index    Time index in the file to write.
+/// \param field_view Field data to write to the file.
+template<class T> void WriteServer::write_surf_var(const std::string& var_name,
+    const size_t t_index, const atlas::field::MissingValue& missingValue,
+    const atlas::array::ArrayView<T, 2>& field_view) {
+  oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::write_surf_var "
+                     << var_name << std::endl;
+  // gather data for this level onto the root processor.
+  const std::vector<T> buffer = this->gather_field_on_root<T>(field_view, 0, missingValue);
+  log_status();
+  // write field from the buffer to variable.
+  this->write_surf_var_on_root<T>(var_name, t_index, buffer);
+  log_status();
+}
+template void WriteServer::write_surf_var<double>(const std::string& var_name,
+    const size_t t_index, const atlas::field::MissingValue& missingValue,
+    const atlas::array::ArrayView<double, 2>& field_view);
+template void WriteServer::write_surf_var<float>(const std::string& var_name,
+    const size_t t_index, const atlas::field::MissingValue& missingValue,
+    const atlas::array::ArrayView<float, 2>& field_view);
+
+/// \brief  Write latitude and longitude dimensions.
+void WriteServer::write_dimensions() {
+  oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::write_dimensions" << std::endl;
+  atlas::array::ArrayView<double, 2> lonlat{atlas::array::make_view<double, 2>(
+                                              mesh_.nodes().lonlat())};
+  atlas::field::MissingValue missingValue(mesh_.nodes().lonlat());
+  size_t size = orca_indices_.nx() * orca_indices_.ny();
+
+  const std::vector<double> lon_buffer = this->gather_field_on_root(lonlat, 0, missingValue);
+  const std::vector<double> lat_buffer = this->gather_field_on_root(lonlat, 1, missingValue);
+
+  if (myrank == mpiroot) {
+    ASSERT(lat_buffer.size() == size);
+    ASSERT(lon_buffer.size() == size);
+    writer_->write_dimensions(lat_buffer, lon_buffer);
+  }
+}
+
+WriteServer::WriteServer(std::shared_ptr<eckit::Timer> eckit_timer,
+    const eckit::PathName& file_path,
+    const atlas::Mesh& mesh,
+    const std::vector<util::DateTime> datetimes,
+    const std::vector<double> depths,
+    bool is_serial) : mesh_(mesh),
+  orca_indices_(mesh), eckit_timer_(eckit_timer), is_serial_(is_serial),
+  n_levels_(depths.size()) {
+  oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::WriteServer" << std::endl;
+  std::vector<size_t> local_buf_indices;
+
+  if (is_serial_) {
+    if (myrank == mpiroot) {
+      writer_ = std::make_unique<NemoFieldWriter>(file_path, datetimes,
+                                                  orca_indices_.nx(), orca_indices_.ny(),
+                                                  depths);
+    }
+    this->write_dimensions();
+    recvcnt_ = orca_indices_.nx() * orca_indices_.ny();
+    return;
+  }
+
+  auto ij = atlas::array::make_view<int32_t, 2>(mesh_.nodes().field("ij"));
+  auto orcaGrid = atlas::OrcaGrid(mesh_.grid());
+  for (atlas::idx_t i_node = 0; i_node < mesh_.nodes().size(); ++i_node) {
+    const size_t i = ij(i_node, 0);
+    const size_t j = ij(i_node, 1);
+    local_buf_indices.emplace_back(orca_indices_(i, j));
+  }
+
+  // gather all remote buffer indices
+  int sendcnt = local_buf_indices.size();
+  recvcounts_.resize(atlas::mpi::comm().size());
+
+  atlas::mpi::comm().allGather(sendcnt, recvcounts_.begin(), recvcounts_.end());
+
+  recvdispls_.resize(atlas::mpi::comm().size());
+  recvdispls_[0] = 0;
+  recvcnt_ = recvcounts_[0];
+  for ( size_t jproc = 1; jproc < atlas::mpi::comm().size(); ++jproc ) {
+      recvdispls_[jproc] = recvdispls_[jproc - 1] + recvcounts_[jproc - 1];
+      recvcnt_ += recvcounts_[jproc];
+  }
+
+  ASSERT(recvcnt_ >= static_cast<int>(orca_indices_.nx()*orca_indices_.ny()));
+
+  if (myrank == mpiroot) {
+    writer_ = std::make_unique<NemoFieldWriter>(file_path, datetimes,
+                                                orca_indices_.nx(), orca_indices_.ny(),
+                                                depths);
+    unsorted_buffer_indices_.resize(recvcnt_);
+  }
+
+  atlas::mpi::comm().gatherv(&local_buf_indices.front(), local_buf_indices.size(),
+                             &unsorted_buffer_indices_.front(),
+                             &recvcounts_.front(), &recvdispls_.front(), mpiroot);
+
+  this->write_dimensions();
+}
+}  // namespace orcamodel

--- a/src/orca-jedi/nemo_io/WriteServer.h
+++ b/src/orca-jedi/nemo_io/WriteServer.h
@@ -1,0 +1,76 @@
+/*
+ * (C) British Crown Copyright 2024 Met Office
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "oops/util/DateTime.h"
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/array.h"
+#include "atlas/mesh.h"
+#include "atlas/field/MissingValue.h"
+#include "atlas-orca/grid/OrcaGrid.h"
+
+#include "orca-jedi/nemo_io/OrcaIndex.h"
+#include "orca-jedi/nemo_io/NemoFieldWriter.h"
+
+#include "eckit/exception/Exceptions.h"
+#include "eckit/log/Timer.h"
+#include "eckit/system/ResourceUsage.h"
+
+namespace orcamodel {
+class WriteServer {
+ public:
+  explicit WriteServer(std::shared_ptr<eckit::Timer> eckit_timer,
+      const eckit::PathName& file_path,
+      const atlas::Mesh& mesh,
+      const std::vector<util::DateTime> datetimes,
+      const std::vector<double> depths, bool is_serial);
+  WriteServer(WriteServer &&) = default;
+  WriteServer(const WriteServer &) = default;
+  WriteServer &operator=(WriteServer &&) = default;
+  WriteServer &operator=(const WriteServer &) = default;
+
+  template<class T> void write_vol_var(const std::string& var_name,
+      const size_t t_index,
+      const atlas::field::MissingValue& missingValue,
+      const atlas::array::ArrayView<T, 2>& field_view);
+  template<class T> void write_surf_var(const std::string& var_name,
+      const size_t t_index,
+      const atlas::field::MissingValue& missingValue,
+      const atlas::array::ArrayView<T, 2>& field_view);
+
+ private:
+  void log_status() const {
+    oops::Log::trace() << "orcamodel::log_status " << eckit_timer_->elapsed() << " "
+        << static_cast<double>(eckit::system::ResourceUsage().maxResidentSetSize()) / 1.0e+9
+        << " Gb" << std::endl;
+  }
+  void write_dimensions();
+  template<class T> void write_vol_var_on_root(const std::string& var_name,
+      const size_t t_index, const std::vector<T>& buffer);
+  template<class T> void write_surf_var_on_root(const std::string& var_name,
+      const size_t t_index, const std::vector<T>& buffer);
+  template<class T> std::vector<T> gather_field_on_root(
+      const atlas::array::ArrayView<T, 2>& field_view, const size_t i_level,
+      const atlas::field::MissingValue& missingValue) const;
+  template<class T> std::vector<T> sort_buffer(
+    const std::vector<T> & buffer) const;
+  const size_t mpiroot = 0;
+  const size_t myrank = atlas::mpi::rank();
+  const atlas::Mesh& mesh_;
+  const OrcaIndexToBufferIndex orca_indices_;
+  std::vector<size_t> unsorted_buffer_indices_;
+  std::vector<int> recvcounts_;
+  std::vector<int> recvdispls_;
+  std::unique_ptr<NemoFieldWriter> writer_;
+  std::shared_ptr<eckit::Timer> eckit_timer_;
+  bool is_serial_;
+  const size_t n_levels_;
+  int recvcnt_;
+};
+}  // namespace orcamodel

--- a/src/orca-jedi/state/StateIOUtils.cc
+++ b/src/orca-jedi/state/StateIOUtils.cc
@@ -172,8 +172,8 @@ void writeFieldsToFile(
       };
       ApplyForFieldType(write,
                         geom.fieldPrecision(fieldName),
-                        eckit::BadParameter("orcamodel::writeFieldsToFile '"
-                          + nemoName + "' field type not recognised"));
+                        std::string("State(ORCA)::writeFieldsToFile '")
+                          + nemoName + "' field type not recognised.");
     }
 }
 

--- a/src/orca-jedi/utilities/Types.cc
+++ b/src/orca-jedi/utilities/Types.cc
@@ -1,0 +1,15 @@
+/*
+ * (C) British Crown Copyright 2024 Met Office
+ */
+
+#include "orca-jedi/utilities/Types.h"
+
+namespace orcamodel {
+
+template <typename T> const netCDF::NcType NetCDFTypeMap<T>::ncType = netCDF::ncDouble;
+template <> const netCDF::NcType NetCDFTypeMap<float>::ncType = netCDF::ncFloat;
+
+template const netCDF::NcType NetCDFTypeMap<float>::ncType;
+template const netCDF::NcType NetCDFTypeMap<double>::ncType;
+
+}  // namespace orcamodel

--- a/src/orca-jedi/utilities/Types.h
+++ b/src/orca-jedi/utilities/Types.h
@@ -4,10 +4,11 @@
 
 #pragma once
 
-#include <string>
-#include "eckit/exception/Exceptions.h"
 #include <netcdf>
-#include <exception>
+
+#include <string>
+
+#include "eckit/exception/Exceptions.h"
 
 namespace orcamodel {
 

--- a/src/orca-jedi/utilities/Types.h
+++ b/src/orca-jedi/utilities/Types.h
@@ -5,8 +5,9 @@
 #pragma once
 
 #include <string>
-
 #include "eckit/exception/Exceptions.h"
+#include <netcdf>
+#include <exception>
 
 namespace orcamodel {
 
@@ -29,4 +30,9 @@ void ApplyForFieldType(const Functor& functor, FieldDType field_type,
   }
 }
 
+// create a mapping between C++ types and NetCDF type objects
+template <typename T>
+struct NetCDFTypeMap {
+  static const netCDF::NcType ncType;
+};
 }  // namespace orcamodel

--- a/src/tests/orca-jedi/CMakeLists.txt
+++ b/src/tests/orca-jedi/CMakeLists.txt
@@ -20,6 +20,18 @@ ecbuild_add_test( TARGET  test_orcajedi_nemo_io_read_server.x
                   CONDITION  eckit_HAVE_MPI
                   LIBS    orcamodel )
 
+ecbuild_add_test( TARGET  test_orcajedi_nemo_io_write_server_MPI2.x
+                  SOURCES test_nemo_io_write_server.cc
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  MPI        2
+                  CONDITION  eckit_HAVE_MPI
+                  LIBS    orcamodel )
+
+ecbuild_add_test( TARGET  test_orcajedi_nemo_io_write_server.x
+                  SOURCES test_nemo_io_write_server.cc
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  LIBS    orcamodel )
+
 ecbuild_add_test( TARGET  test_orcajedi_geometry.x
                   SOURCES test_geometry.cc
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}

--- a/src/tests/orca-jedi/test_nemo_io_field_writer.cc
+++ b/src/tests/orca-jedi/test_nemo_io_field_writer.cc
@@ -35,6 +35,8 @@ CASE("test parallel serially distributed write field array views") {
   eckit::PathName test_data_path("../testoutput/orca1_t_test_output.nc");
 
   atlas::OrcaGrid grid("ORCA1_T");
+  size_t nx = grid.nx() + grid.haloWest() + grid.haloEast();
+  size_t ny = grid.ny() + grid.haloSouth() + grid.haloNorth();
   auto meshgen_config = grid.meshgenerator();
 
   atlas::MeshGenerator meshgen(meshgen_config);
@@ -57,38 +59,66 @@ CASE("test parallel serially distributed write field array views") {
   auto ij = atlas::array::make_view<int32_t, 2>(mesh.nodes().field("ij"));
   auto ghost = atlas::array::make_view<int32_t, 1>(mesh.nodes().ghost());
 
-  for (size_t i = 0; i < ice_fv.size(); ++i) {
-    if (ghost(i)) continue;
+  std::vector<double> ice_buf, temp_buf;
+  for (size_t i = 0; i < ice_fv.shape(0); ++i) {
     ice_fv(i, 0) = ij(i, 0);
+    ice_buf.emplace_back(ij(i, 0));
+  }
+  temp_buf.resize(3*ice_buf.size());
+  for (size_t i = 0; i < temp_fv.shape(0); ++i) {
     temp_fv(i, 0) = ij(i, 0);
     temp_fv(i, 1) = ij(i, 1) + 100;
     temp_fv(i, 2) = ij(i, 0) + 200;
+    temp_buf[i                   ] = ij(i, 0);
+    temp_buf[i +   ice_buf.size()] = ij(i, 1) + 100;
+    temp_buf[i + 2*ice_buf.size()] = ij(i, 0) + 200;
   }
 
   int rank = atlas::mpi::rank();
   SECTION("writes fields") {
     if (rank == 0) {
-      std::vector<util::DateTime> datetimes(1);
-      datetimes[0] = util::DateTime("1970-01-01T00:00:00Z");
+      std::vector<util::DateTime> datetimes{util::DateTime("1970-01-01T00:00:00Z")};
       {
-        NemoFieldWriter field_writer(test_data_path, mesh, datetimes,
-            {1, 2, 3});
-        field_writer.write_surf_var("iiceconc", ice_fv, 0);
-        field_writer.write_vol_var("votemper", temp_fv, 0);
+        NemoFieldWriter field_writer(test_data_path, datetimes, nx, ny, {1, 2, 3});
+
+        atlas::array::ArrayView<double, 2> lonlat{atlas::array::make_view<double, 2>(
+                                                    mesh.nodes().lonlat())};
+        std::vector<double> lons;
+        std::vector<double> lats;
+        for (int i_node = 0; i_node < lonlat.shape(0); ++i_node) {
+          lons.emplace_back(lonlat(i_node, 0));
+          lats.emplace_back(lonlat(i_node, 1));
+        }
+
+        EXPECT(lons.size() == nx*ny);
+        EXPECT(lons.size() == lonlat.shape(0));
+        EXPECT(lats.size() == nx*ny);
+        EXPECT(lats.size() == lonlat.shape(0));
+        field_writer.write_dimensions(lats, lons);
+        std::cout << "sizes: " << ice_buf.size() << " =! " << nx*ny << std::endl;
+        EXPECT(ice_buf.size() == nx*ny);
+        EXPECT(ice_buf.size() == ice_fv.shape(0));
+        field_writer.write_surf_var("iiceconc", ice_buf, 0);
+        EXPECT(temp_buf.size() == 3*nx*ny);
+        EXPECT(temp_buf.size() == temp_fv.size());
+        field_writer.write_vol_var("votemper", temp_buf, 0);
       }
-      // wait up to 20 seconds for the file system...
-      for (int wait_count=0; wait_count < 10; ++wait_count) {
-        if (test_data_path.exists()) break;
-        sleep(2);
-      }
-      EXPECT(test_data_path.exists());
     }
   }
+
+  // wait up to 20 seconds for the file system.
+  for (int wait_count=0; wait_count < 10; ++wait_count) {
+    if (test_data_path.exists()) break;
+    sleep(2);
+  }
+  EXPECT(test_data_path.exists());
 
   SECTION("surface field matches with data in memory") {
     if (rank == 0) {
       NemoFieldReader field_reader(test_data_path);
       std::vector<double> data = field_reader.read_var_slice<double>("iiceconc", 0, 0);
+      EXPECT(data.size() == nx*ny);
+      EXPECT(data.size() == ice_fv.shape(0));
       for (atlas::idx_t iNode = 0; iNode < ice_fv.shape(0); ++iNode) {
         if (ghost(iNode)) continue;
         EXPECT_EQUAL(data[iNode], ice_fv(iNode, 0));
@@ -107,101 +137,35 @@ CASE("test parallel serially distributed write field array views") {
     }
   }
 
-
   SECTION("volume field matches with data in memory") {
     if (rank == 0) {
       NemoFieldReader field_reader(test_data_path);
       std::vector<double> data = field_reader.read_var_slice<double>("votemper", 0, 0);
+      EXPECT(data.size() == nx*ny);
+      EXPECT(data.size() == temp_fv.shape(0));
       for (size_t iNode = 0; iNode < data.size(); ++iNode) {
         if (ghost(iNode)) continue;
         EXPECT_EQUAL(data[iNode], temp_fv(iNode, 0));
       }
       data.clear();
       data = field_reader.read_var_slice<double>("votemper", 0, 1);
+      EXPECT(data.size() == nx*ny);
+      EXPECT(data.size() == temp_fv.shape(0));
       for (size_t iNode = 0; iNode < data.size(); ++iNode) {
         if (ghost(iNode)) continue;
         EXPECT_EQUAL(data[iNode], temp_fv(iNode, 1));
       }
       data.clear();
       data = field_reader.read_var_slice<double>("votemper", 0, 2);
+      EXPECT(data.size() == nx*ny);
+      EXPECT(data.size() == temp_fv.shape(0));
       for (size_t iNode = 0; iNode < data.size(); ++iNode) {
         if (ghost(iNode)) continue;
         EXPECT_EQUAL(data[iNode], temp_fv(iNode, 2));
       }
     }
   }
-
-//  SECTION("volume field") {
-//    atlas::Field field(funcSpace.createField<double>(
-//                          atlas::option::name("votemper") |
-//                          atlas::option::levels(3)));
-//    auto field_view = atlas::array::make_view<double, 2>(field);
-//
-//    field_reader.read_volume_var("votemper", mesh, 0, field_view);
-//    auto ij = atlas::array::make_view<int32_t, 2>(mesh.nodes().field("ij"));
-//
-//    auto ghost = atlas::array::make_view<int32_t, 1>(mesh.nodes().ghost());
-//    std::vector<double> raw_data;
-//    for (int k =0; k <3; k++) {
-//      raw_data = field_reader.read_var_slice("votemper", 0, k);
-//      for (int i = 0; i < field_view.shape(0); ++i) {
-//        if (ghost(i)) continue;
-//        if (raw_data[i] != field_view(i, k)) {
-//            std::cout << "mismatch: "
-//                      << " ij(" << i << ", 0) " << ij(i, 0)
-//                      << " ij(" << i << ", 1) " << ij(i, 1)
-//                      << " 1 proc " << raw_data[i] << " "
-//                      << " with mesh " << field_view(i, k) << std::endl;
-//        }
-//        EXPECT_EQUAL(raw_data[i], field_view(i, k));
-//      }
-//    }
-//  }
-//
-//  SECTION("depth field") {
-//    atlas::Field field(funcSpace.createField<double>(
-//                          atlas::option::name("depth") |
-//                          atlas::option::levels(3)));
-//    auto field_view = atlas::array::make_view<double, 2>(field);
-//
-//    field_reader.read_vertical_var("nav_lev", mesh, field_view);
-//    auto ij = atlas::array::make_view<int32_t, 2>(mesh.nodes().field("ij"));
-//
-//    auto ghost = atlas::array::make_view<int32_t, 1>(mesh.nodes().ghost());
-//    std::vector<double> levels{0, 10, 100};
-//    for (int k =0; k <3; k++) {
-//      for (int i = 0; i < field_view.shape(0); ++i) {
-//        if (ghost(i)) continue;
-//        if (levels[k] != field_view(i, k)) {
-//            std::cout << "mismatch: "
-//                      << " ij(" << i << ", 0) " << ij(i, 0)
-//                      << " ij(" << i << ", 1) " << ij(i, 1)
-//                      << " 1 proc " << levels[k] << " "
-//                      << " with mesh " << field_view(i, k) << std::endl;
-//        }
-//        EXPECT_EQUAL(levels[k], field_view(i, k));
-//      }
-//    }
-//  }
 }
-
-// for domain distributed MPI...
-//  bool write_nemo_field = false;
-//  if (write_nemo_field) {
-//    mpi::comm().barrier();
-//    size_t rank = 0;
-//    while (rank < atlas::mpi::size()) {
-//      if (rank == mpi::rank()) {
-//        std::cout << "write data from rank " << rank << std::endl;
-//        eckit::PathName pathname{"nemo_test_out.nc"};
-//        NemoFieldWriter field_writer(pathname, src.mesh());
-//        field_writer.write_surf_var(nemo_variable_name, iiceconc);
-//      }
-//      rank++;
-//      mpi::comm().barrier();
-//    }
-//  }
-
 }  // namespace test
 }  // namespace orcamodel
 

--- a/src/tests/orca-jedi/test_nemo_io_read_server.cc
+++ b/src/tests/orca-jedi/test_nemo_io_read_server.cc
@@ -46,7 +46,7 @@ CASE("test MPI distributed reads field array view") {
     auto partitioner = atlas::grid::Partitioner(partitioner_config);
     auto mesh = meshgen.generate(grid, partitioner);
     auto funcSpace = atlas::functionspace::NodeColumns(mesh);
-    auto orca_index = OrcaIndex(mesh.grid());
+    auto orca_index = OrcaIndexToBufferIndex(mesh.grid());
 
     std::vector<double> raw_data;
     {

--- a/src/tests/orca-jedi/test_nemo_io_write_server.cc
+++ b/src/tests/orca-jedi/test_nemo_io_write_server.cc
@@ -56,6 +56,7 @@ void applyMPISerialised(const Functor& functor, const std::string& partitioner_n
 
 CASE("test MPI distributed field array view write to disk") {
   auto partitioner_names = std::vector<std::string>{"serial", "checkerboard"};
+  std::string grid_name("ORCA2_T");
   size_t nparts = atlas::mpi::size();
   if (nparts == 1)
     partitioner_names = std::vector<std::string>{"serial"};
@@ -63,7 +64,7 @@ CASE("test MPI distributed field array view write to disk") {
     // setup atlas data before write
     eckit::PathName test_data_path(std::string("../testoutput/write_orca2_t_")
         + partitioner_name + "_" + std::to_string(nparts) + ".nc");
-    atlas::OrcaGrid grid("ORCA2_T");
+    atlas::OrcaGrid grid(grid_name);
 
     auto meshgen_config = grid.meshgenerator();
     atlas::MeshGenerator meshgen(meshgen_config);
@@ -75,20 +76,10 @@ CASE("test MPI distributed field array view write to disk") {
     auto funcSpace = atlas::functionspace::NodeColumns(mesh);
     auto orca2buffer = OrcaIndexToBufferIndex(mesh);
 
-    SECTION(partitioner_name + "_" + std::to_string(nparts) + " test ORCA indexing") {
-      auto ij = atlas::array::make_view<int32_t, 2>(mesh.nodes().field("ij"));
-      EXPECT(orca2buffer.nx() == 182);
-      EXPECT(orca2buffer.ny() == 149);
-      for (int32_t inode = 0; inode < ij.shape(0); ++inode) {
-        if (orca2buffer(ij(inode, 0), ij(inode, 1)) != orca2buffer(inode)) {
-          std::cout << "mismatch in orca indexers: inode: i, j "
-                    << "orca2buffer(" << ij(inode, 0) << "," << ij(inode, 1)
-                    << ") != orca2buffer(" << inode << "): "
-                    << orca2buffer(ij(inode, 0), ij(inode, 1))
-                    << " != " << orca2buffer(inode)
-                    << std::endl;
-        }
-        EXPECT(orca2buffer(ij(inode, 0), ij(inode, 1)) == orca2buffer(inode));
+    if (grid_name == "ORCA2_T") {
+      SECTION(partitioner_name + "_" + std::to_string(nparts) + " test ORCA indexing") {
+        EXPECT(orca2buffer.nx() == 182);
+        EXPECT(orca2buffer.ny() == 149);
       }
     }
 

--- a/src/tests/orca-jedi/test_nemo_io_write_server.cc
+++ b/src/tests/orca-jedi/test_nemo_io_write_server.cc
@@ -1,0 +1,252 @@
+/*
+ * (C) British Crown Copyright 2024 Met Office
+ */
+
+#include "eckit/log/Bytes.h"
+#include "eckit/testing/Test.h"
+
+#include "oops/util/DateTime.h"
+
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/array.h"
+#include "atlas/util/Config.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/mesh.h"
+#include "atlas/grid.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/field/Field.h"
+
+#include "atlas-orca/grid/OrcaGrid.h"
+
+#include "eckit/exception/Exceptions.h"
+
+#include "orca-jedi/nemo_io/WriteServer.h"
+#include "orca-jedi/nemo_io/NemoFieldReader.h"
+#include "orca-jedi/nemo_io/OrcaIndex.h"
+
+#include "tests/orca-jedi/OrcaModelTestEnvironment.h"
+
+namespace orcamodel {
+namespace test {
+
+/// \brief helper function to apply a lambda across all MPI ranks in turn when a partition is
+///        distributed, and just the root partition if not distributed.
+/// \param functor           lambda function to apply.
+/// \param partitioner_name  name of the partitioner.
+template<typename Functor>
+void applyMPISerialised(const Functor& functor, const std::string& partitioner_name) {
+  if (partitioner_name == "serial") {
+    if (atlas::mpi::comm().rank() == 0) {
+      functor();
+    }
+  } else {
+    atlas::mpi::comm().barrier();
+    size_t rank = 0;
+    while (rank < atlas::mpi::comm().size()) {
+      if (rank == atlas::mpi::comm().rank()) {
+        functor();
+      }
+      rank++;
+      atlas::mpi::comm().barrier();
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+CASE("test MPI distributed field array view write to disk") {
+  auto partitioner_names = std::vector<std::string>{"serial", "checkerboard"};
+  size_t nparts = atlas::mpi::size();
+  if (nparts == 1)
+    partitioner_names = std::vector<std::string>{"serial"};
+  for (std::string partitioner_name : partitioner_names) {
+    // setup atlas data before write
+    eckit::PathName test_data_path(std::string("../testoutput/write_orca2_t_")
+        + partitioner_name + "_" + std::to_string(nparts) + ".nc");
+    atlas::OrcaGrid grid("ORCA2_T");
+
+    auto meshgen_config = grid.meshgenerator();
+    atlas::MeshGenerator meshgen(meshgen_config);
+    auto partitioner_config = grid.partitioner();
+    partitioner_config.set("type", partitioner_name);
+    auto partitioner = atlas::grid::Partitioner(partitioner_config);
+    auto mesh = meshgen.generate(grid, partitioner);
+
+    auto funcSpace = atlas::functionspace::NodeColumns(mesh);
+    auto orca2buffer = OrcaIndexToBufferIndex(mesh);
+
+    SECTION(partitioner_name + "_" + std::to_string(nparts) + " test ORCA indexing") {
+      auto ij = atlas::array::make_view<int32_t, 2>(mesh.nodes().field("ij"));
+      EXPECT(orca2buffer.nx() == 182);
+      EXPECT(orca2buffer.ny() == 149);
+      for (int32_t inode = 0; inode < ij.shape(0); ++inode) {
+        if (orca2buffer(ij(inode, 0), ij(inode, 1)) != orca2buffer(inode)) {
+          std::cout << "mismatch in orca indexers: inode: i, j "
+                    << "orca2buffer(" << ij(inode, 0) << "," << ij(inode, 1)
+                    << ") != orca2buffer(" << inode << "): "
+                    << orca2buffer(ij(inode, 0), ij(inode, 1))
+                    << " != " << orca2buffer(inode)
+                    << std::endl;
+        }
+        EXPECT(orca2buffer(ij(inode, 0), ij(inode, 1)) == orca2buffer(inode));
+      }
+    }
+
+    auto ghost = atlas::array::make_view<int32_t, 1>(mesh.nodes().ghost());
+
+    auto field_ice = funcSpace.createField<double>(
+      atlas::option::name("iiceconc") | atlas::option::levels(1));
+    auto field_t0_temp = funcSpace.createField<float>(
+      atlas::option::name("votemper0") | atlas::option::levels(3));
+    auto field_t1_temp = funcSpace.createField<float>(
+      atlas::option::name("votemper1") | atlas::option::levels(3));
+
+    field_ice.metadata().set("missing_value", 0);
+    field_ice.metadata().set("missing_value_type", "approximately-equals");
+    field_ice.metadata().set("missing_value_epsilon", 1e-6);
+    field_t0_temp.metadata().set("missing_value", 0);
+    field_t0_temp.metadata().set("missing_value_type", "approximately-equals");
+    field_t0_temp.metadata().set("missing_value_epsilon", 1e-6);
+    field_t1_temp.metadata().set("missing_value", 0);
+    field_t1_temp.metadata().set("missing_value_type", "approximately-equals");
+    field_t1_temp.metadata().set("missing_value_epsilon", 1e-6);
+
+    atlas::field::MissingValue ice_mv(field_ice);
+    atlas::field::MissingValue temp0_mv(field_t0_temp);
+    atlas::field::MissingValue temp1_mv(field_t1_temp);
+
+    auto field_view_ice = atlas::array::make_view<double, 2>(field_ice);
+    auto field_view_t0_temp = atlas::array::make_view<float, 2>(field_t0_temp);
+    auto field_view_t1_temp = atlas::array::make_view<float, 2>(field_t1_temp);
+
+    // fill fields
+    {
+      const size_t num_nodes = field_view_ice.shape(0);
+      for (size_t inode = 0; inode < num_nodes; ++inode) {
+        if (ghost(inode)) continue;
+        field_view_ice(inode, 0) = inode;
+        for (size_t ilevel = 0; ilevel < 3; ++ilevel) {
+          field_view_t0_temp(inode, ilevel) = inode + ilevel*5;
+          field_view_t1_temp(inode, ilevel) = inode + ilevel*10;
+        }
+      }
+    }
+
+    funcSpace.haloExchange(field_ice);
+    funcSpace.haloExchange(field_t0_temp);
+    funcSpace.haloExchange(field_t1_temp);
+
+    SECTION(partitioner_name + "_" + std::to_string(nparts)
+             + " write data to file via write server") {
+      std::vector<util::DateTime> datetimes{util::DateTime("1970-01-01T00:00:00Z"),
+                                            util::DateTime("1970-01-02T00:00:00Z")};
+      std::shared_ptr<eckit::Timer> eckit_timer =
+          std::make_shared<eckit::Timer>("write_server tests: ", oops::Log::debug());
+      const bool serial_distribution = (atlas::mpi::size() == 1 || partitioner_name == "serial");
+      WriteServer writer(eckit_timer, test_data_path, mesh,
+                         datetimes, {1, 2, 3}, serial_distribution);
+
+      writer.write_surf_var<double>("iiceconc", 0, ice_mv, field_view_ice);
+      writer.write_vol_var<float>("votemper", 0, temp0_mv, field_view_t0_temp);
+      writer.write_vol_var<float>("votemper", 1, temp1_mv, field_view_t1_temp);
+    }
+
+    SECTION(partitioner_name + "_" + std::to_string(nparts) + " File exists") {
+      auto check_file_exists = [&](){
+        // wait up to 20 seconds for the file system...
+        for (int wait_count=0; wait_count < 10; ++wait_count) {
+          if (test_data_path.exists()) break;
+          sleep(2);
+        }
+        EXPECT(test_data_path.exists());
+      };
+      applyMPISerialised(check_file_exists, partitioner_name);
+    }
+
+    SECTION(partitioner_name + "_" + std::to_string(nparts) + " check latitude/longitude data") {
+      auto check_lon_lat = [&](){
+        NemoFieldReader field_reader(test_data_path);
+        std::vector<atlas::PointXY> data = field_reader.read_locs();
+
+        auto lonlat = atlas::array::make_view<double, 2>(mesh.nodes().lonlat());
+        auto ij = atlas::array::make_view<int32_t, 2>(mesh.nodes().field("ij"));
+        const size_t num_nodes = ij.shape(0);
+        EXPECT(num_nodes <= data.size());
+        for (size_t inode = 0; inode < num_nodes; ++inode) {
+          if (ghost(inode)) continue;
+          const int64_t ibuf = orca2buffer(ij(inode, 0), ij(inode, 1));
+          EXPECT(data[ibuf](0) == lonlat(inode, 0));
+          EXPECT(data[ibuf](1) == lonlat(inode, 1));
+        }
+      };
+      applyMPISerialised(check_lon_lat, partitioner_name);
+    }
+
+    SECTION(partitioner_name + "_" + std::to_string(nparts) + " check surface data") {
+      auto check_surface_data = [&](){
+        NemoFieldReader field_reader(test_data_path);
+        std::vector<double> data = field_reader.read_var_slice<double>("iiceconc", 0, 0);
+
+        auto ij = atlas::array::make_view<int32_t, 2>(mesh.nodes().field("ij"));
+        const size_t num_nodes = ij.shape(0);
+        EXPECT(num_nodes <= data.size());
+        for (size_t inode = 0; inode < num_nodes; ++inode) {
+          if (ghost(inode)) continue;
+          const int64_t ibuf = orca2buffer(ij(inode, 0), ij(inode, 1));
+          if (ice_mv(field_view_ice(inode, 0))) {
+            EXPECT(std::abs(data[ibuf] - 1e+20) < 1e-6);
+          } else {
+            EXPECT(data[ibuf] == field_view_ice(inode, 0));
+          }
+        }
+      };
+      applyMPISerialised(check_surface_data, partitioner_name);
+    }
+
+    SECTION(partitioner_name + "_" + std::to_string(nparts) + " check volume data") {
+      auto check_volume_data = [&](){
+        NemoFieldReader field_reader(test_data_path);
+        std::vector<float> data_t0_l0 = field_reader.read_var_slice<float>("votemper", 0, 0);
+        std::vector<float> data_t0_l1 = field_reader.read_var_slice<float>("votemper", 0, 1);
+        std::vector<float> data_t0_l2 = field_reader.read_var_slice<float>("votemper", 0, 2);
+        std::vector<float> data_t1_l0 = field_reader.read_var_slice<float>("votemper", 1, 0);
+        std::vector<float> data_t1_l1 = field_reader.read_var_slice<float>("votemper", 1, 1);
+        std::vector<float> data_t1_l2 = field_reader.read_var_slice<float>("votemper", 1, 2);
+
+        auto ij = atlas::array::make_view<int32_t, 2>(mesh.nodes().field("ij"));
+
+        auto check_slice = [ghost, ij, orca2buffer](const std::vector<float>& test_data,
+            const atlas::array::ArrayView<float, 2>& original_fv,
+            const atlas::field::MissingValue mv,
+            const size_t ilev) {
+          const size_t num_nodes = ij.shape(0);
+          EXPECT(num_nodes <= test_data.size());
+          for (size_t inode = 0; inode < num_nodes; ++inode) {
+            if (ghost(inode)) continue;
+            const int64_t ibuf = orca2buffer(ij(inode, 0), ij(inode, 1));
+            if (mv(original_fv(inode, ilev))) continue;
+            if (std::abs(test_data[ibuf] - original_fv(inode, ilev)) >= 1e-7)
+              std::cout << "test_data[" << ibuf << "] " << test_data[ibuf]
+                        << " original_fv(" << inode << ", " << ilev << ") "
+                        << original_fv(inode, ilev) << std::endl;
+            EXPECT(std::abs(test_data[ibuf] - original_fv(inode, ilev)) < 1e-7);
+          }
+        };
+        check_slice(data_t0_l0, field_view_t0_temp, temp0_mv, 0);
+        check_slice(data_t0_l1, field_view_t0_temp, temp0_mv, 1);
+        check_slice(data_t0_l2, field_view_t0_temp, temp0_mv, 2);
+        check_slice(data_t1_l0, field_view_t1_temp, temp1_mv, 0);
+        check_slice(data_t1_l1, field_view_t1_temp, temp1_mv, 1);
+        check_slice(data_t1_l2, field_view_t1_temp, temp1_mv, 2);
+      };
+      applyMPISerialised(check_volume_data, partitioner_name);
+    }
+  }
+}
+
+}  // namespace test
+}  // namespace orcamodel
+
+int main(int argc, char** argv) {
+    return orcamodel::test::run(argc, argv);
+}


### PR DESCRIPTION
## Description

Add parallel write of atlas fields for any partitioner. Data is written by the root processor only, with each processor sending its owned data to the root processor, where it is sorted before being written to the file. The ORCA logic is now abstracted out of the field writer to allow for the addition of non-orca grids. There is also some small refactoring to the reading classes to unify the naming and approaches and hopefully make things a little more clear.

## Impact

This change ought to help with parallel 3DVar changes, when these are added by Dan Lea.

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] New functions are documented briefly via Doxygen comments in the code
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [x] I have run [mo-bundle](http://fcm1/cylc-review/taskjobs/tsearle/?suite=mobb-oj84) to check integration with the rest of JEDI and run the unit tests under all environments
