### PR TITLE
Swap order of levels and locations in interpolator result array

### DIFF
--- a/src/orca-jedi/geometry/Geometry.cc
+++ b/src/orca-jedi/geometry/Geometry.cc
@@ -186,9 +186,9 @@ void Geometry::create_extrafields() {
       << std::endl;
   extraFields_->add(hmask);
 
-  // Create geometry mask or gmask.
+  // Create horizontal geometry mask or gmask.
   atlas::Field gmask = funcSpace_.createField<int32_t>(
-    atlas::option::name("gmask") | atlas::option::levels(n_levels_));
+    atlas::option::name("gmask") | atlas::option::levels(1));
 
   auto field_view2 = atlas::array::make_view<int32_t, 2>(gmask);
   for (atlas::idx_t j = 0; j < field_view2.shape(0); ++j) {
@@ -227,7 +227,7 @@ void Geometry::create_extrafields() {
 }
 
 // -----------------------------------------------------------------------------
-/// \brief Give the number of levels for each provided level - surface variables
+/// \brief Give the number of levels for each provided variable - surface variables
 ///        have 1 level, volumetric variables have "number levels" levels.
 /// \param[in]     vars  variables to check.
 /// \return        vector of number of levels in each variable.
@@ -391,6 +391,18 @@ void Geometry::set_gmask(atlas::Field & field) const {
     using T = decltype(typeVal);
     auto field_viewin = atlas::array::make_view<T, 2>(field);
     auto field_viewgm = atlas::array::make_view<int32_t, 2>(gmask);
+    {
+      std::stringstream ss;
+      ss << "orcamodel::Geometry::set_gmask field and gmask shape dim 0 do not match: "
+         << field_viewin.shape(0) << " != " << field_viewgm.shape(0);
+      ASSERT_MSG(field_viewgm.shape(0) == field_viewin.shape(0), ss.str());
+    }
+    {
+      std::stringstream ss;
+      ss << "orcamodel::Geometry::set_gmask field and gmask shape dim 1 do not match: "
+         << field_viewin.shape(1) << " != " << field_viewgm.shape(1);
+      ASSERT_MSG(field_viewgm.shape(1) == field_viewin.shape(1), ss.str());
+    }
     if (has_mv) {
       for (atlas::idx_t j = 0; j < field_viewgm.shape(0); ++j) {
         for (atlas::idx_t k = 0; k < field_viewgm.shape(1); ++k) {

--- a/src/orca-jedi/geometry/Geometry.h
+++ b/src/orca-jedi/geometry/Geometry.h
@@ -75,6 +75,7 @@ class Geometry : public util::Printable {
   std::shared_ptr<eckit::Timer> timer() const {return eckit_timer_;}
   void log_status() const;
   void set_gmask(atlas::Field &) const;
+  const size_t n_levels() const {return n_levels_;}
 
  private:
   void print(std::ostream &) const;

--- a/src/orca-jedi/geometry/Geometry.h
+++ b/src/orca-jedi/geometry/Geometry.h
@@ -75,7 +75,6 @@ class Geometry : public util::Printable {
   std::shared_ptr<eckit::Timer> timer() const {return eckit_timer_;}
   void log_status() const;
   void set_gmask(atlas::Field &) const;
-  const size_t n_levels() const {return n_levels_;}
 
  private:
   void print(std::ostream &) const;

--- a/src/orca-jedi/interpolator/Interpolator.cc
+++ b/src/orca-jedi/interpolator/Interpolator.cc
@@ -34,7 +34,7 @@ namespace orcamodel {
 
 atlas::functionspace::PointCloud atlasObsFuncSpaceFactory(
     const std::vector<double>& lats, const std::vector<double>& lons) {
-  size_t nlocs = lats.size();
+  const size_t nlocs = lats.size();
 
   // Setup observation functionspace
   oops::Log::trace() << "orcamodel::Interpolator:: creating "
@@ -125,7 +125,7 @@ void Interpolator::apply(const oops::Variables& vars, const State& state,
 /// \param iter Reference to the interator into the output vector.
 template <class T>
 void Interpolator::executeInterpolation(
-    const std::string& gv_varname, size_t var_size, const State& state,
+    const std::string& gv_varname, const size_t var_size, const State& state,
     const std::vector<bool>& mask, std::vector<double>::iterator& iter) const {
   atlas::Field tgt_field = atlasObsFuncSpace_.createField<T>(
       atlas::option::name(gv_varname) | atlas::option::levels(var_size));
@@ -134,24 +134,27 @@ void Interpolator::executeInterpolation(
   atlas::field::MissingValue mv(state.stateFields()[gv_varname]);
   bool has_mv = static_cast<bool>(mv);
   for (std::size_t iloc = 0; iloc < nlocs_; iloc++) {
-    for (std::size_t klev = 0; klev < var_size; ++klev) {
-      if (mask[iloc]) {
+    if (mask[iloc]) {
+      for (std::size_t klev = 0; klev < var_size; ++klev) {
         if (has_mv && mv(field_view(iloc, klev))) {
           *iter = util::missingValue<double>();
         } else {
           *iter = static_cast<double>(field_view(iloc, klev));
         }
+        std::advance(iter, 1);
       }
-      ++iter;
+    } else {
+      // skip past elements not required according to the mask.
+      std::advance(iter, var_size);
     }
   }
 }
 
 template void Interpolator::executeInterpolation<double>(
-    const std::string& gv_varname, size_t var_size, const State& state,
+    const std::string& gv_varname, const size_t var_size, const State& state,
     const std::vector<bool>& mask, std::vector<double>::iterator& iter) const;
 template void Interpolator::executeInterpolation<float>(
-    const std::string& gv_varname, size_t var_size, const State& state,
+    const std::string& gv_varname, const size_t var_size, const State& state,
     const std::vector<bool>& mask, std::vector<double>::iterator& iter) const;
 
 /// \brief Interpolate from model space to observation space
@@ -162,7 +165,6 @@ template void Interpolator::executeInterpolation<float>(
 void Interpolator::apply(const oops::Variables& vars, const Increment& inc,
                          const std::vector<bool>& mask,
                          std::vector<double>& result) const {
-  // input is inc output is result
   const size_t nvars = vars.size();
 
   for (size_t j = 0; j < nvars; ++j) {
@@ -214,8 +216,6 @@ void Interpolator::apply(const oops::Variables& vars, const Increment& inc,
 void Interpolator::applyAD(const oops::Variables& vars, Increment& inc,
                            const std::vector<bool>& mask,
                            const std::vector<double>& resultin) const {
-  // input is resultin output is inc
-
   oops::Log::trace() << "orcamodel::Interpolator::applyAD start " << std::endl;
 
   const size_t nvars = vars.size();

--- a/src/orca-jedi/interpolator/Interpolator.cc
+++ b/src/orca-jedi/interpolator/Interpolator.cc
@@ -2,100 +2,86 @@
  * (C) British Crown Copyright 2024 Met Office
  */
 
+#include "orca-jedi/interpolator/Interpolator.h"
+
 #include <cstddef>
 #include <fstream>
 #include <memory>
 #include <ostream>
-#include <string>
 #include <sstream>
-#include <vector>
+#include <string>
 #include <utility>
+#include <vector>
 
+#include "atlas/field/MissingValue.h"
+#include "atlas/functionspace.h"
+#include "atlas/interpolation.h"
 #include "eckit/config/Configuration.h"
 #include "eckit/config/LocalConfiguration.h"
 #include "eckit/exception/Exceptions.h"
-
-#include "atlas/interpolation.h"
-#include "atlas/functionspace.h"
-#include "atlas/field/MissingValue.h"
-
-#include "oops/util/DateTime.h"
 #include "oops/util/Logger.h"
-#include "oops/util/ObjectCounter.h"
 #include "oops/util/Printable.h"
 #include "oops/util/missingValues.h"
-
 #include "orca-jedi/geometry/Geometry.h"
-#include "orca-jedi/state/State.h"
 #include "orca-jedi/increment/Increment.h"
-
-#include "orca-jedi/interpolator/Interpolator.h"
-
-namespace eckit {
-class Configuration;
-}
+#include "orca-jedi/state/State.h"
 
 namespace ufo {
 class GeoVaLs;
 }
 
 namespace orcamodel {
-class State;
-class Geometry;
 
 atlas::functionspace::PointCloud atlasObsFuncSpaceFactory(
-    const std::vector<double>& lats,
-    const std::vector<double>& lons) {
-    size_t nlocs = lats.size();
+    const std::vector<double>& lats, const std::vector<double>& lons) {
+  size_t nlocs = lats.size();
 
-    // Setup observation functionspace
-    oops::Log::trace() << "orcamodel::Interpolator:: creating "
-                       << "atlasObsFuncSpace with nlocs = " << nlocs
-                       << std::endl;
-    atlas::Field points("lonlat", atlas::array::make_datatype<double>(),
-        atlas::array::make_shape(nlocs, 2));
-    auto arrv_t = atlas::array::make_view<double, 2>(points);
-    for (unsigned int j = 0; j < nlocs; ++j) {
-      arrv_t(j, 1) = lats[j];
-      arrv_t(j, 0) = lons[j];
-    }
-    oops::Log::trace() << "orcamodel::Interpolator:: creating "
-                       << "atlasObsFuncSpace ... done" << std::endl;
-     return atlas::functionspace::PointCloud(std::move(points));
+  // Setup observation functionspace
+  oops::Log::trace() << "orcamodel::Interpolator:: creating "
+                     << "atlasObsFuncSpace with nlocs = " << nlocs << std::endl;
+  atlas::Field points("lonlat", atlas::array::make_datatype<double>(),
+                      atlas::array::make_shape(nlocs, 2));
+  auto arrv_t = atlas::array::make_view<double, 2>(points);
+  for (unsigned int j = 0; j < nlocs; ++j) {
+    arrv_t(j, 1) = lats[j];
+    arrv_t(j, 0) = lons[j];
+  }
+  oops::Log::trace() << "orcamodel::Interpolator:: creating "
+                     << "atlasObsFuncSpace ... done" << std::endl;
+  return atlas::functionspace::PointCloud(std::move(points));
 }
 
-Interpolator::Interpolator(const eckit::Configuration & conf,
-    const Geometry & geom, const std::vector<double>& lats,
-    const std::vector<double>& lons) :
-    nlocs_(lats.size()),
-    atlasObsFuncSpace_(atlasObsFuncSpaceFactory(lats, lons)),
-    interpolator_(eckit::LocalConfiguration(conf, "atlas-interpolator"),
-                  geom.functionSpace(),
-                  atlasObsFuncSpace_),
-    comm_(geom.getComm()) {
+Interpolator::Interpolator(const eckit::Configuration& conf,
+                           const Geometry& geom,
+                           const std::vector<double>& lats,
+                           const std::vector<double>& lons)
+    : nlocs_(lats.size()),
+      atlasObsFuncSpace_(atlasObsFuncSpaceFactory(lats, lons)),
+      interpolator_(eckit::LocalConfiguration(conf, "atlas-interpolator"),
+                    geom.functionSpace(), atlasObsFuncSpace_),
+      comm_(geom.getComm()) {
   params_.validateAndDeserialize(conf);
-  oops::Log::trace() << "orcamodel::Interpolator:: conf:" << conf
-                     << std::endl;
+  oops::Log::trace() << "orcamodel::Interpolator:: conf:" << conf << std::endl;
   if (nlocs_ == 0) {
     oops::Log::trace() << "orcamodel::Interpolator:: nlocs == 0" << std::endl;
   }
 }
 
 void Interpolator::apply(const oops::Variables& vars, const State& state,
-    const std::vector<bool> & mask,
-    std::vector<double>& result) const {
+                         const std::vector<bool>& mask,
+                         std::vector<double>& result) const {
   oops::Log::trace() << "[" << comm_.rank()
                      << "] orcamodel::Interpolator::apply starting "
                      << std::endl;
 
   const size_t nvars = vars.size();
 
-  for (size_t j=0; j < nvars; ++j) {
+  for (size_t j = 0; j < nvars; ++j) {
     if (!state.variables().has(vars[j].name())) {
       std::stringstream err_stream;
       err_stream << "orcamodel::Interpolator::apply varname \" "
-                 << "\" " << vars[j].name()
-                 << " not found in the model state." << std::endl;
+                 << "\" " << vars[j].name() << " not found in the model state."
+                 << std::endl;
       err_stream << "    add the variable to the state variables and "
                  << "add a mapping from the geometry to that variable."
                  << std::endl;
@@ -103,12 +89,11 @@ void Interpolator::apply(const oops::Variables& vars, const State& state,
     }
   }
 
-  const std::vector<size_t> varSizes =
-    state.geometry()->variableSizes(vars);
+  const std::vector<size_t> varSizes = state.geometry()->variableSizes(vars);
   oops::Log::debug() << "orcamodel::Interpolator::apply nvars = " << nvars
                      << " nlocs_ = " << nlocs_;
   size_t nvals = 0;
-  for (size_t jvar=0; jvar < nvars; ++jvar) {
+  for (size_t jvar = 0; jvar < nvars; ++jvar) {
     nvals += nlocs_ * varSizes[jvar];
     oops::Log::debug() << " varSizes[" << jvar << "] = " << varSizes[jvar];
   }
@@ -116,20 +101,20 @@ void Interpolator::apply(const oops::Variables& vars, const State& state,
   result.resize(nvals);
 
   auto res_iter = result.begin();
-  for (size_t jvar=0; jvar < nvars; ++jvar) {
+  for (size_t jvar = 0; jvar < nvars; ++jvar) {
     const auto execute = [&](auto typeVal) {
       using T = decltype(typeVal);
-      executeInterpolation<T>(vars[jvar].name(), varSizes[jvar], state, mask, res_iter);
+      executeInterpolation<T>(vars[jvar].name(), varSizes[jvar], state, mask,
+                              res_iter);
     };
 
     ApplyForFieldType(execute,
                       state.geometry()->fieldPrecision(vars[jvar].name()),
-                      std::string("orcamodel::Interpolator::apply '")
-                        + vars[jvar].name() + "' field type not recognised");
+                      std::string("orcamodel::Interpolator::apply '") +
+                          vars[jvar].name() + "' field type not recognised");
   }
   ASSERT(result.size() == nvals);
-  oops::Log::trace() << "orcamodel::Interpolator::apply done "
-                     << std::endl;
+  oops::Log::trace() << "orcamodel::Interpolator::apply done " << std::endl;
 }
 
 /// \brief Execute the atlas interpolation on a single field.
@@ -138,22 +123,19 @@ void Interpolator::apply(const oops::Variables& vars, const State& state,
 /// \param state The state object containing the model state.
 /// \param mask The locations where the interpolant should be set.
 /// \param iter Reference to the interator into the output vector.
-template<class T> void Interpolator::executeInterpolation(
-    const std::string& gv_varname,
-    size_t var_size,
-    const State& state,
-    const std::vector<bool> & mask,
-    std::vector<double>::iterator& iter) const {
+template <class T>
+void Interpolator::executeInterpolation(
+    const std::string& gv_varname, size_t var_size, const State& state,
+    const std::vector<bool>& mask, std::vector<double>::iterator& iter) const {
   atlas::Field tgt_field = atlasObsFuncSpace_.createField<T>(
-      atlas::option::name(gv_varname) |
-      atlas::option::levels(var_size));
+      atlas::option::name(gv_varname) | atlas::option::levels(var_size));
   interpolator_.execute(state.stateFields()[gv_varname], tgt_field);
   auto field_view = atlas::array::make_view<T, 2>(tgt_field);
   atlas::field::MissingValue mv(state.stateFields()[gv_varname]);
   bool has_mv = static_cast<bool>(mv);
-  for (std::size_t klev=0; klev < var_size; ++klev) {
-    for (std::size_t iloc=0; iloc < nlocs_; iloc++) {
-      if ( mask[iloc] ) {
+  for (std::size_t iloc = 0; iloc < nlocs_; iloc++) {
+    for (std::size_t klev = 0; klev < var_size; ++klev) {
+      if (mask[iloc]) {
         if (has_mv && mv(field_view(iloc, klev))) {
           *iter = util::missingValue<double>();
         } else {
@@ -166,17 +148,11 @@ template<class T> void Interpolator::executeInterpolation(
 }
 
 template void Interpolator::executeInterpolation<double>(
-    const std::string& gv_varname,
-    size_t var_size,
-    const State& state,
-    const std::vector<bool> & mask,
-    std::vector<double>::iterator& iter) const;
+    const std::string& gv_varname, size_t var_size, const State& state,
+    const std::vector<bool>& mask, std::vector<double>::iterator& iter) const;
 template void Interpolator::executeInterpolation<float>(
-    const std::string& gv_varname,
-    size_t var_size,
-    const State& state,
-    const std::vector<bool> & mask,
-    std::vector<double>::iterator& iter) const;
+    const std::string& gv_varname, size_t var_size, const State& state,
+    const std::vector<bool>& mask, std::vector<double>::iterator& iter) const;
 
 /// \brief Interpolate from model space to observation space
 /// \param vars Oops variables
@@ -184,17 +160,17 @@ template void Interpolator::executeInterpolation<float>(
 /// \param mask Mask vector in observation space
 /// \param result Result (output) vector in observation space
 void Interpolator::apply(const oops::Variables& vars, const Increment& inc,
-           const std::vector<bool> & mask,
-           std::vector<double>& result) const {
+                         const std::vector<bool>& mask,
+                         std::vector<double>& result) const {
   // input is inc output is result
   const size_t nvars = vars.size();
 
-  for (size_t j=0; j < nvars; ++j) {
+  for (size_t j = 0; j < nvars; ++j) {
     if (!inc.variables().has(vars[j])) {
       std::stringstream err_stream;
       err_stream << "orcamodel::Interpolator::apply varname \" "
-                 << "\" " << vars[j]
-                 << " not found in the model increment." << std::endl;
+                 << "\" " << vars[j] << " not found in the model increment."
+                 << std::endl;
       err_stream << "    add the variable to the increment variables and "
                  << "add a mapping from the geometry to that variable."
                  << std::endl;
@@ -202,14 +178,13 @@ void Interpolator::apply(const oops::Variables& vars, const Increment& inc,
     }
   }
 
-  const std::vector<size_t> varSizes =
-    inc.geometry()->variableSizes(vars);
+  const std::vector<size_t> varSizes = inc.geometry()->variableSizes(vars);
   size_t nvals = 0;
-  for (size_t jvar=0; jvar < nvars; ++jvar) nvals += nlocs_ * varSizes[jvar];
+  for (size_t jvar = 0; jvar < nvars; ++jvar) nvals += nlocs_ * varSizes[jvar];
   result.resize(nvals);
 
   std::size_t out_idx = 0;
-  for (size_t jvar=0; jvar < nvars; ++jvar) {
+  for (size_t jvar = 0; jvar < nvars; ++jvar) {
     auto gv_varname = vars[jvar].name();
     atlas::Field tgt_field = atlasObsFuncSpace_.createField<double>(
         atlas::option::name(gv_varname) |
@@ -218,8 +193,8 @@ void Interpolator::apply(const oops::Variables& vars, const Increment& inc,
     auto field_view = atlas::array::make_view<double, 2>(tgt_field);
     atlas::field::MissingValue mv(inc.incrementFields()[gv_varname]);
     bool has_mv = static_cast<bool>(mv);
-    for (std::size_t klev=0; klev < varSizes[jvar]; ++klev) {
-      for (std::size_t iloc=0; iloc < nlocs_; iloc++) {
+    for (std::size_t iloc = 0; iloc < nlocs_; iloc++) {
+      for (std::size_t klev = 0; klev < varSizes[jvar]; ++klev) {
         if (has_mv && mv(field_view(iloc, klev))) {
           result[out_idx] = util::missingValue<double>();
         } else {
@@ -237,22 +212,20 @@ void Interpolator::apply(const oops::Variables& vars, const Increment& inc,
 /// \param mask Mask (observation space) vector
 /// \param resultin Values (observation space) vector (input)
 void Interpolator::applyAD(const oops::Variables& vars, Increment& inc,
-             const std::vector<bool> & mask,
-             const std::vector<double> & resultin) const
-{
+                           const std::vector<bool>& mask,
+                           const std::vector<double>& resultin) const {
   // input is resultin output is inc
 
-  oops::Log::trace() << "orcamodel::Interpolator::applyAD start "
-                     << std::endl;
+  oops::Log::trace() << "orcamodel::Interpolator::applyAD start " << std::endl;
 
   const size_t nvars = vars.size();
 
-  for (size_t j=0; j < nvars; ++j) {
+  for (size_t j = 0; j < nvars; ++j) {
     if (!inc.variables().has(vars[j])) {
       std::stringstream err_stream;
       err_stream << "orcamodel::Interpolator::apply varname \" "
-                 << "\" " << vars[j]
-                 << " not found in the model increment." << std::endl;
+                 << "\" " << vars[j] << " not found in the model increment."
+                 << std::endl;
       err_stream << "    add the variable to the increment variables and "
                  << "add a mapping from the geometry to that variable."
                  << std::endl;
@@ -260,47 +233,43 @@ void Interpolator::applyAD(const oops::Variables& vars, Increment& inc,
     }
   }
 
-  const std::vector<size_t> varSizes =
-    inc.geometry()->variableSizes(vars);
-  size_t nvals = 0;
-
-  for (size_t jvar=0; jvar < nvars; ++jvar) nvals += nlocs_ * varSizes[jvar];
+  const std::vector<size_t> varSizes = inc.geometry()->variableSizes(vars);
 
   std::size_t out_idx = 0;
-  for (size_t jvar=0; jvar < nvars; ++jvar) {
+  for (size_t jvar = 0; jvar < nvars; ++jvar) {
     auto gv_varname = vars[jvar].name();
     auto tgt_field = atlasObsFuncSpace_.createField<double>(
-      atlas::option::name(gv_varname) |
-      atlas::option::levels(varSizes[jvar]));
+        atlas::option::name(gv_varname) |
+        atlas::option::levels(varSizes[jvar]));
 
-// Copying observation array vector to an atlas observation field (tgt_field)
+    // Copying observation array vector to an atlas observation field
+    // (tgt_field)
     auto field_view = atlas::array::make_view<double, 2>(tgt_field);
     atlas::field::MissingValue mv(inc.incrementFields()[gv_varname]);
     bool has_mv = static_cast<bool>(mv);
 
-    for (std::size_t klev=0; klev < varSizes[jvar]; ++klev) {
-      for (std::size_t iloc=0; iloc < nlocs_; iloc++) {
-          if (has_mv && mv(field_view(iloc, klev))) {
-             field_view(iloc, klev) = util::missingValue<double>();
-          } else {
-             field_view(iloc, klev) = resultin[out_idx];
-          }
+    for (std::size_t iloc = 0; iloc < nlocs_; iloc++) {
+      for (std::size_t klev = 0; klev < varSizes[jvar]; ++klev) {
+        if (has_mv && mv(field_view(iloc, klev))) {
+          field_view(iloc, klev) = util::missingValue<double>();
+        } else {
+          field_view(iloc, klev) = resultin[out_idx];
+        }
         ++out_idx;
       }
     }
 
-// halo exchange update ghost points
+    // halo exchange update ghost points
     std::shared_ptr<const Geometry> geom = inc.geometry();
     geom->functionSpace().haloExchange(inc.incrementFields()[gv_varname]);
 
     interpolator_.execute_adjoint(inc.incrementFields()[gv_varname], tgt_field);
-  }    // jvar
+  }  // jvar
 
-  oops::Log::trace() << "orcamodel::Interpolator::applyAD done "
-                     << std::endl;
+  oops::Log::trace() << "orcamodel::Interpolator::applyAD done " << std::endl;
 }
 
-void Interpolator::print(std::ostream & os) const {
+void Interpolator::print(std::ostream& os) const {
   os << "orcamodel::Interpolator: " << std::endl;
   os << "  Obs function space " << atlasObsFuncSpace_ << std::endl;
   os << "  Interpolator " << interpolator_ << std::endl;

--- a/src/orca-jedi/interpolator/Interpolator.h
+++ b/src/orca-jedi/interpolator/Interpolator.h
@@ -10,23 +10,19 @@
 #include <string>
 #include <vector>
 
+#include "atlas/functionspace.h"
+#include "atlas/interpolation.h"
 #include "eckit/config/Configuration.h"
 #include "eckit/config/LocalConfiguration.h"
-#include "eckit/mpi/Comm.h"
 #include "eckit/exception/Exceptions.h"
-
-#include "atlas/interpolation.h"
-#include "atlas/functionspace.h"
-
+#include "eckit/mpi/Comm.h"
 #include "oops/util/DateTime.h"
 #include "oops/util/Logger.h"
 #include "oops/util/ObjectCounter.h"
 #include "oops/util/Printable.h"
-
-#include "orca-jedi/interpolator/InterpolatorParameters.h"
 #include "orca-jedi/geometry/Geometry.h"
+#include "orca-jedi/interpolator/InterpolatorParameters.h"
 #include "orca-jedi/state/State.h"
-
 
 namespace eckit {
 class Configuration;
@@ -38,45 +34,41 @@ class Geometry;
 class Increment;
 
 atlas::functionspace::PointCloud atlasObsFuncSpaceFactory(
-    const std::vector<double> & locs);
+    const std::vector<double>& locs);
 
 class Interpolator : public util::Printable,
-  private util::ObjectCounter<Interpolator> {
+                     private util::ObjectCounter<Interpolator> {
  public:
-  static const std::string classname() {return "orcamodel::Interpolator";}
+  static const std::string classname() { return "orcamodel::Interpolator"; }
 
   // Parameters will not work properly until support added to oops getvalues
   // typedef OrcaInterpolatorParameters Parameters_;
 
-  Interpolator(const eckit::Configuration & conf, const Geometry & geom,
-      const std::vector<double>& lats, const std::vector<double>& lons);
+  Interpolator(const eckit::Configuration& conf, const Geometry& geom,
+               const std::vector<double>& lats,
+               const std::vector<double>& lons);
 
   virtual ~Interpolator() {}
 
   void apply(const oops::Variables& vars, const State& state,
-             const std::vector<bool> & mask,
-             std::vector<double>& result) const;
+             const std::vector<bool>& mask, std::vector<double>& result) const;
   void apply(const oops::Variables& vars, const Increment& inc,
-             const std::vector<bool> & mask,
-             std::vector<double>& result) const;
+             const std::vector<bool>& mask, std::vector<double>& result) const;
   void applyAD(const oops::Variables& vars, Increment& inc,
-               const std::vector<bool> & mask,
-               const std::vector<double> &) const;
+               const std::vector<bool>& mask, const std::vector<double>&) const;
 
  private:
-  template<class T> void executeInterpolation(
-      const std::string& gv_varname,
-      size_t var_size,
-      const State& state,
-      const std::vector<bool> & mask,
-      std::vector<double>::iterator& result) const;
-  void print(std::ostream &) const override;
-  int64_t nlocs_;
+  template <class T>
+  void executeInterpolation(const std::string& gv_varname, size_t var_size,
+                            const State& state, const std::vector<bool>& mask,
+                            std::vector<double>::iterator& result) const;
+  void print(std::ostream&) const override;
+  std::size_t nlocs_;
   atlas::functionspace::PointCloud atlasObsFuncSpace_;
   atlas::Interpolation interpolator_;
   // Parameters_ params_;
   OrcaInterpolatorParameters params_;
-  const eckit::mpi::Comm & comm_;
+  const eckit::mpi::Comm& comm_;
 };
 
 }  // namespace orcamodel

--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -84,7 +84,8 @@ State::State(const Geometry & geom,
          stateFields_);
     nemo_file_name = params.errorFieldFile.value().value_or("");
     if (params_.setGmask.value().value_or(false)) {
-      // Using the mask from a surface variable to set the geometry extrafields gmask as 3D masks are not fully supported.
+      // Using the mask from a surface variable to set the geometry extrafields gmask
+      //  as 3D masks are not fully supported.
       for (auto & field : stateFields_) {
         if (static_cast<size_t>(field.shape(1)) == 1) {
           geom.set_gmask(field);

--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -84,8 +84,13 @@ State::State(const Geometry & geom,
          stateFields_);
     nemo_file_name = params.errorFieldFile.value().value_or("");
     if (params_.setGmask.value().value_or(false)) {
-      // Using the mask from the first state field to set geometry extrafields gmask.
-      geom.set_gmask(stateFields_[0]);
+      // Using the mask from a surface variable to set the geometry extrafields gmask as 3D masks are not fully supported.
+      for (auto & field : stateFields_) {
+        if (static_cast<size_t>(field.shape(1)) == 1) {
+          geom.set_gmask(field);
+          break;
+        }
+      }
     }
     if (params.errorFieldFile.value()) {
       readFieldsFromFile(nemo_file_name, *geom_, validTime(), "background error standard deviation",
@@ -138,7 +143,7 @@ State::~State() {
 void State::subsetFieldSet(const oops::Variables & variables) {
   oops::Log::trace() << "State(ORCA)::subsetFieldSet subsetting." << std::endl;
   atlas::FieldSet subset;
-  for (int iVar = 0; iVar < variables.size(); iVar++) {
+  for (size_t iVar = 0; iVar < variables.size(); iVar++) {
     auto variable = variables[iVar].name();
     if (!stateFields_.has(variable)) {
       throw eckit::BadValue("State(ORCA)::subsetFieldSet '"
@@ -149,7 +154,7 @@ void State::subsetFieldSet(const oops::Variables & variables) {
 
   stateFields_.clear();
 
-  for (int iVar = 0; iVar < variables.size(); iVar++) {
+  for (size_t iVar = 0; iVar < variables.size(); iVar++) {
     auto variable = variables[iVar].name();
     stateFields_.add(subset[variable]);
   }

--- a/src/tests/orca-jedi/test_interpolator.cc
+++ b/src/tests/orca-jedi/test_interpolator.cc
@@ -106,9 +106,9 @@ CASE("test  interpolator") {
     settings_map["ORCA2_T"].vol_vars = oops::Variables{
         {oops::Variable{"sea_water_potential_temperature"}}};
     settings_map["ORCA2_T"].vol_values = std::vector<double>{
-        18.4888877869, missing_value, 18.1592998505,
-        18           , missing_value, 17.7500019073,
-        missing_value, missing_value, missing_value};
+        18.4888877869, 18           , missing_value,
+        missing_value, missing_value, missing_value,
+        18.1592998505, 17.7500019073, missing_value};
   }
 
   // AMM1 settings
@@ -161,9 +161,9 @@ CASE("test  interpolator") {
     settings_map["AMM1"].vol_vars = oops::Variables{
         {oops::Variable{"sea_water_potential_temperature"}}};
     settings_map["AMM1"].vol_values = std::vector<double>{
-        11.9501609802, 13.9884538651, 10.1916904449,
-        11.9500904083, 13.8567619324, 10.1912517548,
-        11.9499549866, 13.7289009094, 10.1908035278};
+        11.9501609802, 11.9500904083, 11.9499549866,
+        13.9884538651, 13.8567619324, 13.7289009094,
+        10.1916904449, 10.1912517548, 10.1908035278};
   }
 
   for (const auto& [key, settings] : settings_map) {

--- a/src/tests/orca-jedi/test_state.cc
+++ b/src/tests/orca-jedi/test_state.cc
@@ -169,9 +169,9 @@ CASE("test basic state") {
         gmask_sum = field_sum;
       }
     }
-    // The sum should be equal to the number of ocean points in the orca2 grid
+    // The sum should be equal to the number of horizontal ocean points in the orca2 grid
     // minus ghost points and some additional masked points needed for BUMP to work.
-    EXPECT(gmask_sum == 264600);
+    EXPECT(gmask_sum == 26460);
   }
 }
 


### PR DESCRIPTION
## Description

OOPs is increasing efficiency by swapping the order of levels and locations in the generation of geovals. This change is a companion change to adapt to the swap.

## Dependencies

build-group=https://github.com/JCSDA-internal/ufo/pull/3726
build-group=https://github.com/JCSDA-internal/oops/pull/2916

## Impact

Minor memory performance improvements expected from the parent change.

## Issues Resolved

Fixes #141 

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] New functions are documented briefly via Doxygen comments in the code
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [x] I have run [mo-bundle](https://cylchub/services/cylc-review/taskjobs/toby.searle/?suite=mobb-oj148) to check integration with the rest of JEDI and run the unit tests under all environments

## Sith testing
 - [ ] [exab_gulf configuration](https://cylchub/services/cylc-review/taskjobs/toby.searle/?&suite=sith_oj148%2Fexab_gulf)
 - [ ] [exab_amm7 configuration](https://cylchub/services/cylc-review/taskjobs/toby.searle/?&suite=sith_oj148%2Fexab_amm7)
 - [ ] [exab_amm15 configuration](https://cylchub/services/cylc-review/taskjobs/toby.searle/?&suite=sith_oj148%2Fexab_amm15)
 - [ ] [exab_ostia configuration](https://cylchub/services/cylc-review/taskjobs/toby.searle/?&suite=sith_oj148%2Fexab_ostia)
 - [ ] [exab_ocnd configuration](https://cylchub/services/cylc-review/taskjobs/toby.searle/?&suite=sith_oj148%2Fexab_ocnd)
 - [ ] [exab_gl_ocn configuration](https://cylchub/services/cylc-review/taskjobs/toby.searle/?&suite=sith_oj148%2Fexab_gl_ocn)