### PR TITLE
Remove validation options from OOPS Applications

### DIFF
--- a/src/mains/CMakeLists.txt
+++ b/src/mains/CMakeLists.txt
@@ -39,10 +39,3 @@ ecbuild_add_executable( TARGET  orcamodel_ErrorCovarianceToolbox.x
                         SOURCES orcamodelErrorCovarianceToolbox.cc
                         LIBS    orcamodel
                       )
-
-oops_output_json_schema( "orcamodel_hofx.x" )
-oops_output_json_schema( "orcamodel_hofx3D.x" )
-# The applications below throw an error generating json schema.
-# This appears to be a generic issue see also oops/qg/mains/CMakeLists.txt
-#oops_output_json_schema( "orcamodel_3DVar.x" )
-#oops_output_json_schema( "orcamodel_ErrorCovarianceToolbox.x" )


### PR DESCRIPTION
## Description

Update required by https://github.com/JCSDA-internal/oops/pull/2795, see also: JCSDA-internal/oops#2794.

## Dependencies

build-group=JCSDA-internal/oops#2795
build-group=JCSDA-internal/saber#979
build-group=JCSDA-internal/ioda#1391
build-group=JCSDA-internal/ufo#3548

## Testing

Run test suite via: `./bin/bbb play "no_app_val" -z TASKS=all_ctest` All test have passed, see: [no_app_val](http://fcm1/cylc-review/cycles/ssandbac/?suite=no_app_val)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR