### PR TITLE
Improve cmake diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,12 +47,13 @@ find_package( nemo-feedback )
 ################################################################################
 # Features that can be enabled / disabled with -DENABLE_<FEATURE>
 
-# check if Doxygen is installed
-find_package(Doxygen)
 ecbuild_add_option( FEATURE ORCA_JEDI_DOCS
                     DESCRIPTION "orca-jedi documentation"
                     DEFAULT OFF
                     REQUIRED_PACKAGES "Doxygen" )
+if( ENABLE_DOCS OR ENABLE_ORCA_JEDI_DOCS )
+    add_subdirectory( docs )
+endif()
 
 ################################################################################
 # sources
@@ -65,12 +66,9 @@ include_directories ( ${CMAKE_CURRENT_SOURCE_DIR}/src
 
 add_subdirectory( src )
 
-add_subdirectory ( docs )
-
 ################################################################################
 # Export and summarize
 
 ecbuild_install_project( NAME orcamodel )
 
 ecbuild_print_summary()
-

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,18 +1,14 @@
-if (HAVE_ORCA_JEDI_DOCS)
-    # set input and output files
-    set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
-    set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+# set input and output files
+set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
+set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
 
-    # request to configure the file
-    configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
-    message("Doxygen build started")
+# request to configure the file
+configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
+message(STATUS "Doxygen build started")
 
-    # note the option ALL which allows to build the docs together with the application
-    add_custom_target( doc_doxygen ALL
-        COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        COMMENT "Generating API documentation with Doxygen"
-        VERBATIM )
-else (HAVE_ORCA_JEDI_DOCS)
-  message("Doxygen need to be installed to generate the doxygen documentation")
-endif (HAVE_ORCA_JEDI_DOCS)
+# note the option ALL which allows to build the docs together with the application
+add_custom_target( doc_doxygen ALL
+    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Generating API documentation with Doxygen"
+    VERBATIM )

--- a/src/mains/CMakeLists.txt
+++ b/src/mains/CMakeLists.txt
@@ -1,5 +1,5 @@
 if( ${nemo-feedback_FOUND} )
-  message("      nemo-feedback_FOUND adding NEMO Feedback Writer")
+  message(STATUS "Found nemo-feedback: adding NEMO Feedback Writer")
   ecbuild_add_executable( TARGET  orcamodel_hofx.x
                           SOURCES orcamodelHofX.cc
                           LIBS    orcamodel nemo_feedback
@@ -18,7 +18,7 @@ if( ${nemo-feedback_FOUND} )
                           DEFINITIONS NEMO_FEEDBACK_EXISTS
                         )
 else()
-  message("      compiling without feedback file support")
+  message(NOTICE "Could NOT find nemo-feedback: compiling without feedback file support")
   ecbuild_add_executable( TARGET  orcamodel_hofx.x
                           SOURCES orcamodelHofX.cc
                           LIBS    orcamodel


### PR DESCRIPTION
## Description

Only consider building docs if relevant ENABLE_DOCS or ENABLE_ORCA_JEDI_DOCS is ON. No diagnostics when they are not on.

If nemo-feedback found, print message in STATUS mode.

If nemo-feedback not found, print message in NOTICE mode (as now).

## Checklist

- [x] I have updated the unit tests to cover the change _-na-_
- [x] New functions are documented briefly via Doxygen comments in the code _-na-_
- [x] I have linted my code using cpplint _-na-_
- [x] I have run the unit tests
- [x] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments
