### PR TITLE
separate model variables and obs variables types

### DIFF
--- a/src/orca-jedi/geometry/Geometry.cc
+++ b/src/orca-jedi/geometry/Geometry.cc
@@ -27,7 +27,6 @@ oops::Variables orcaVariableFactory(const eckit::Configuration & config) {
   OrcaGeometryParameters params;
   params.validateAndDeserialize(config);
 
-  std::vector<int> channels{};
   std::vector<std::string> names{};
   for (const NemoFieldParameters& nemoVariable :
         params.nemoFields.value()) {
@@ -37,7 +36,7 @@ oops::Variables orcaVariableFactory(const eckit::Configuration & config) {
     }
   }
 
-  return oops::Variables(names, channels);
+  return oops::Variables(names);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/orca-jedi/increment/Increment.cc
+++ b/src/orca-jedi/increment/Increment.cc
@@ -408,8 +408,8 @@ void Increment::dirac(const eckit::Configuration & conf) {
         std::ostringstream err_stream;
         err_stream << orcamodel::Increment::classname()
                    << " field shape and delta function location configuration mismatch,"
-                   << " requested point is out of bounds at: (" << iydir[i]*nx + ixdir[i] << ", " << izdir[i]
-                   << ") for field with shape " << field.shape() ;
+                   << " requested point is out of bounds at: (" << iydir[i]*nx + ixdir[i] << ", "
+                   << izdir[i] << ") for field with shape " << field.shape();
         throw eckit::BadValue(err_stream.str(), Here());
       }
     }

--- a/src/tests/orca-jedi/test_geometry.cc
+++ b/src/tests/orca-jedi/test_geometry.cc
@@ -60,30 +60,28 @@ CASE("test basic geometry") {
   }
 
   SECTION("test geometry variable sizes") {
-    const std::vector<int> channels{};
     std::vector<std::string> varnames {"sea_ice_area_fraction",
       "sea_water_potential_temperature"};
-    oops::Variables oops_vars(varnames, channels);
+    oops::Variables oops_vars(varnames);
     auto varsizes = geometry.variableSizes(oops_vars);
     EXPECT_EQUAL(varsizes.size(), 2);
     EXPECT_EQUAL(varsizes[0], 1);
     EXPECT_EQUAL(varsizes[1], 10);
-    oops::Variables not_vars({"NOTAVARIBLE"}, channels);
+    oops::Variables not_vars({"NOTAVARIBLE"});
     EXPECT_THROWS_AS(geometry.variableSizes(not_vars), eckit::BadValue);
   }
 
   SECTION("test geometry variable NEMO model spaces") {
-    const std::vector<int> channels{};
     std::vector<std::string> varnames {"sea_ice_area_fraction",
       "sea_water_potential_temperature", "depth"};
-    oops::Variables oops_vars(varnames, channels);
+    oops::Variables oops_vars(varnames);
     auto varsizes = geometry.variableNemoSpaces(oops_vars);
     EXPECT_EQUAL(varsizes.size(), 3);
     EXPECT_EQUAL(varsizes[0], "surface");
     EXPECT_EQUAL(varsizes[1], "volume");
     EXPECT_EQUAL(varsizes[2], "vertical");
 
-    oops::Variables not_vars({"NOTAVARIBLE"}, channels);
+    oops::Variables not_vars({"NOTAVARIBLE"});
     EXPECT_THROWS_AS(geometry.variableNemoSpaces(not_vars), eckit::BadValue);
 
     eckit::LocalConfiguration bad_config;

--- a/src/tests/orca-jedi/test_increment.cc
+++ b/src/tests/orca-jedi/test_increment.cc
@@ -49,13 +49,12 @@ CASE("test increment") {
   config.set("number levels", 10);
   Geometry geometry(config, eckit::mpi::comm());
 
-  const std::vector<int> channels{};
   std::vector<std::string> varnames2 {"sea_ice_area_fraction",
     "sea_water_potential_temperature"};
-  oops::Variables oops_vars2(varnames2, channels);
+  oops::Variables oops_vars2(varnames2);
 
   std::vector<std::string> varnames {"sea_ice_area_fraction"};
-  oops::Variables oops_vars(varnames, channels);
+  oops::Variables oops_vars(varnames);
 
   util::DateTime datetime("2021-06-30T00:00:00Z");
 

--- a/src/tests/orca-jedi/test_increment.cc
+++ b/src/tests/orca-jedi/test_increment.cc
@@ -59,14 +59,12 @@ CASE("test increment") {
   util::DateTime datetime("2021-06-30T00:00:00Z");
 
   SECTION("test constructor") {
-    std::cout << "----------------" << std::endl;
     Increment increment(geometry, oops_vars2, datetime);
     // copy
     Increment increment2 = increment;
   }
 
   SECTION("test setting increment value") {
-    std::cout << "----------------------------" << std::endl;
     Increment increment(geometry, oops_vars, datetime);
     std::cout << std::endl << "Increment ones: " << std::endl;
     increment.ones();
@@ -82,7 +80,6 @@ CASE("test increment") {
   }
 
   SECTION("test dirac") {
-    std::cout << "----------------" << std::endl;
     eckit::LocalConfiguration dirac_config;
     std::vector<int> ix = {20, 30};
     std::vector<int> iy = {10, 40};
@@ -92,13 +89,15 @@ CASE("test increment") {
     dirac_config.set("izdir", iz);
 
     Increment increment(geometry, oops_vars, datetime);
+    EXPECT_THROWS_AS(increment.dirac(dirac_config), eckit::BadValue);
+
+    dirac_config.set("izdir", std::vector<int>{0, 0});
     increment.dirac(dirac_config);
     increment.print(std::cout);
     EXPECT(std::abs(increment.norm() - 0.0086788) < 1e-6);
   }
 
   SECTION("test mathematical operators") {
-    std::cout << "---------------------------" << std::endl;
     Increment increment1(geometry, oops_vars, datetime);
     Increment increment2(geometry, oops_vars, datetime);
     increment1.ones();
@@ -130,7 +129,6 @@ CASE("test increment") {
   }
 
   SECTION("test increments to fieldset and back to increments") {
-    std::cout << "--------------------------------------------------" << std::endl;
     Increment increment1(geometry, oops_vars, datetime);
     increment1.ones();
     Increment increment2(geometry, oops_vars, datetime);
@@ -144,7 +142,6 @@ CASE("test increment") {
   }
 
   SECTION("test increment diff with state inputs") {
-    std::cout << "-------------------------------------" << std::endl;
     // Using the same variables and double type as the increments
     // Code to deal with differing variables in state and increment not currently implemented
     orcamodel::State state1(geometry, oops_vars, datetime);

--- a/src/tests/orca-jedi/test_state.cc
+++ b/src/tests/orca-jedi/test_state.cc
@@ -50,7 +50,6 @@ CASE("test basic state") {
     .set("model space", "volume");
   config.set("nemo variables", nemo_var_mappings);
   Geometry geometry(config, eckit::mpi::comm());
-  const std::vector<int> channels{};
 
   eckit::LocalConfiguration state_config;
   std::vector<std::string> state_variables {"sea_ice_area_fraction"};
@@ -73,20 +72,19 @@ CASE("test basic state") {
   }
 
   SECTION("test constructor") {
-    oops::Variables oops_vars(state_variables, channels);
+    oops::Variables oops_vars(state_variables);
     util::DateTime datetime("2021-06-30T00:00:00Z");
     State state(geometry, oops_vars, datetime);
   }
 
   SECTION("test subset copy constructor") {
-    oops::Variables oops_vars({"sea_ice_area_fraction", "sea_surface_foundation_temperature"},
-        channels);
+    oops::Variables oops_vars({"sea_ice_area_fraction", "sea_surface_foundation_temperature"});
     util::DateTime datetime("2021-06-30T00:00:00Z");
     State state(geometry, oops_vars, datetime);
 
-    State state_copy(oops::Variables({"sea_ice_area_fraction"}, channels), state);
+    State state_copy(oops::Variables({"sea_ice_area_fraction"}), state);
 
-    EXPECT_THROWS_AS(State(oops::Variables({"NOT_IN_SRC_STATE"}, channels), state),
+    EXPECT_THROWS_AS(State(oops::Variables({"NOT_IN_SRC_STATE"}), state),
         eckit::BadValue);
   }
 


### PR DESCRIPTION
## Description
Use the new `oops::ObsVariables` for observations and `oops::Variables` for model variables.

## Issue(s) addressed

Resolves #90

## Impact

Resolves compile-time errors due to recent oops changes, alongside an out-of-bounds error in the Increments class.

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [ ] I have run [mo-bundle](http://fcm1/cylc-review/taskjobs/tsearle/?suite=mobb-oops2591) to check integration with the rest of JEDI and run the unit tests under all environments
