### PR TITLE
move StateIOUtils to utilities/IOUtils

### DIFF
--- a/src/orca-jedi/CMakeLists.txt
+++ b/src/orca-jedi/CMakeLists.txt
@@ -21,8 +21,6 @@ model/ModelBiasIncrement.h
 model/Model.h
 state/State.h
 state/State.cc
-state/StateIOUtils.h
-state/StateIOUtils.cc
 nemo_io/NemoFieldReader.h
 nemo_io/NemoFieldReader.cc
 nemo_io/NemoFieldWriter.h
@@ -35,6 +33,8 @@ nemo_io/WriteServer.cc
 utilities/OrcaModelTraits.h
 utilities/Types.h
 utilities/Types.cc
+utilities/IOUtils.h
+utilities/IOUtils.cc
 variablechanges/VariableChangeParameters.h
 variablechanges/VariableChange.h
 )

--- a/src/orca-jedi/increment/Increment.cc
+++ b/src/orca-jedi/increment/Increment.cc
@@ -28,9 +28,9 @@
 
 #include "ufo/GeoVaLs.h"
 
+#include "orca-jedi/utilities/IOUtils.h"
 #include "orca-jedi/geometry/Geometry.h"
 #include "orca-jedi/state/State.h"
-#include "orca-jedi/state/StateIOUtils.h"
 #include "orca-jedi/increment/Increment.h"
 #include "orca-jedi/increment/IncrementParameters.h"
 

--- a/src/orca-jedi/increment/IncrementParameters.h
+++ b/src/orca-jedi/increment/IncrementParameters.h
@@ -20,7 +20,7 @@ class OrcaIncrementParameters : public oops::Parameters {
   OOPS_CONCRETE_PARAMETERS(OrcaIncrementParameters, oops::Parameters)
 
  public:
-  oops::RequiredParameter<std::string> nemoFieldFile{"filepath", this};
+  oops::RequiredParameter<std::string> nemoFieldFile{"output path", this};
   oops::RequiredParameter<util::DateTime> date{"date", this};
 };
 
@@ -28,8 +28,8 @@ class OrcaDiracParameters : public oops::Parameters {
   OOPS_CONCRETE_PARAMETERS(OrcaDiracParameters, oops::Parameters)
 
  public:
-  oops::RequiredParameter<std::vector<int>> ixdir{"ixdir", this};
-  oops::RequiredParameter<std::vector<int>> iydir{"iydir", this};
-  oops::RequiredParameter<std::vector<int>> izdir{"izdir", this};
+  oops::RequiredParameter<std::vector<int>> ixdir{"x indices", this};
+  oops::RequiredParameter<std::vector<int>> iydir{"y indices", this};
+  oops::RequiredParameter<std::vector<int>> izdir{"z indices", this};
 };
 }  //  namespace orcamodel

--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -39,7 +39,7 @@
 #include "orca-jedi/variablechanges/VariableChange.h"
 #include "orca-jedi/increment/Increment.h"
 #include "orca-jedi/state/State.h"
-#include "orca-jedi/state/StateIOUtils.h"
+#include "orca-jedi/utilities/IOUtils.h"
 #include "orca-jedi/utilities/Types.h"
 
 
@@ -78,9 +78,12 @@ State::State(const Geometry & geom,
   if (params_.analyticInit.value().value_or(false)) {
     this->analytic_init(*geom_);
   } else {
-    readFieldsFromFile(params_, *geom_, validTime(), "background",
-       stateFields_);
-    readFieldsFromFile(params_, *geom_, validTime(), "background variance",
+    std::string nemo_file_name;
+    nemo_file_name = params.nemoFieldFile.value();
+    readFieldsFromFile(nemo_file_name, *geom_, validTime(), "background",
+         stateFields_);
+    nemo_file_name = params.varianceFieldFile.value().value_or("");
+    readFieldsFromFile(nemo_file_name, *geom_, validTime(), "background variance",
        stateFields_);
   }
   geom_->log_status();
@@ -185,7 +188,8 @@ void State::read(const OrcaStateParameters & params) {
     throw eckit::UserError(msg.str(), Here());
   }
 
-  readFieldsFromFile(params, *geom_, validTime(), "background",
+  std::string nemo_file_name = params.nemoFieldFile.value();
+  readFieldsFromFile(nemo_file_name, *geom_, validTime(), "background",
       stateFields_);
   oops::Log::trace() << "State(ORCA)::read done" << std::endl;
 }
@@ -225,7 +229,8 @@ void State::setupStateFields() {
 
 void State::write(const OrcaStateParameters & params) const {
   oops::Log::trace() << "State(ORCA)::write starting" << std::endl;
-  writeStateFieldsToFile(params, *geom_, validTime(), stateFields_);
+  writeFieldsToFile(params.outputNemoFieldFile.value().value_or(""), *geom_, validTime(),
+      stateFields_);
 }
 
 void State::write(const eckit::Configuration & config) const {

--- a/src/orca-jedi/utilities/IOUtils.h
+++ b/src/orca-jedi/utilities/IOUtils.h
@@ -10,26 +10,18 @@
 #include "atlas/field.h"
 
 #include "orca-jedi/geometry/Geometry.h"
-#include "orca-jedi/state/State.h"
-#include "orca-jedi/state/StateParameters.h"
-#include "orca-jedi/utilities/Types.h"
 #include "orca-jedi/nemo_io/ReadServer.h"
 
 namespace orcamodel {
 
 void readFieldsFromFile(
-  const OrcaStateParameters & params,
+  const std::string & nemo_file_name,
   const Geometry & geom,
   const util::DateTime & valid_date,
   const std::string & variable_type,
   atlas::FieldSet & fs);
-void writeStateFieldsToFile(
-  const OrcaStateParameters & params,
-  const Geometry & geom,
-  const util::DateTime & valid_date,
-  const atlas::FieldSet & fs);
 void writeFieldsToFile(
-  const std::string nemo_field_path,
+  const std::string & output_file_name,
   const Geometry & geom,
   const util::DateTime & valid_date,
   const atlas::FieldSet & fs);

--- a/src/tests/orca-jedi/test_increment.cc
+++ b/src/tests/orca-jedi/test_increment.cc
@@ -16,7 +16,7 @@
 #include "atlas/library/Library.h"
 
 #include "orca-jedi/increment/Increment.h"
-#include "orca-jedi/state/StateIOUtils.h"
+#include "orca-jedi/utilities/IOUtils.h"
 
 #include "tests/orca-jedi/OrcaModelTestEnvironment.h"
 
@@ -63,10 +63,10 @@ CASE("test increment") {
   util::DateTime datetime("2021-06-30T00:00:00Z");
 
   SECTION("test increment parameters") {
-    inc_config.set("filepath", "../Data/orca2_t_nemo.nc");
+    inc_config.set("output path", "../Data/orca2_t_nemo.nc");
     params.validateAndDeserialize(inc_config);
     EXPECT(params.nemoFieldFile.value() ==
-        inc_config.getString("filepath"));
+        inc_config.getString("output path"));
     auto datetime = static_cast<util::DateTime>(inc_config.getString("date"));
     EXPECT(params.date.value() == datetime);
   }
@@ -97,14 +97,14 @@ CASE("test increment") {
     std::vector<int> ix = {20, 30};
     std::vector<int> iy = {10, 40};
     std::vector<int> iz = {1, 3};
-    dirac_config.set("ixdir", ix);
-    dirac_config.set("iydir", iy);
-    dirac_config.set("izdir", iz);
+    dirac_config.set("x indices", ix);
+    dirac_config.set("y indices", iy);
+    dirac_config.set("z indices", iz);
 
     Increment increment(geometry, oops_vars, datetime);
     EXPECT_THROWS_AS(increment.dirac(dirac_config), eckit::BadValue);
 
-    dirac_config.set("izdir", std::vector<int>{0, 0});
+    dirac_config.set("z indices", std::vector<int>{0, 0});
     increment.dirac(dirac_config);
     increment.print(std::cout);
     EXPECT(std::abs(increment.norm() - 0.0086788) < 1e-6);
@@ -174,7 +174,7 @@ CASE("test increment") {
   SECTION("test increment write") {
     Increment increment1(geometry, oops_vars, datetime);
     increment1.ones();
-    inc_config.set("filepath", "../testoutput/orca2_t_increment_output.nc");
+    inc_config.set("output path", "../testoutput/orca2_t_increment_output.nc");
     params.validateAndDeserialize(inc_config);
     increment1.write(params);
   }


### PR DESCRIPTION
Rather than express my suggestions through words I decided it was easiest to express it more directly as code. My review contains two suggestions essentially:
  1. move IOUtils to shared directory to share use between states and increments
  2. update parameters to use long names.

This is just a review and it is for going into your branch, so you ought to have the power to merge into your branch whatever you like from it. (either on command-line or the big green button below)