### PR TITLE
Use my credentials to store and retrieve container

### DIFF
--- a/.github/workflows/build_ci_image.yml
+++ b/.github/workflows/build_ci_image.yml
@@ -12,7 +12,7 @@ on:
 # workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.actor }}/orca-jedi/ci-almalinux9
+  IMAGE_NAME: twsearle/orca-jedi/ci-almalinux9
 
 jobs:
   build-and-push-image:
@@ -35,8 +35,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: twsearle
+          password: ${{ secrets.GHCR_PAT }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       # This step uses

--- a/.github/workflows/build_ci_image.yml
+++ b/.github/workflows/build_ci_image.yml
@@ -68,9 +68,12 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max`
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
 
       # This step generates an artifact attestation for the image, which is an
       # unforgeable statement about where and how it was built. It increases

--- a/.github/workflows/build_ci_image.yml
+++ b/.github/workflows/build_ci_image.yml
@@ -12,7 +12,7 @@ on:
 # workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: darth/orca-jedi/ci-almalinux9
+  IMAGE_NAME: ${{ github.actor }}/orca-jedi/ci-almalinux9
 
 jobs:
   build-and-push-image:
@@ -36,7 +36,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       # This step uses
       # [docker/metadata-action](https://github.com/docker/metadata-action#about)
       # to extract tags and labels that will be applied to the specified image.

--- a/.github/workflows/build_ci_image.yml
+++ b/.github/workflows/build_ci_image.yml
@@ -37,6 +37,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       # This step uses
       # [docker/metadata-action](https://github.com/docker/metadata-action#about)
       # to extract tags and labels that will be applied to the specified image.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,28 +26,28 @@ jobs:
           path: ci/jedicmake
           repository: JCSDA-internal/jedi-cmake
           submodules: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
       - name: checkout oops
         uses: actions/checkout@v3
         with:
           path: ci/oops
           repository: JCSDA-internal/oops
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
       - name: checkout ioda
         uses: actions/checkout@v3
         with:
           path: ci/ioda
           repository: JCSDA-internal/ioda
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
       - name: checkout ufo
         uses: actions/checkout@v3
         with:
           path: ci/ufo
           repository: JCSDA-internal/ufo
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
       - name: checkout atlas-data
         uses: actions/checkout@v3
@@ -55,17 +55,17 @@ jobs:
           path: ci/atlas-data
           repository: MetOffice/atlas-data
           lfs: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: darth
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor}}
+          password: ${{ secrets.GH_PAT }}
 
       - name: Pull Docker image
-        run: docker pull ghcr.io/darth/orca-jedi/ci-almalinux9:develop
+        run: docker pull ghcr.io/${{ github.actor }}/orca-jedi/ci-almalinux9:develop
 
       - name: build and test
         run: |
@@ -73,4 +73,4 @@ jobs:
             --entrypoint=/usr/local/src/orca-jedi/ci/build-and-test.sh \
             --workdir=/usr/local/src/orca-jedi/ci \
             --volume $PWD:/usr/local/src/orca-jedi \
-            ghcr.io/${{ github.actor }}/orca-jedi/ci-almalinux9:v1.2.0
+            ghcr.io/${{ github.actor }}/orca-jedi/ci-almalinux9:develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,9 @@ on:
     branches: [develop]
   pull_request:
     branches: [develop]
-
+env:
+    REGISTRY: ghcr.io
+    IMAGE_NAME: twsearle/orca-jedi/ci-almalinux9:latest
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -60,12 +62,12 @@ jobs:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor}}
-          password: ${{ secrets.GH_PAT }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull Docker image
-        run: docker pull ghcr.io/${{ github.actor }}/orca-jedi/ci-almalinux9:develop
+        run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: build and test
         run: |
@@ -73,4 +75,4 @@ jobs:
             --entrypoint=/usr/local/src/orca-jedi/ci/build-and-test.sh \
             --workdir=/usr/local/src/orca-jedi/ci \
             --volume $PWD:/usr/local/src/orca-jedi \
-            ghcr.io/${{ github.actor }}/orca-jedi/ci-almalinux9:develop
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      packages: read
     steps:
       - name: checkout current repo
         uses: actions/checkout@v3
@@ -21,34 +26,28 @@ jobs:
           path: ci/jedicmake
           repository: JCSDA-internal/jedi-cmake
           submodules: true
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: checkout oops
         uses: actions/checkout@v3
         with:
           path: ci/oops
           repository: JCSDA-internal/oops
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: checkout ioda
         uses: actions/checkout@v3
         with:
           path: ci/ioda
           repository: JCSDA-internal/ioda
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: checkout ufo
         uses: actions/checkout@v3
         with:
           path: ci/ufo
           repository: JCSDA-internal/ufo
-          token: ${{ secrets.GH_PAT }}
-
-      - name: checkout atlas-orca
-        uses: actions/checkout@v3
-        with:
-          path: ci/atlas-orca
-          repository: ECMWF/atlas-orca
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: checkout atlas-data
         uses: actions/checkout@v3
@@ -56,7 +55,17 @@ jobs:
           path: ci/atlas-data
           repository: MetOffice/atlas-data
           lfs: true
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: darth
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull Docker image
+        run: docker pull ghcr.io/darth/orca-jedi/ci-almalinux9:develop
 
       - name: build and test
         run: |
@@ -64,4 +73,4 @@ jobs:
             --entrypoint=/usr/local/src/orca-jedi/ci/build-and-test.sh \
             --workdir=/usr/local/src/orca-jedi/ci \
             --volume $PWD:/usr/local/src/orca-jedi \
-            'jcsda/docker-gnu-openmpi-dev:latest'
+            ghcr.io/${{ github.actor }}/orca-jedi/ci-almalinux9:v1.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,28 +28,28 @@ jobs:
           path: ci/jedicmake
           repository: JCSDA-internal/jedi-cmake
           submodules: true
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GHCR_PAT }}
 
       - name: checkout oops
         uses: actions/checkout@v3
         with:
           path: ci/oops
           repository: JCSDA-internal/oops
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GHCR_PAT }}
 
       - name: checkout ioda
         uses: actions/checkout@v3
         with:
           path: ci/ioda
           repository: JCSDA-internal/ioda
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GHCR_PAT }}
 
       - name: checkout ufo
         uses: actions/checkout@v3
         with:
           path: ci/ufo
           repository: JCSDA-internal/ufo
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GHCR_PAT }}
 
       - name: checkout atlas-data
         uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
           path: ci/atlas-data
           repository: MetOffice/atlas-data
           lfs: true
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GHCR_PAT }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: read
-      pull-requests: read
-      packages: read
     steps:
       - name: checkout current repo
         uses: actions/checkout@v3
@@ -63,8 +58,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: twsearle
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Pull Docker image
         run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [develop]
 env:
     REGISTRY: ghcr.io
-    IMAGE_NAME: twsearle/orca-jedi/ci-almalinux9:latest
+    IMAGE_NAME: twsearle/orca-jedi/ci-almalinux9:feature-use-personal-ghcr-container
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/ci/CMakeLists.txt
+++ b/ci/CMakeLists.txt
@@ -17,7 +17,6 @@ if(NOT DEFINED jedicmake_DIR)
   set(jedicmake_DIR "${CMAKE_BINARY_DIR}/jedicmake")
 endif()
 
-add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/atlas-orca" EXCLUDE_FROM_ALL)
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/oops" EXCLUDE_FROM_ALL)
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/ioda" EXCLUDE_FROM_ALL)
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/ufo" EXCLUDE_FROM_ALL)

--- a/ci/hpccm_recipe_almalinux9.py
+++ b/ci/hpccm_recipe_almalinux9.py
@@ -45,6 +45,8 @@ nceplibs_bufr_vn = USERARG.get('nceplibs_bufr_vn', '12.0.1')
 netcdf_vn = USERARG.get('netcdf_vn', '4.9.2')
 netcdfcxx_vn = USERARG.get('netcdfcxx_vn', '4.3.1')
 netcdfftn_vn = USERARG.get('netcdfftn_vn', '4.6.1')
+netcdf4python_vn = USERARG.get('netcdf4python_vn', '1.6.5')
+numpy_vn = USERARG.get('numpy_vn', '1.26.4')
 odc_vn = USERARG.get('odc_vn', '1.5.2')
 openmpi_vn = USERARG.get('openmpi_vn', '4.1.5')
 pycodestyle_vn = USERARG.get('pycodestyle_vn', '2.10')
@@ -266,6 +268,11 @@ Stage0 += generic_autotools(
     configure_opts=['--with-idxtype=long', '--without-regard-for-quality'],
 )
 
+Stage0 += pip(pip='pip3', packages=[
+    f"pycodestyle=={pycodestyle_vn}",
+    f"numpy=={numpy_vn}",
+    f"netcdf4=={netcdf4python_vn}",
+])
 Stage1 += baseimage(image='almalinux:9', _distro='rhel')
 Stage1 += comment('JEDI development image with GNU and OpenMPI')
 Stage1 += label(metadata={


### PR DESCRIPTION
## Description

*NOTE* This is a temporary fix to the CI to get us past the atlas upgrade. I will help refactor this to use a centralised solution when possible if desired.

Rather than use a persistent GitHub PAT for CI, I experimented to use each users ephemeral GITHUB_TOKEN, which is automatically generated and has a lifetime for only the life of the github workflow run. This is safer, and also gets around us needing more permissions on the darth account to create packages. However, it didn't work on this repo. I am not sure why, but authentication did not work.

Resolves #111 