### PR TITLE
Remove hack in CostJo

### DIFF
--- a/src/tests/testoutput/test_3dvar_sic.ref
+++ b/src/tests/testoutput/test_3dvar_sic.ref
@@ -1,3 +1,4 @@
+CostJo   : Nonlinear Jo(Sea Ice) = 1.4687500000000000e+00, nobs = 47, Jo/n = 3.1250000000000000e-02, err = 2.0000000000000000e+00
        Independent levels:  1[1]
           Subset Sc0 size:            26460
           Domain area (% of Earth area): 0.100E+03%
@@ -9,7 +10,6 @@
              Level   1 ~> 100.0%
              Level   1 ~>  0.100E+01 vert. coord.
 CostJb   : Nonlinear Jb = 0.0000000000000000e+00
-CostJo   : Nonlinear Jo(Sea Ice) = 1.4687500000000000e+00, nobs = 47, Jo/n = 3.1250000000000000e-02, err = 2.0000000000000000e+00
 CostFunction: Nonlinear J = 1.4687500000000000e+00
 DRPCGMinimizer: reduction in residual norm = 1.4155891817936023e+02
 CostFunction::addIncrement: Analysis: 
@@ -18,9 +18,6 @@ CostFunction::addIncrement: Analysis:
     atlas field norms:
         ice_area_fraction: 3.16815e-03
 
-
-
-
-CostJb   : Nonlinear Jb = 0.00000e+00
 CostJo   : Nonlinear Jo(Sea Ice) = 7.87621e-01, nobs = 47, Jo/n = 1.67579e-02, err = 2.00000e+00
+CostJb   : Nonlinear Jb = 0.00000e+00
 CostFunction: Nonlinear J = 7.87621e-01

--- a/src/tests/testoutput/test_3dvar_sic_identity.ref
+++ b/src/tests/testoutput/test_3dvar_sic_identity.ref
@@ -1,5 +1,5 @@
-CostJb   : Nonlinear Jb = 0.0000000000000000e+00
 CostJo   : Nonlinear Jo(Sea Ice) = 1.4687500000000000e+00, nobs = 47, Jo/n = 3.1250000000000000e-02, err = 2.0000000000000000e+00
+CostJb   : Nonlinear Jb = 0.0000000000000000e+00
 CostFunction: Nonlinear J = 1.4687500000000000e+00
 DRPCGMinimizer: reduction in residual norm = 7.2399282392205355e-01
 CostFunction::addIncrement: Analysis: 
@@ -8,9 +8,6 @@ CostFunction::addIncrement: Analysis:
     atlas field norms:
         ice_area_fraction: 3.20155e-03
 
-
-
-
-CostJb   : Nonlinear Jb = 0.00000e+00
 CostJo   : Nonlinear Jo(Sea Ice) = 1.10491e+00, nobs = 47, Jo/n = 2.35087e-02, err = 2.00000e+00
+CostJb   : Nonlinear Jb = 0.00000e+00
 CostFunction: Nonlinear J = 1.10491e+00


### PR DESCRIPTION
## Description

Update to the KGO due to a code refactor in OOPS where a previous "hack" had been added. See https://github.com/JCSDA-internal/oops/pull/2913 for details.

Tested the change via mo-bundle: `./bin/bbb play "test_rmjohack" -z TASKS=all_ctest` and the outputs are here: [test_rmjohack](https://cylchub/services/cylc-review/cycles/Steven.Sandbach/?suite=test_rmjohack).

I have setup a full clean run in the same way and output will be here: [test_rmjohack2](https://cylchub/services/cylc-review/cycles/Steven.Sandbach/?suite=test_rmjohack2)

## Dependencies

List the other PRs that this PR is dependent on:

- [ ] JCSDA-internal/oops#2913
- [ ] JCSDA-internal/lfric-jedi#1066
- [ ] metoffice/jjtests#82

build-group=JCSDA-internal/oops#2913
build-group=JCSDA-internal/lfric-jedi#1066
build-group=metoffice/jjtests#82

## Impact

None as this is just an update to diagnostic print

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
