### PR TITLE
adapt to oops::Variables changes

### DIFF
--- a/src/orca-jedi/geometry/Geometry.cc
+++ b/src/orca-jedi/geometry/Geometry.cc
@@ -31,16 +31,10 @@ oops::Variables orcaVariableFactory(const eckit::Configuration & config) {
   std::vector<std::string> names{};
   for (const NemoFieldParameters& nemoVariable :
         params.nemoFields.value()) {
-    std::string  name = nemoVariable.name.value();
+    std::string name = nemoVariable.name.value();
     if (std::find(names.begin(), names.end(), name) == names.end()) {
       names.emplace_back(name);
-      size_t local_nlevels{params.nLevels.value()};
-      if (nemoVariable.modelSpace.value() == "surface") {
-        local_nlevels = 1;
-      }
-      eckit::LocalConfiguration conf;
-      conf.set("levels", local_nlevels);
-      variables.push_back(oops::Variable(name, conf));
+      variables.push_back(oops::Variable(name));
     }
   }
 

--- a/src/orca-jedi/increment/Increment.cc
+++ b/src/orca-jedi/increment/Increment.cc
@@ -498,12 +498,12 @@ void Increment::setupIncrementFields() {
   for (size_t i=0; i < vars_.size(); ++i) {
     // add variable if it isn't already in incrementFields
     std::vector<size_t> varSizes = geom_->variableSizes(vars_);
-    if (!incrementFields_.has(vars_[i])) {
+    if (!incrementFields_.has(vars_[i].name())) {
       incrementFields_.add(geom_->functionSpace().createField<double>(
-           atlas::option::name(vars_[i]) |
+           atlas::option::name(vars_[i].name()) |
            atlas::option::levels(varSizes[i])));
       oops::Log::trace() << "Increment(ORCA)::setupIncrementFields : "
-                         << vars_[i]
+                         << vars_[i].name()
                          << " with shape (" << (*(incrementFields_.end()-1)).shape(0)
                          << ", " << (*(incrementFields_.end()-1)).shape(1) << ")"
                          << std::endl;

--- a/src/orca-jedi/interpolator/Interpolator.cc
+++ b/src/orca-jedi/interpolator/Interpolator.cc
@@ -91,10 +91,10 @@ namespace orcamodel {
     const size_t nvars = vars.size();
 
     for (size_t j=0; j < nvars; ++j) {
-      if (!state.variables().has(vars[j])) {
+      if (!state.variables().has(vars[j].name())) {
         std::stringstream err_stream;
         err_stream << "orcamodel::Interpolator::apply varname \" "
-                   << "\" " << vars[j]
+                   << "\" " << vars[j].name()
                    << " not found in the model state." << std::endl;
         err_stream << "    add the variable to the state variables and "
                    << "add a mapping from the geometry to that variable."
@@ -119,13 +119,13 @@ namespace orcamodel {
     for (size_t jvar=0; jvar < nvars; ++jvar) {
       const auto execute = [&](auto typeVal) {
         using T = decltype(typeVal);
-        executeInterpolation<T>(vars[jvar], varSizes[jvar], state, res_iter);
+        executeInterpolation<T>(vars[jvar].name(), varSizes[jvar], state, res_iter);
       };
 
       ApplyForFieldType(execute,
-                        state.geometry()->fieldPrecision(vars[jvar]),
+                        state.geometry()->fieldPrecision(vars[jvar].name()),
                         std::string("orcamodel::Interpolator::apply '")
-                          + vars[jvar] + "' field type not recognised");
+                          + vars[jvar].name() + "' field type not recognised");
     }
     ASSERT(result.size() == nvals);
     oops::Log::trace() << "orcamodel::Interpolator::apply done "

--- a/src/orca-jedi/state/State.h
+++ b/src/orca-jedi/state/State.h
@@ -111,10 +111,10 @@ class State : public util::Printable,
   void setupStateFields();
   void print(std::ostream &) const override;
   std::shared_ptr<const Geometry> geom_;
+  OrcaStateParameters params_;
   oops::Variables vars_;
   util::DateTime time_;
   atlas::FieldSet stateFields_;
-  OrcaStateParameters params_;
 };
 // -----------------------------------------------------------------------------
 

--- a/src/orca-jedi/state/StateIOUtils.cc
+++ b/src/orca-jedi/state/StateIOUtils.cc
@@ -58,7 +58,7 @@ void readFieldsFromFile(
       const std::vector<std::string> coordSpaces =
         geom.variableNemoSpaces(vars);
       for (size_t i = 0; i < vars.size(); ++i)
-        varCoordTypeMap[vars[i]] = coordSpaces[i];
+        varCoordTypeMap[vars[i].name()] = coordSpaces[i];
     }
     for (atlas::Field field : fs) {
       std::string fieldName = field.name();
@@ -145,7 +145,7 @@ void writeFieldsToFile(
       const std::vector<std::string> coordSpaces =
         geom.variableNemoSpaces(vars);
       for (size_t i=0; i < vars.size(); ++i)
-        varCoordTypeMap[vars[i]] = coordSpaces[i];
+        varCoordTypeMap[vars[i].name()] = coordSpaces[i];
     }
 
     auto nemo_field_path = eckit::PathName(output_filename);

--- a/src/tests/orca-jedi/test_geometry.cc
+++ b/src/tests/orca-jedi/test_geometry.cc
@@ -60,28 +60,26 @@ CASE("test basic geometry") {
   }
 
   SECTION("test geometry variable sizes") {
-    std::vector<std::string> varnames {"sea_ice_area_fraction",
-      "sea_water_potential_temperature"};
-    oops::Variables oops_vars(varnames);
+    oops::Variables oops_vars{{oops::Variable{"sea_ice_area_fraction"},
+                               oops::Variable{"sea_water_potential_temperature"}}};
     auto varsizes = geometry.variableSizes(oops_vars);
     EXPECT_EQUAL(varsizes.size(), 2);
     EXPECT_EQUAL(varsizes[0], 1);
     EXPECT_EQUAL(varsizes[1], 10);
-    oops::Variables not_vars({"NOTAVARIBLE"});
+    oops::Variables not_vars{{oops::Variable{"NOTAVARIBLE"}}};
     EXPECT_THROWS_AS(geometry.variableSizes(not_vars), eckit::BadValue);
   }
 
   SECTION("test geometry variable NEMO model spaces") {
-    std::vector<std::string> varnames {"sea_ice_area_fraction",
-      "sea_water_potential_temperature", "depth"};
-    oops::Variables oops_vars(varnames);
+    oops::Variables oops_vars{{oops::Variable{"sea_ice_area_fraction"},
+      oops::Variable{"sea_water_potential_temperature"}, oops::Variable{"depth"}}};
     auto varsizes = geometry.variableNemoSpaces(oops_vars);
     EXPECT_EQUAL(varsizes.size(), 3);
     EXPECT_EQUAL(varsizes[0], "surface");
     EXPECT_EQUAL(varsizes[1], "volume");
     EXPECT_EQUAL(varsizes[2], "vertical");
 
-    oops::Variables not_vars({"NOTAVARIBLE"});
+    oops::Variables not_vars{{oops::Variable{"NOTAVARIBLE"}}};
     EXPECT_THROWS_AS(geometry.variableNemoSpaces(not_vars), eckit::BadValue);
 
     eckit::LocalConfiguration bad_config;

--- a/src/tests/orca-jedi/test_increment.cc
+++ b/src/tests/orca-jedi/test_increment.cc
@@ -49,12 +49,10 @@ CASE("test increment") {
   config.set("number levels", 10);
   Geometry geometry(config, eckit::mpi::comm());
 
-  std::vector<std::string> varnames2 {"sea_ice_area_fraction",
-    "sea_water_potential_temperature"};
-  oops::Variables oops_vars2(varnames2);
+  oops::Variables oops_vars2{{oops::Variable{"sea_ice_area_fraction"},
+    oops::Variable{"sea_water_potential_temperature"}}};
 
-  std::vector<std::string> varnames {"sea_ice_area_fraction"};
-  oops::Variables oops_vars(varnames);
+  oops::Variables oops_vars{{oops::Variable{"sea_ice_area_fraction"}}};
 
   util::DateTime datetime("2021-06-30T00:00:00Z");
 
@@ -148,10 +146,10 @@ CASE("test increment") {
     orcamodel::State state2(geometry, oops_vars, datetime);
     state1.zero();
     state2.zero();
-    std::cout << "state1 norm:" << varnames[0];
-    std::cout << state1.norm<double>(varnames[0]) << std::endl;
-    std::cout << "state2 norm:" << varnames[0];
-    std::cout << state2.norm<double>(varnames[0]) << std::endl;
+    std::cout << "state1 norm:" << oops_vars[0].name();
+    std::cout << state1.norm<double>(oops_vars[0].name()) << std::endl;
+    std::cout << "state2 norm:" << oops_vars[0].name();
+    std::cout << state2.norm<double>(oops_vars[0].name()) << std::endl;
     Increment increment(geometry, oops_vars, datetime);
     increment.diff(state1, state2);
     std::cout << "increment (diff state1 state2):" << std::endl;

--- a/src/tests/orca-jedi/test_interpolator.cc
+++ b/src/tests/orca-jedi/test_interpolator.cc
@@ -89,7 +89,7 @@ CASE("test basic interpolator") {
   Interpolator interpolator(interpolator_conf, geometry, lats, lons);
 
   SECTION("test interpolator.apply fails missing variable") {
-    oops::Variables variables({"NOTAVARIABLE"});
+    oops::Variables variables{{oops::Variable{"NOTAVARIABLE"}}};
     std::vector<double> vals(3);
     std::vector<bool> mask(3);
     EXPECT_THROWS_AS(interpolator.apply(variables, state, mask, vals),
@@ -100,8 +100,8 @@ CASE("test basic interpolator") {
     // two variables at n locations
     std::vector<double> vals(2*nlocs);
     std::vector<bool> mask(2*nlocs);
-    interpolator.apply(oops::Variables({"sea_ice_area_fraction",
-        "sea_surface_foundation_temperature"}), state, mask, vals);
+    interpolator.apply(oops::Variables{{oops::Variable{"sea_ice_area_fraction"},
+        oops::Variable{"sea_surface_foundation_temperature"}}}, state, mask, vals);
 
     double missing_value = util::missingValue<double>();
     std::vector<double> testvals = {1, missing_value, 0, 18.4888916016,
@@ -116,7 +116,7 @@ CASE("test basic interpolator") {
   SECTION("test interpolator.apply multiple levels") {
     std::vector<double> vals(nlevs*nlocs);
     std::vector<bool> mask(nlevs*nlocs);
-    interpolator.apply(oops::Variables({"sea_water_potential_temperature"}),
+    interpolator.apply(oops::Variables{{oops::Variable{"sea_water_potential_temperature"}}},
                                        state, mask, vals);
 
     double missing_value = util::missingValue<double>();

--- a/src/tests/orca-jedi/test_interpolator_parallel.cc
+++ b/src/tests/orca-jedi/test_interpolator_parallel.cc
@@ -115,7 +115,7 @@ CASE("test serial interpolator") {
   Interpolator interpolator(interpolator_conf, geometry, lats, lons);
 
   SECTION("test interpolator.apply fails missing variable") {
-    oops::Variables variables({"NOTAVARIABLE"});
+    oops::Variables variables{oops::Variable{"NOTAVARIABLE"}};
     std::vector<double> vals(nlocs);
     std::vector<bool> mask(nlocs);
     EXPECT_THROWS_AS(interpolator.apply(variables, state, mask, vals),
@@ -126,8 +126,8 @@ CASE("test serial interpolator") {
     // two variables at n locations
     std::vector<double> vals(2*nlocs);
     std::vector<bool> mask(2*nlocs);
-    interpolator.apply(oops::Variables({"sea_surface_height_anomaly",
-        "sea_surface_foundation_temperature"}), state, mask, vals);
+    interpolator.apply(oops::Variables({oops::Variable{"sea_surface_height_anomaly"},
+        oops::Variable{"sea_surface_foundation_temperature"}}), state, mask, vals);
 
     double missing_value = util::missingValue<double>();
     std::vector<double> testvals(2*nlocs, 0);
@@ -153,7 +153,7 @@ CASE("test serial interpolator") {
   //  SECTION("test interpolator.apply multiple levels") {
   //    std::vector<double> vals(nlevs*nlocs);
   //    std::vector<bool> mask(nlevs*nlocs);
-  //    interpolator.apply(oops::Variables({"sea_water_potential_temperature"}),
+  //    interpolator.apply(oops::Variables{oops::Variable{"sea_water_potential_temperature"}},
   //                                       state, mask, vals);
 
   //    double missing_value = util::missingValue<double>();
@@ -261,7 +261,7 @@ CASE("test checkerboard interpolator") {
   Interpolator interpolator(interpolator_conf, geometry, lats, lons);
 
   SECTION("test interpolator.apply fails missing variable") {
-    oops::Variables variables({"NOTAVARIABLE"});
+    oops::Variables variables{oops::Variable{"NOTAVARIABLE"}};
     std::vector<double> vals(nlocs);
     std::vector<bool> mask(nlocs);
     EXPECT_THROWS_AS(interpolator.apply(variables, state, mask, vals),
@@ -272,8 +272,8 @@ CASE("test checkerboard interpolator") {
     // two variables at n locations
     std::vector<double> vals(2*nlocs);
     std::vector<bool> mask(2*nlocs);
-    interpolator.apply(oops::Variables({"sea_surface_height_anomaly",
-        "sea_surface_foundation_temperature"}), state, mask, vals);
+    interpolator.apply(oops::Variables{oops::Variable{"sea_surface_height_anomaly"},
+        oops::Variable{"sea_surface_foundation_temperature"}}, state, mask, vals);
 
     double missing_value = util::missingValue<double>();
     std::vector<double> testvals(2*nlocs, 0);


### PR DESCRIPTION
## Description

Adapt to the changes to the `oops::Variables` class. This is now a collection of the new type `oops::Variable` that can include metadata.

In the future, we can likely refactor a lot of orca-jedi to make use of the new `oops::Variables` class. However, we need guidance first on what metadata is valid.

## Issue(s) addressed

Resolves #93 

## Dependencies

List the other PRs that this PR is dependent on:

build-group=https://github.com/JCSDA-internal/oops/pull/2646
build-group=https://github.com/JCSDA-internal/vader/pull/262
build-group=https://github.com/JCSDA-internal/ufo/pull/3347
build-group=https://github.com/JCSDA-internal/saber/pull/868
build-group=https://github.com/JCSDA-internal/fv3-jedi/pull/1215

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [x] I have run [mo-bundle](http://fcm1/cylc-review/taskjobs/tsearle/?suite=mobb-oj94) to check integration with the rest of JEDI and run the unit tests under all environments (will not run all tests without corresponding changes in other Met Office repos)
