### PR TITLE
oops missing value during inc adjoint interpolate.

### DIFF
--- a/src/orca-jedi/interpolator/Interpolator.cc
+++ b/src/orca-jedi/interpolator/Interpolator.cc
@@ -242,16 +242,25 @@ void Interpolator::applyAD(const oops::Variables& vars, Increment& inc,
         atlas::option::name(gv_varname) |
         atlas::option::levels(varSizes[jvar]));
 
+    // Use the OOPS missing value as the default for increment fields,
+    // however in the future we might need to switch to a value defined in
+    // configuration or read from file, therefore we keep it logically separate
+    // for now.
+    const double inc_default_missing_value = util::missingValue<double>();
+    tgt_field.metadata().set("missing_value", inc_default_missing_value);
+    tgt_field.metadata().set("missing_value_type", "approximately-equals");
+    tgt_field.metadata().set("missing_value_epsilon", 1e-6);
+
     // Copying observation array vector to an atlas observation field
     // (tgt_field)
     auto field_view = atlas::array::make_view<double, 2>(tgt_field);
-    atlas::field::MissingValue mv(inc.incrementFields()[gv_varname]);
+    atlas::field::MissingValue mv(tgt_field);
     bool has_mv = static_cast<bool>(mv);
 
     for (std::size_t iloc = 0; iloc < nlocs_; iloc++) {
       for (std::size_t klev = 0; klev < varSizes[jvar]; ++klev) {
-        if (has_mv && mv(field_view(iloc, klev))) {
-          field_view(iloc, klev) = util::missingValue<double>();
+        if (has_mv && (resultin[out_idx] == util::missingValue<double>())) {
+          field_view(iloc, klev) = inc_default_missing_value;
         } else {
           field_view(iloc, klev) = resultin[out_idx];
         }


### PR DESCRIPTION
## Description

Checking missing values on an unitialised atlas field was causing floating point exceptions under certain debug settings. This points to a deeper issue where the comparison and setting of missing values in the apply adjoint interpolator were not consistent.

For now, I have added a default increment missing value to use during the interpolation, in case any of the data in the source vector (Hx-space data) contains missing values.

In the future, we need to do a more comprehensive cross-jedi pass for missing values handling of increments and 3DVar.

## Issue(s) addressed

Resolves #150

### Testing
 - [x] [exab_gulf configuration](https://cylchub/services/cylc-review/taskjobs/toby.searle/?&suite=sith_oj152%2Fexab_gulf)
 - [x] [exab_amm7 configuration](https://cylchub/services/cylc-review/taskjobs/toby.searle/?&suite=sith_oj152%2Fexab_amm7)
 - [x] [exab_amm15 configuration](https://cylchub/services/cylc-review/taskjobs/toby.searle/?&suite=sith_oj152%2Fexab_amm15)
 - [x] [exab_ostia configuration](https://cylchub/services/cylc-review/taskjobs/toby.searle/?&suite=sith_oj152%2Fexab_ostia)
 - [x] [exab_ocnd configuration](https://cylchub/services/cylc-review/taskjobs/toby.searle/?&suite=sith_oj152%2Fexab_ocnd)
 - [x] [exab_gl_ocn configuration](https://cylchub/services/cylc-review/taskjobs/toby.searle/?&suite=sith_oj152%2Fexab_gl_ocn)

## Checklist

- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [x] I have run [mo-bundle](https://cylchub/services/cylc-review/cycles/toby.searle/?suite=mobb-oj152) to check integration with the rest of JEDI and run the unit tests under all environments
