### PR TITLE
All config values less than 1e30

### DIFF
--- a/src/orca-jedi/increment/Increment.cc
+++ b/src/orca-jedi/increment/Increment.cc
@@ -39,7 +39,7 @@
 #include "atlas-orca/grid/OrcaGrid.h"
 
 #define INCREMENT_FILL_TOL 1e-6
-#define INCREMENT_FILL_VALUE 1e30
+#define INCREMENT_FILL_VALUE 1e27
 
 namespace orcamodel {
 

--- a/src/tests/testinput/3dvar_sic.yaml
+++ b/src/tests/testinput/3dvar_sic.yaml
@@ -30,7 +30,7 @@ cost function:
           - groups:
             - ice_area_fraction 
             value: 10
-      msvalr: 1e30
+      msvalr: 1e27
     saber outer blocks:
     - saber block name: BUMP_StdDev
       read:
@@ -47,7 +47,7 @@ cost function:
           - variables:
             - ice_area_fraction
             value: 1
-      msvalr: 1e30
+      msvalr: 1e27
   geometry: &Geom
     nemo variables:
       - name: ice_area_fraction
@@ -113,7 +113,7 @@ variational:
     algorithm: DRPCG
   iterations:
   - ninner: 1
-    gradient norm reduction: 1e-30
+    gradient norm reduction: 1e-27
     geometry: *Geom
     test: on
     online diagnostics:

--- a/src/tests/testinput/3dvar_sic_identity.yaml
+++ b/src/tests/testinput/3dvar_sic_identity.yaml
@@ -73,7 +73,7 @@ variational:
     algorithm: DRPCG
   iterations:
   - ninner: 1
-    gradient norm reduction: 1e-30
+    gradient norm reduction: 1e-27
     geometry: *Geom
     test: on
     online diagnostics:

--- a/src/tests/testinput/bump_nicas_setup.yaml
+++ b/src/tests/testinput/bump_nicas_setup.yaml
@@ -34,7 +34,7 @@ background error:
         - groups:
           - ice_area_fraction 
           value: 10
-      msvalr: 1e30
+      msvalr: 1e27
 background:
   date: '2021-06-30T12:00:00Z'
   state variables: &vars [ ice_area_fraction ]

--- a/src/tests/testinput/dirac.yaml
+++ b/src/tests/testinput/dirac.yaml
@@ -25,7 +25,7 @@ background error:
         - groups:
           - ice_area_fraction 
           value: 10
-      msvalr: 1e30
+      msvalr: 1e27
   saber outer blocks:
   - saber block name: BUMP_StdDev
     read:
@@ -42,7 +42,7 @@ background error:
         - variables:
           - ice_area_fraction
           value: 1
-      msvalr: 1e30
+      msvalr: 1e27
 
 dirac:
   x indices: [20]


### PR DESCRIPTION
## Description

Make all missing value indicators and other values representable by float for safety.

[Manual mo-bundle ci](https://github.com/MetOffice/mo-bundle/actions/runs/14495262747/job/40661251840#step:5:6372) testing suggests this fixes an issue with tests in https://github.com/JCSDA-internal/ufo/pull/3673 but we would need to merge and rerun to confirm.

My theory is that on some systems there is an underlying function that is trying to do float operations with `1e30`. This might cause overflows and unpredictable results. Its hard for us to check though as we only seem to see these failures on our CI systems.

I want to make this change anyway, as it has no downside and seems sensible to me as, at a minimum, you can use the same missing data indicator for double and float data.

## Issue(s) addressed

Resolves #131 

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] New functions are documented briefly via Doxygen comments in the code
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [ ] I have run [mo-bundle](https://cylchub/services/cylc-review/taskjobs/toby.searle/?suite=mobb-oj135) to check integration with the rest of JEDI and run the unit tests under all environments
