### PR TITLE
use eckit::LibraryManager to check for atlas-orca

### DIFF
--- a/src/tests/orca-jedi/test_geometry.cc
+++ b/src/tests/orca-jedi/test_geometry.cc
@@ -7,6 +7,7 @@
 #include "eckit/mpi/Comm.h"
 #include "eckit/testing/Test.h"
 #include "eckit/exception/Exceptions.h"
+#include "eckit/system/LibraryManager.h"
 
 #include "oops/base/Variables.h"
 
@@ -22,7 +23,7 @@ namespace test {
 //-----------------------------------------------------------------------------
 
 CASE("test basic geometry") {
-  EXPECT(eckit::system::Library::exists("atlas-orca"));
+  EXPECT(eckit::system::LibraryManager::exists("atlas-orca"));
 
   eckit::LocalConfiguration config;
   std::vector<eckit::LocalConfiguration> nemo_var_mappings(5);

--- a/src/tests/orca-jedi/test_increment.cc
+++ b/src/tests/orca-jedi/test_increment.cc
@@ -9,6 +9,7 @@
 #include "eckit/mpi/Comm.h"
 #include "eckit/testing/Test.h"
 #include "eckit/exception/Exceptions.h"
+#include "eckit/system/LibraryManager.h"
 
 #include "oops/base/Variables.h"
 
@@ -26,7 +27,7 @@ namespace test {
 //-----------------------------------------------------------------------------
 
 CASE("test increment") {
-  EXPECT(eckit::system::Library::exists("atlas-orca"));
+  EXPECT(eckit::system::LibraryManager::exists("atlas-orca"));
 
   eckit::LocalConfiguration config;
   std::vector<eckit::LocalConfiguration> nemo_var_mappings(4);


### PR DESCRIPTION
## Description

The `Library::exists()` function in eckit is deprecated. It is replaced with `LibraryManager::exists()` in eckit 2.0. This change enables compilation under eckit 2.0 and onwards to adapt to the change.

## Issue(s) addressed

Resolves #181

## Impact

Should allow [mo-bundle#933](https://github.com/MetOffice/mo-bundle/issues/933) to compile.

## Checklist

- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [ ] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments
