### PR TITLE
Added transpose stub to match upcoming capability in OOPS

### DIFF
--- a/src/orca-jedi/state/State.h
+++ b/src/orca-jedi/state/State.h
@@ -86,7 +86,7 @@ class State : public util::Printable,
   void deserialize(const std::vector<double> &, std::size_t &) override {}
   void transpose(const State & DistState, const eckit::mpi::Comm & global,
      const int ensNum, const int transNum) {
-     throw eckit::NotImplemented("ORCA-JEDI State::transpose not implemented", Here());
+     throw eckit::NotImplemented("orcamodel::State::transpose: not implemented", Here());
   }
 
 /// Utilities

--- a/src/orca-jedi/state/State.h
+++ b/src/orca-jedi/state/State.h
@@ -84,6 +84,10 @@ class State : public util::Printable,
   std::size_t serialSize() const override {return 0;}
   void serialize(std::vector<double> &) const override {}
   void deserialize(const std::vector<double> &, std::size_t &) override {}
+  void transpose(const State & DistState, const eckit::mpi::Comm & global,
+     const int ensNum, const int transNum) {
+     throw eckit::NotImplemented("ORCA-JEDI State::transpose not implemented", Here());
+  }
 
 /// Utilities
   std::shared_ptr<const Geometry> geometry() const {return geom_;}


### PR DESCRIPTION
## Description

Adds a stub for the transpose method to State.h in order to comply with the method's upcoming addition to OOPS.

## Issue(s) addressed

See discussion: https://github.com/orgs/JCSDA-internal/discussions/164

## Dependencies

This should be merged alongside the equivalent PRs for lfric-jedi and ops-um-jedi, but is not dependent on them.

## Impact

Expected impact on downstream repositories or workflows:
None unless transpose functionality is to be added to orca-jedi, in which case the stub will need to be expanded
into a full method.

## Checklist

- [n/a] I have updated the unit tests to cover the change
- [n/a] New functions are documented briefly via Doxygen comments in the code
- [n/a] I have linted my code using cpplint
- [✓] I have run the unit tests
- [✓] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments
See mo-bundle test output:
http://fcm1/cylc-review/taskjobs/dstone/?suite=mob_transpose