### PR TITLE
Remove harcoded model traits in model code

### DIFF
--- a/src/mains/orcamodel3DVar.cc
+++ b/src/mains/orcamodel3DVar.cc
@@ -6,7 +6,6 @@
  */
 
 #include "atlas/library/Library.h"
-#include "oops/generic/instantiateModelFactory.h"
 
 #include "oops/runs/Run.h"
 #include "oops/runs/Variational.h"
@@ -22,7 +21,6 @@
 
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
-  oops::instantiateModelFactory<orcamodel::OrcaModelTraits>();
   atlas::Library::instance().initialise();
   saber::instantiateCovarFactory<orcamodel::OrcaModelTraits>();
   ufo::instantiateObsFilterFactory();

--- a/src/mains/orcamodelHofX.cc
+++ b/src/mains/orcamodelHofX.cc
@@ -3,7 +3,6 @@
  */
 
 #include "atlas/library/Library.h"
-#include "oops/generic/instantiateModelFactory.h"
 
 #include "oops/runs/HofX4D.h"
 #include "oops/runs/Run.h"
@@ -18,7 +17,6 @@
 
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
-  oops::instantiateModelFactory<orcamodel::OrcaModelTraits>();
   atlas::Library::instance().initialise();
   ufo::instantiateObsFilterFactory();
 #if defined(NEMO_FEEDBACK_EXISTS)

--- a/src/mains/orcamodelHofX3D.cc
+++ b/src/mains/orcamodelHofX3D.cc
@@ -3,7 +3,6 @@
  */
 
 #include "atlas/library/Library.h"
-#include "oops/generic/instantiateModelFactory.h"
 
 #include "oops/runs/HofX3D.h"
 #include "oops/runs/Run.h"
@@ -18,7 +17,6 @@
 
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
-  oops::instantiateModelFactory<orcamodel::OrcaModelTraits>();
   atlas::Library::instance().initialise();
   ufo::instantiateObsFilterFactory();
 #if defined(NEMO_FEEDBACK_EXISTS)

--- a/src/orca-jedi/CMakeLists.txt
+++ b/src/orca-jedi/CMakeLists.txt
@@ -15,6 +15,7 @@ interpolator/Interpolator.h
 interpolator/Interpolator.cc
 increment/Increment.cc
 increment/Increment.h
+linearmodel/LinearModel.h
 model/ModelBiasCovariance.h
 model/ModelBias.h
 model/ModelBiasIncrement.h

--- a/src/orca-jedi/linearmodel/LinearModel.h
+++ b/src/orca-jedi/linearmodel/LinearModel.h
@@ -1,0 +1,73 @@
+/*
+ * (C) British Crown Copyright 2025 Met Office
+ */
+
+#pragma once
+
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "oops/util/ObjectCounter.h"
+#include "oops/util/Printable.h"
+
+// Forward declarations
+namespace eckit {
+class Configuration;
+}
+
+namespace util {
+class Duration;
+}
+
+namespace orcamodel {
+class Geometry;
+class Increment;
+class ModelBias;
+class ModelBiasIncrement;
+class State;
+
+// -----------------------------------------------------------------------------
+
+/// OrcaModel linearmodel definition.
+/*
+ *  Empty OrcaModel linear model definition to satisfy oops API.
+ */
+
+class LinearModel: public util::Printable,
+                   private util::ObjectCounter<LinearModel> {
+ public:
+  static const std::string classname() {return "orcamodel::LinearModel";}
+  static std::vector<std::string> names() {return {"empty-orcaLinearModel"};}
+
+  LinearModel(const Geometry &, const eckit::Configuration &) {
+    ABORT("LinearModel not implemented");
+  }
+  ~LinearModel() {}
+
+/// Model trajectory computation
+  void setTrajectory(const State &,
+                     State &,
+                     const ModelBias &) {}
+
+/// Run TLM and its adjoint
+  void initializeTL(Increment &) const  {}
+  void stepTL(Increment &, const ModelBiasIncrement &) const  {}
+  void finalizeTL(Increment &) const  {}
+
+  void initializeAD(Increment &) const  {}
+  void stepAD(Increment &, ModelBiasIncrement &) const  {}
+  void finalizeAD(Increment &) const  {}
+
+/// Other utilities
+  const util::Duration & timeResolution() const {return emptyDuration_;}
+  const util::Duration & stepTrajectory() const {return emptyDuration_;}
+
+ private:
+  void print(std::ostream &) const {}
+
+// Data
+  const util::Duration emptyDuration_;
+};
+// -----------------------------------------------------------------------------
+}  // namespace orcamodel

--- a/src/orca-jedi/model/Model.h
+++ b/src/orca-jedi/model/Model.h
@@ -10,7 +10,6 @@
 #include <sstream>
 
 #include "eckit/exception/Exceptions.h"
-#include "oops/interface/ModelBase.h"
 #include "oops/base/Variables.h"
 #include "oops/util/Duration.h"
 #include "oops/util/ObjectCounter.h"
@@ -24,7 +23,6 @@
 
 #include "orca-jedi/geometry/Geometry.h"
 #include "orca-jedi/state/StateParameters.h"
-#include "orca-jedi/utilities/OrcaModelTraits.h"
 
 // Forward declarations
 namespace eckit {
@@ -46,8 +44,7 @@ class OrcaModelParameters : public oops::Parameters {
   /// Model variables
   oops::RequiredParameter<std::vector<OrcaStateParameters>> states{
     "states",
-    "List of configuration options used to initialize the" +
-    " model state at each time step",
+    "List of configuration options used to initialize the model state at each time step",
     this};
 };
 
@@ -58,10 +55,10 @@ class OrcaModelParameters : public oops::Parameters {
  *  OrcaModel nonlinear model definition and configuration parameters.
  */
 
-class Model: public oops::interface::ModelBase<OrcaModelTraits>,
-             private util::ObjectCounter<Model> {
+class Model: public util::Printable, private util::ObjectCounter<Model> {
  public:
   static const std::string classname() {return "orcamodel::Model";}
+  static std::vector<std::string> names() {return {"none"};} // is it needed? no-orca-model?
 
   Model(const Geometry & geom, const eckit::Configuration & conf)
     : tstep_(conf.getString("tstep")), geom_(geom) {

--- a/src/orca-jedi/model/Model.h
+++ b/src/orca-jedi/model/Model.h
@@ -58,7 +58,7 @@ class OrcaModelParameters : public oops::Parameters {
 class Model: public util::Printable, private util::ObjectCounter<Model> {
  public:
   static const std::string classname() {return "orcamodel::Model";}
-  static std::vector<std::string> names() {return {"none"};} // is it needed? no-orca-model?
+  static std::vector<std::string> names() {return {"empty-orcaModel"};}
 
   Model(const Geometry & geom, const eckit::Configuration & conf)
     : tstep_(conf.getString("tstep")), geom_(geom) {

--- a/src/orca-jedi/utilities/OrcaModelTraits.h
+++ b/src/orca-jedi/utilities/OrcaModelTraits.h
@@ -11,6 +11,7 @@
 #include "orca-jedi/interpolator/Interpolator.h"
 #include "orca-jedi/increment/Increment.h"
 
+#include "orca-jedi/linearmodel/LinearModel.h"
 #include "orca-jedi/model/Model.h"
 #include "orca-jedi/model/ModelBias.h"
 #include "orca-jedi/model/ModelBiasIncrement.h"
@@ -38,6 +39,7 @@ struct OrcaModelTraits {
   typedef orcamodel::ModelBiasCovariance       ModelAuxCovariance;
   typedef orcamodel::Model                     Model;
   typedef orcamodel::State                     State;
+  typedef orcamodel::LinearModel               LinearModel;
   typedef orcamodel::VariableChange            VariableChange;
   typedef orcamodel::LinearVariableChange      LinearVariableChange;
   typedef orcamodel::ModelData                 ModelData;

--- a/src/orca-jedi/utilities/OrcaModelTraits.h
+++ b/src/orca-jedi/utilities/OrcaModelTraits.h
@@ -11,6 +11,7 @@
 #include "orca-jedi/interpolator/Interpolator.h"
 #include "orca-jedi/increment/Increment.h"
 
+#include "orca-jedi/model/Model.h"
 #include "orca-jedi/model/ModelBias.h"
 #include "orca-jedi/model/ModelBiasIncrement.h"
 #include "orca-jedi/model/ModelBiasCovariance.h"
@@ -35,6 +36,7 @@ struct OrcaModelTraits {
   typedef orcamodel::ModelBias                 ModelAuxControl;
   typedef orcamodel::ModelBiasIncrement        ModelAuxIncrement;
   typedef orcamodel::ModelBiasCovariance       ModelAuxCovariance;
+  typedef orcamodel::Model                     Model;
   typedef orcamodel::State                     State;
   typedef orcamodel::VariableChange            VariableChange;
   typedef orcamodel::LinearVariableChange      LinearVariableChange;


### PR DESCRIPTION
## Description

Update required by oops API update as documented in jcsda-internal/oops#2961.

This update was applied following the changes in `lfric-jedi` https://github.com/JCSDA-internal/lfric-jedi/pull/1110 but ignoring the specialization for the linear model. An empty LinearModel has been added due to the oops API changes. Although the class is not used, an empty implementation is now required (see: See: https://github.com/JCSDA-internal/oops/pull/2961#issuecomment-3176523367 and response: https://github.com/JCSDA-internal/oops/pull/2961#issuecomment-3185249411 for details). 

Tested via: `cylc vip -n "LFRnoHarCodedTraitC1" -z TASKS=all_ctest` with output [here](https://cylchub/services/cylc-review/cycles/Steven.Sandbach/?suite=LFRnoHarCodedTraitC1%2Frun1). All test have passed - not sure whats going on with cylc review - it shows that some fail but its empty when you click on the failed task.

## Issue(s) addressed

Contributes to jcsda-internal/oops#2932

## Dependencies

build-group=jcsda-internal/oops#2961

Will need to merge all three model interafaces:
- [ ] lfric-jedi: https://github.com/JCSDA-internal/lfric-jedi/pull/1110
- [ ] ops-um-jedi: https://github.com/JCSDA-internal/ops-um-jedi/pull/257

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
