### PR TITLE
Update to v1.9.2 CI to test against atlas 0.44.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 env:
     REGISTRY: ghcr.io
-    IMAGE_NAME: twsearle/orca-jedi/ci-almalinux9:v1.9.0
+    IMAGE_NAME: twsearle/orca-jedi/ci-almalinux9:v1.9.2
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Use the latest continuous integration container to ensure that  orca-jedi is compatible with the latest packages.
