### PR TITLE
prepare for atlas version 0.38.0

### DIFF
--- a/src/orca-jedi/increment/Increment.cc
+++ b/src/orca-jedi/increment/Increment.cc
@@ -85,8 +85,6 @@ Increment::Increment(const Increment & other, const bool copy)
 
   setupIncrementFields();
 
-  auto ghost = atlas::array::make_view<int32_t, 1>(
-      geom_->mesh().nodes().ghost());
   if (copy) {
     for (size_t i=0; i < vars_.size(); ++i) {
       // copy variable from _Fields to new field set
@@ -96,7 +94,7 @@ Increment::Increment(const Increment & other, const bool copy)
       auto field_view_other = atlas::array::make_view<double, 2>(field);
       for (atlas::idx_t j = 0; j < field_view.shape(0); ++j) {
         for (atlas::idx_t k = 0; k < field_view.shape(1); ++k) {
-          if (!ghost(j)) field_view(j, k) = field_view_other(j, k);
+          field_view(j, k) = field_view_other(j, k);
         }
       }
     }

--- a/src/tests/orca-jedi/test_interpolator.cc
+++ b/src/tests/orca-jedi/test_interpolator.cc
@@ -82,7 +82,7 @@ CASE("test basic interpolator") {
   State state(geometry, stateParams);
 
   SECTION("test interpolator succeeds even with no locations") {
-   Interpolator interpolator(interpolator_conf, geometry, {}, {});
+    Interpolator interpolator(interpolator_conf, geometry, {}, {});
   }
 
   Interpolator interpolator(interpolator_conf, geometry, lats, lons);

--- a/src/tests/orca-jedi/test_interpolator.cc
+++ b/src/tests/orca-jedi/test_interpolator.cc
@@ -81,10 +81,9 @@ CASE("test basic interpolator") {
   stateParams.validateAndDeserialize(state_config);
   State state(geometry, stateParams);
 
-  // Disable this section until jopa-bundle uses a new version of atlas
-  // SECTION("test interpolator succeeds even with no locations") {
-  //  Interpolator interpolator(interpolator_conf, geometry, {}, {});
-  // }
+  SECTION("test interpolator succeeds even with no locations") {
+   Interpolator interpolator(interpolator_conf, geometry, {}, {});
+  }
 
   Interpolator interpolator(interpolator_conf, geometry, lats, lons);
 


### PR DESCRIPTION
## Description

Atlas at tag/0.38.0 will throw an error if a field is accessed where the fieldset contains multiple fields with the same name. This change fixes an error in the `Increment` class that added multiple fields with the same name to the objects owned fieldset. As part of this change, `Increment` copy constructor will now perform a deep copy rather than a shallow copy.

## Issue(s) addressed

Partial fix for #98

## Impact

None expected.

## build groups

build-group=ecmwf/atlas#211

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] I have run the unit tests
- [x] I have run [mo-bundle](http://fcm1/cylc-review/taskjobs/tsearle/?suite=mobb-atlas-develop) to check integration with the rest of JEDI and run the unit tests under all environments
   - this fails some tests due to a separate MPI issue with the atlas-orca meshgenerator that will be resolved in a separate PR.
