### PR TITLE
filter null ocean colour data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ add_subdirectory( src )
 
 add_subdirectory ( docs )
 
+add_subdirectory ( share )
+
 ################################################################################
 # Export and summarize
 

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -1,0 +1,20 @@
+# (C) British Crown Copyright 2024 Met Office
+
+list( APPEND shared_files
+    odb_col_chl_query_filter_null.yaml
+)
+
+set( destination share/orca-jedi/odb-query )
+
+install(
+    FILES       ${shared_files}
+    DESTINATION ${destination}
+    PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
+
+file( MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${destination} )
+
+foreach( file ${shared_files} )
+    execute_process(COMMAND "${CMAKE_COMMAND}" "-E" "copy_if_different"
+        "${CMAKE_CURRENT_SOURCE_DIR}/${file}"
+        "${CMAKE_BINARY_DIR}/${destination}/${file}")
+endforeach()

--- a/share/odb_col_chl_query_filter_null.yaml
+++ b/share/odb_col_chl_query_filter_null.yaml
@@ -1,6 +1,6 @@
 where:
   varno: [288,]
-query: initial_obsvalue is not null
+  query: initial_obsvalue is not null
 variables:
 - name: receipt_time
 - name: receipt_date

--- a/share/odb_col_chl_query_filter_null.yaml
+++ b/share/odb_col_chl_query_filter_null.yaml
@@ -1,0 +1,15 @@
+where:
+  varno: [288,]
+query: initial_obsvalue is not null
+variables:
+- name: receipt_time
+- name: receipt_date
+- name: initial_obsvalue
+- name: instrument_type
+- name: lat
+- name: lon
+- name: date
+- name: time
+- name: ops_obsgroup
+- name: varno
+- name: seqno


### PR DESCRIPTION
## Description

75% of ocean colour observations are null values in ODB files.  We can improve performance and comparibility with the OPS by filtering these observations from the ODB file before JOPA runs. Ideally, we would do this during creation of the ODB file, however I am not sure how to do this, and this may not be in scope for the ODB creation executables.

I attempted to add this to the base query file, however ODB is unable to handle files with a different number of valid `varno`'s. My change was removed as it caused various crashes on different platforms:
https://github.com/JCSDA-internal/ioda/pull/1345

As an alternative, I am temporarily adding the query file to orca-jedi on the assumption that we only need Chlorophyll data (true for PS46) so that we filter down to non-null values.

In the future, I hope that upstream changes by @adammaycock or @DJDavies2 might render this file unnecessary.

## Impact

Enables comparison of OPS and JOPA ocean colour outputs.
