### PR TITLE
Throw errors instead of warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,20 @@ if( ENABLE_DOCS OR ENABLE_ORCA_JEDI_DOCS )
 endif()
 
 ################################################################################
+# Project-wide compiler options
+
+message( "   CMAKE_CXX_COMPILER_ID : ${CMAKE_CXX_COMPILER_ID}" )
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+endif()
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU|Clang")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Werror")
+endif()
+
+################################################################################
 # sources
 
 #include( atlas_compile_flags )

--- a/src/orca-jedi/increment/Increment.cc
+++ b/src/orca-jedi/increment/Increment.cc
@@ -89,7 +89,7 @@ Increment::Increment(const Increment & other, const bool copy)
   setupIncrementFields();
 
   if (copy) {
-    for (size_t i=0; i < vars_.size(); ++i) {
+    for (atlas::idx_t i=0; i < static_cast<atlas::idx_t>(vars_.size()); ++i) {
       // copy variable from _Fields to new field set
       atlas::Field field = other.incrementFields_[i];
       oops::Log::debug() << "Copying increment field " << field.name() << std::endl;
@@ -557,7 +557,7 @@ void Increment::toFieldSet(atlas::FieldSet & fset) const {
 
   fset = atlas::FieldSet();
 
-  for (size_t i=0; i < vars_.size(); ++i) {
+  for (atlas::idx_t i=0; i < static_cast<atlas::idx_t>(vars_.size()); ++i) {
     // copy variable from increments to new field set
     atlas::Field fieldinc = incrementFields_[i];
     std::string fieldName = fieldinc.name();

--- a/src/orca-jedi/nemo_io/AtlasIndex.h
+++ b/src/orca-jedi/nemo_io/AtlasIndex.h
@@ -101,9 +101,9 @@ class OrcaIndexToBufferIndex : public AtlasIndexToBufferIndex {
   std::pair<int, int> ij(const size_t inode) const {
     auto ij = atlas::array::make_view<int32_t, 2>(mesh_.nodes().field("ij"));
     int i = ij(inode, 0) >= 0 ? ij(inode, 0) : nx_ + ij(inode, 0);
-    const int ci = i >= nx_ ? i - nx_ : i;
+    const int ci = i >= static_cast<int>(nx_) ? i - nx_ : i;
     int j = ij(inode, 1) + 1;
-    const int cj = j >= ny_ ? ny_ - 1 : j;
+    const int cj = j >= static_cast<int>(ny_) ? ny_ - 1 : j;
     return std::pair<int, int>{ci, cj};
   }
 };

--- a/src/orca-jedi/nemo_io/NemoFieldReader.cc
+++ b/src/orca-jedi/nemo_io/NemoFieldReader.cc
@@ -431,8 +431,6 @@ template<typename T> std::vector<T> NemoFieldReader::read_vertical_var(
   oops::Log::trace() << "orcamodel::NemoFieldReader::read_vertical_var"
                      << std::endl;
   try {
-    size_t nx = read_dim_size("x");
-    size_t ny = read_dim_size("y");
     size_t nz = read_dim_size(z_dimvar_name_);
 
     if (nlevels > nz) {

--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -426,7 +426,7 @@ void State::toFieldSet(atlas::FieldSet & fset) const {
 
   fset = atlas::FieldSet();
 
-  for (size_t i=0; i < vars_.size(); ++i) {
+  for (atlas::idx_t i=0; i < static_cast<atlas::idx_t>(vars_.size()); ++i) {
     // copy variable from increments to new field set
     atlas::Field field = stateFields_[i];
     std::string fieldName = field.name();

--- a/src/tests/orca-jedi/test_geometry.cc
+++ b/src/tests/orca-jedi/test_geometry.cc
@@ -150,7 +150,7 @@ CASE("test basic geometry") {
         "owned",
         "gmask",
         "area"};
-    int num_matches = 0;
+    size_t num_matches = 0;
     std::cout << "extraField list: ";
     for (atlas::Field field : extraFields) {
       std::string fieldname = field.name();
@@ -164,7 +164,7 @@ CASE("test basic geometry") {
     std::cout << std::endl;
     std::cout << "Number of extraFields " << extraFields.size() << std::endl;
     std::cout << "Number matches to expected names " << num_matches << std::endl;
-    EXPECT(extraFields.size() == num_matches);
+    EXPECT(static_cast<size_t>(extraFields.size()) == num_matches);
     EXPECT(extraFieldNames.size() == num_matches);
   }
 }

--- a/src/tests/orca-jedi/test_nemo_io_field_writer.cc
+++ b/src/tests/orca-jedi/test_nemo_io_field_writer.cc
@@ -60,12 +60,12 @@ CASE("test parallel serially distributed write field array views") {
   auto ghost = atlas::array::make_view<int32_t, 1>(mesh.nodes().ghost());
 
   std::vector<double> ice_buf, temp_buf;
-  for (size_t i = 0; i < ice_fv.shape(0); ++i) {
+  for (atlas::idx_t i = 0; i < ice_fv.shape(0); ++i) {
     ice_fv(i, 0) = ij(i, 0);
     ice_buf.emplace_back(ij(i, 0));
   }
   temp_buf.resize(3*ice_buf.size());
-  for (size_t i = 0; i < temp_fv.shape(0); ++i) {
+  for (atlas::idx_t i = 0; i < temp_fv.shape(0); ++i) {
     temp_fv(i, 0) = ij(i, 0);
     temp_fv(i, 1) = ij(i, 1) + 100;
     temp_fv(i, 2) = ij(i, 0) + 200;
@@ -85,19 +85,19 @@ CASE("test parallel serially distributed write field array views") {
                                                     mesh.nodes().lonlat())};
         std::vector<double> lons;
         std::vector<double> lats;
-        for (int i_node = 0; i_node < lonlat.shape(0); ++i_node) {
+        for (atlas::idx_t i_node = 0; i_node < lonlat.shape(0); ++i_node) {
           lons.emplace_back(lonlat(i_node, 0));
           lats.emplace_back(lonlat(i_node, 1));
         }
 
         EXPECT(lons.size() == nx*ny);
-        EXPECT(lons.size() == lonlat.shape(0));
+        EXPECT(static_cast<atlas::idx_t>(lons.size()) == lonlat.shape(0));
         EXPECT(lats.size() == nx*ny);
-        EXPECT(lats.size() == lonlat.shape(0));
+        EXPECT(static_cast<atlas::idx_t>(lats.size()) == lonlat.shape(0));
         field_writer.write_dimensions(lats, lons);
         std::cout << "sizes: " << ice_buf.size() << " =! " << nx*ny << std::endl;
         EXPECT(ice_buf.size() == nx*ny);
-        EXPECT(ice_buf.size() == ice_fv.shape(0));
+        EXPECT(static_cast<atlas::idx_t>(ice_buf.size()) == ice_fv.shape(0));
         field_writer.write_surf_var("iiceconc", ice_buf, 0);
         EXPECT(temp_buf.size() == 3*nx*ny);
         EXPECT(temp_buf.size() == temp_fv.size());
@@ -118,7 +118,7 @@ CASE("test parallel serially distributed write field array views") {
       NemoFieldReader field_reader(test_data_path);
       std::vector<double> data = field_reader.read_var_slice<double>("iiceconc", 0, 0);
       EXPECT(data.size() == nx*ny);
-      EXPECT(data.size() == ice_fv.shape(0));
+      EXPECT(static_cast<atlas::idx_t>(data.size()) == ice_fv.shape(0));
       for (atlas::idx_t iNode = 0; iNode < ice_fv.shape(0); ++iNode) {
         if (ghost(iNode)) continue;
         EXPECT_EQUAL(data[iNode], ice_fv(iNode, 0));
@@ -142,7 +142,7 @@ CASE("test parallel serially distributed write field array views") {
       NemoFieldReader field_reader(test_data_path);
       std::vector<double> data = field_reader.read_var_slice<double>("votemper", 0, 0);
       EXPECT(data.size() == nx*ny);
-      EXPECT(data.size() == temp_fv.shape(0));
+      EXPECT(static_cast<atlas::idx_t>(data.size()) == temp_fv.shape(0));
       for (size_t iNode = 0; iNode < data.size(); ++iNode) {
         if (ghost(iNode)) continue;
         EXPECT_EQUAL(data[iNode], temp_fv(iNode, 0));
@@ -150,7 +150,7 @@ CASE("test parallel serially distributed write field array views") {
       data.clear();
       data = field_reader.read_var_slice<double>("votemper", 0, 1);
       EXPECT(data.size() == nx*ny);
-      EXPECT(data.size() == temp_fv.shape(0));
+      EXPECT(static_cast<atlas::idx_t>(data.size()) == temp_fv.shape(0));
       for (size_t iNode = 0; iNode < data.size(); ++iNode) {
         if (ghost(iNode)) continue;
         EXPECT_EQUAL(data[iNode], temp_fv(iNode, 1));
@@ -158,7 +158,7 @@ CASE("test parallel serially distributed write field array views") {
       data.clear();
       data = field_reader.read_var_slice<double>("votemper", 0, 2);
       EXPECT(data.size() == nx*ny);
-      EXPECT(data.size() == temp_fv.shape(0));
+      EXPECT(static_cast<atlas::idx_t>(data.size()) == temp_fv.shape(0));
       for (size_t iNode = 0; iNode < data.size(); ++iNode) {
         if (ghost(iNode)) continue;
         EXPECT_EQUAL(data[iNode], temp_fv(iNode, 2));


### PR DESCRIPTION
## Description

We recently discussed in our JEDI C++ meeting that we would like zero warnings from our JEDI components. This change is to enforce throwing errors for each warning at compile time to enforce zero warnings.

## Issue(s) addressed

Resolves #166

## Impact

Expected impact on downstream repositories or workflows:

## Checklist
 
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [x] I have run [mo-bundle](https://cylchub/services/cylc-review/taskjobs?user=toby.searle&suite=mobb-ufo3907&no_fuzzy_time=0&cycles=&tasks=&task_status=failed&job_status=&order=time_desc&per_page=) to check integration with the rest of JEDI and run the unit tests under all environments
