### PR TITLE
Fix Cray compile failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,12 +58,14 @@ endif()
 ################################################################################
 # Project-wide compiler options
 
-message( "   CMAKE_CXX_COMPILER_ID : ${CMAKE_CXX_COMPILER_ID}" )
+message(STATUS "   CMAKE_CXX_COMPILER_ID : ${CMAKE_CXX_COMPILER_ID}" )
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
 endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "CrayClang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU|Clang")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Werror")


### PR DESCRIPTION
## Description

Don't use -Werror when compling with Cray compiler.  There is a compile warning produced that, in combination with -Werror, results in failure.  This warning doesn't occur with gnu.

## Issue(s) addressed

Resolves #169

## Dependencies

None

## Impact

None

## Checklist

- [y ] I have updated the unit tests to cover the change
- [y ] New functions are documented briefly via Doxygen comments in the code
- [y ] I have linted my code using cpplint
- [y ] I have run the unit tests
- [y ] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments
