### PR TITLE
Use pull_request_target to enable public fork CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [develop]
-  pull_request:
+    branches: [develop, master]
+  pull_request_target:
     branches: [develop]
 
 jobs:


### PR DESCRIPTION
## Description

Change to `pull_request_target` to enable PR from fork to run CI.

## Issue(s) addressed

Resolves #86 

## Checklist

- [ ] I have updated the unit tests to cover the change
- [ ] New functions are documented briefly via Doxygen comments in the code
- [ ] I have linted my code using cpplint
- [ ] I have run the unit tests
- [ ] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments
