### PR TITLE
Remove deprecated oops classes

### DIFF
--- a/src/orca-jedi/variablechanges/LinearVariableChange.cc
+++ b/src/orca-jedi/variablechanges/LinearVariableChange.cc
@@ -6,6 +6,7 @@
 */
 
 #include <string>
+#include <vector>
 
 #include "eckit/exception/Exceptions.h"
 

--- a/src/orca-jedi/variablechanges/LinearVariableChange.h
+++ b/src/orca-jedi/variablechanges/LinearVariableChange.h
@@ -18,11 +18,6 @@
 #include "orca-jedi/state/State.h"
 #include "orca-jedi/variablechanges/LinearVariableChangeParameters.h"
 
-// Forward declarations
-namespace oops {
-class Variables;
-}
-
 namespace orcamodel {
 
 // -----------------------------------------------------------------------------

--- a/src/orca-jedi/variablechanges/LinearVariableChangeParameters.h
+++ b/src/orca-jedi/variablechanges/LinearVariableChangeParameters.h
@@ -6,23 +6,16 @@
 
 #pragma once
 
-#include <string>
-#include <vector>
-
-#include "eckit/exception/Exceptions.h"
-#include "oops/util/DateTime.h"
 #include "oops/base/Variables.h"
-#include "oops/base/LinearVariableChangeParametersBase.h"
-#include "oops/util/parameters/Parameter.h"
-#include "oops/util/parameters/RequiredParameter.h"
+#include "oops/base/ParameterTraitsVariables.h"
+#include "oops/util/parameters/Parameters.h"
 #include "oops/util/parameters/OptionalParameter.h"
 
 
-class LinearVariableChangeParameters :
-    public oops::LinearVariableChangeParametersBase {
-  OOPS_CONCRETE_PARAMETERS(LinearVariableChangeParameters,
-                           oops::LinearVariableChangeParametersBase)
+class LinearVariableChangeParameters : public oops::Parameters {
+  OOPS_CONCRETE_PARAMETERS(LinearVariableChangeParameters, oops::Parameters)
  public:
-  // No linear variable change. No additional parameters
+  oops::OptionalParameter<oops::Variables> inputVariables{"input variables", this};
+  oops::OptionalParameter<oops::Variables> outputVariables{"output variables", this};
 };
 

--- a/src/orca-jedi/variablechanges/VariableChange.h
+++ b/src/orca-jedi/variablechanges/VariableChange.h
@@ -14,11 +14,6 @@
 #include "orca-jedi/state/State.h"
 #include "orca-jedi/variablechanges/VariableChangeParameters.h"
 
-// Forward declarations
-namespace oops {
-class Variables;
-}
-
 namespace orcamodel {
 
 // -----------------------------------------------------------------------------

--- a/src/orca-jedi/variablechanges/VariableChangeParameters.h
+++ b/src/orca-jedi/variablechanges/VariableChangeParameters.h
@@ -4,23 +4,17 @@
 
 #pragma once
 
-#include <string>
-#include <vector>
-
-#include "eckit/exception/Exceptions.h"
-#include "oops/util/DateTime.h"
 #include "oops/base/Variables.h"
-#include "oops/base/VariableChangeParametersBase.h"
-#include "oops/util/parameters/Parameter.h"
-#include "oops/util/parameters/RequiredParameter.h"
+#include "oops/base/ParameterTraitsVariables.h"
+#include "oops/util/parameters/Parameters.h"
 #include "oops/util/parameters/OptionalParameter.h"
 
 
-class VariableChangeParameters :
-    public oops::VariableChangeParametersBase {
-  OOPS_CONCRETE_PARAMETERS(VariableChangeParameters,
-                           oops::VariableChangeParametersBase)
+class VariableChangeParameters : public oops::Parameters {
+  OOPS_CONCRETE_PARAMETERS(VariableChangeParameters, oops::Parameters)
  public:
+  oops::OptionalParameter<oops::Variables> inputVariables{"input variables", this};
+  oops::OptionalParameter<oops::Variables> outputVariables{"output variables", this};
   // No linear variable change. No additional parameters
 };
 


### PR DESCRIPTION
## Description

Remove all shared description of OOPS base class parameters. Please check the docs or get in touch with the developers of OOPS to find out what base class parameters are required as they change from this point forward.

## Issue(s) addressed

Resolves orca-jedi component of https://github.com/orgs/JCSDA-internal/discussions/163

## Impact
 
Should have zero effect as we are not using variable changes or linear variable changes, and we are maintaining our own validation of these parameters.

## Checklist

- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [x] I have run [mo-bundle](http://fcm1/cylc-review/cycles/tsearle?&suite=mobb-oj127) to check integration with the rest of JEDI and run the unit tests under all environments
