### PR TITLE
Update test names and the norm calculation to RMS

### DIFF
--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -263,7 +263,7 @@ void State::setupStateFields() {
              atlas::option::name(vars_[i].name()) |
              atlas::option::levels(varSizes[i])));
         oops::Log::trace() << "State(ORCA)::setupStateFields : "
-                           << vars_[i].name() << "has dtype: "
+                           << vars_[i].name() << " has dtype: "
                            << (*(stateFields_.end()-1)).datatype().str() << std::endl;
 
         // initialise all data to avoid potential compiler/machine dependent bugs in missingValues
@@ -391,7 +391,7 @@ template<class T> double State::norm(const std::string & field_name) const {
     // prevent divide by zero when there are no valid model points on this
     // MPI rank
     if (valid_points) {
-      local_norm = std::sqrt(squares)/valid_points;
+      local_norm = std::sqrt(squares/valid_points);
     }
     return local_norm;
   }
@@ -402,7 +402,7 @@ template<class T> double State::norm(const std::string & field_name) const {
   geom_->getComm().allReduceInPlace(valid_points, eckit::mpi::sum());
 
   if (valid_points) {
-    return std::sqrt(squares)/valid_points;
+    return std::sqrt(squares/valid_points);
   }
 
   return 0;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -3,110 +3,110 @@ add_subdirectory(testoutput)
 add_subdirectory(orca-jedi)
 add_subdirectory(Data)
 
-ecbuild_add_test( TARGET test_orcajedi_coding_norms
+ecbuild_add_test( TARGET orcajedi_coding_norms
                   TYPE SCRIPT
                   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/cpplint.py
                   ARGS --recursive ${CMAKE_CURRENT_SOURCE_DIR}/../ )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx_sic
+ecbuild_add_test( TARGET orcajedi_hofx_sic
                   OMP 1
                   ARGS testinput/hofx_nc_sic.yaml
                   COMMAND orcamodel_hofx.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx3D_sic
+ecbuild_add_test( TARGET orcajedi_hofx3D_sic
                   OMP 1
                   ARGS testinput/hofx3d_nc_sic.yaml
                   COMMAND orcamodel_hofx3D.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx3D_sst
+ecbuild_add_test( TARGET orcajedi_hofx3D_sst
                   OMP 1
                   ARGS testinput/hofx3d_nc_sst.yaml
                   COMMAND orcamodel_hofx3D.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx_sst
+ecbuild_add_test( TARGET orcajedi_hofx_sst
                   OMP 1
                   ARGS testinput/hofx_nc_sst.yaml
                   COMMAND orcamodel_hofx.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx_ssh_parallel_checkerboard
+ecbuild_add_test( TARGET orcajedi_hofx_ssh_parallel_checkerboard
                   OMP 1
                   MPI 2
                   ARGS testinput/hofx_nc_ssh_checkerboard.yaml
                   COMMAND orcamodel_hofx.x )
 
 # Requires atlas-orca halos > 0 change (https://github.com/ecmwf/atlas-orca/pull/20)
-ecbuild_add_test( TARGET test_orcamodel_hofx_ssh_parallel_eorca025
+ecbuild_add_test( TARGET orcajedi_hofx_ssh_parallel_eorca025
                   OMP 1
                   MPI 2
                   ARGS testinput/hofx_nc_ssh_parallel_eorca025.yaml
                   COMMAND orcamodel_hofx.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx_ssh_eorca025
+ecbuild_add_test( TARGET orcajedi_hofx_ssh_eorca025
                   OMP 1
                   MPI 1
                   ARGS testinput/hofx_nc_ssh_eorca025.yaml
                   COMMAND orcamodel_hofx.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx_ssh_amm1
+ecbuild_add_test( TARGET orcajedi_hofx_ssh_amm1
                   OMP 1
                   MPI 1
                   ARGS testinput/hofx_nc_ssh_amm1.yaml
                   COMMAND orcamodel_hofx.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx3D_ssh_amm1
+ecbuild_add_test( TARGET orcajedi_hofx3D_ssh_amm1
                   OMP 1
                   MPI 1
                   ARGS testinput/hofx3d_nc_ssh_amm1.yaml
                   COMMAND orcamodel_hofx3D.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx_potm_amm1r
+ecbuild_add_test( TARGET orcajedi_hofx_potm_amm1r
                   OMP 1
                   MPI 1
                   ARGS testinput/hofx_nc_potm_amm1r.yaml
                   COMMAND orcamodel_hofx.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx3D_ssh_amm1r
+ecbuild_add_test( TARGET orcajedi_hofx3D_ssh_amm1r
                   OMP 1
                   MPI 1
                   ARGS testinput/hofx3d_nc_ssh_amm1r.yaml
                   COMMAND orcamodel_hofx3D.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx_ssh_parallel_serial
+ecbuild_add_test( TARGET orcajedi_hofx_ssh_parallel_serial
                   OMP 1
                   MPI 2
                   ARGS testinput/hofx_nc_ssh_parallel.yaml
                   COMMAND orcamodel_hofx.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx_ssh
+ecbuild_add_test( TARGET orcajedi_hofx_ssh
                   ARGS testinput/hofx_nc_ssh.yaml
                   COMMAND orcamodel_hofx.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx3D_potm
+ecbuild_add_test( TARGET orcajedi_hofx3D_potm
                   OMP 1
                   ARGS testinput/hofx3d_nc_potm.yaml
                   COMMAND orcamodel_hofx3D.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx3D_prof_2var
+ecbuild_add_test( TARGET orcajedi_hofx3D_prof_2var
                   OMP 1
                   ARGS testinput/hofx3d_nc_prof_2vars.yaml
                   COMMAND orcamodel_hofx3D.x )
 
-ecbuild_add_test( TARGET test_orcamodel_3DVar_sic
+ecbuild_add_test( TARGET orcajedi_3DVar_sic
                   OMP 1
                   ARGS testinput/3dvar_sic.yaml
                   COMMAND orcamodel_3DVar.x )
 
-ecbuild_add_test( TARGET test_orcamodel_3DVar_sic_identity
+ecbuild_add_test( TARGET orcajedi_3DVar_sic_identity
                   OMP 1
                   ARGS testinput/3dvar_sic_identity.yaml
                   COMMAND orcamodel_3DVar.x )
 
-ecbuild_add_test( TARGET test_orcamodel_Dirac
+ecbuild_add_test( TARGET orcajedi_Dirac
                   OMP 1
                   ARGS testinput/dirac.yaml
                   COMMAND orcamodel_ErrorCovarianceToolbox.x )
                   
-ecbuild_add_test( TARGET test_orcamodel_bump_nicas_setup
+ecbuild_add_test( TARGET orcajedi_bump_nicas_setup
                   OMP 1
                   ARGS testinput/bump_nicas_setup.yaml
                   COMMAND orcamodel_ErrorCovarianceToolbox.x )

--- a/src/tests/orca-jedi/CMakeLists.txt
+++ b/src/tests/orca-jedi/CMakeLists.txt
@@ -1,51 +1,53 @@
 include_directories( ${PROJECT_SOURCE_DIR}/src )
 
-ecbuild_add_test( TARGET  test_orcajedi_nemo_io_field_reader.x
+ecbuild_add_test( TARGET  orcajedi_nemo_io_field_reader.x
                   SOURCES test_nemo_io_field_reader.cc
                   LIBS    orcamodel )
 
-ecbuild_add_test( TARGET  test_orcajedi_nemo_io_field_writer.x
+ecbuild_add_test( TARGET  orcajedi_nemo_io_field_writer.x
                   SOURCES test_nemo_io_field_writer.cc
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   MPI        2
                   CONDITION  eckit_HAVE_MPI
                   LIBS    orcamodel )
 
-ecbuild_add_test( TARGET  test_orcajedi_nemo_io_read_server_MPI2.x
+ecbuild_add_test( TARGET  orcajedi_nemo_io_read_server_MPI2.x
                   SOURCES test_nemo_io_read_server.cc
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   MPI        2
                   CONDITION  eckit_HAVE_MPI
                   LIBS    orcamodel )
 
-ecbuild_add_test( TARGET  test_orcajedi_nemo_io_write_server_MPI2.x
+ecbuild_add_test( TARGET  orcajedi_nemo_io_write_server_MPI2.x
                   SOURCES test_nemo_io_write_server.cc
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   MPI        2
                   CONDITION  eckit_HAVE_MPI
                   LIBS    orcamodel )
 
-ecbuild_add_test( TARGET  test_orcajedi_nemo_io_write_server.x
+ecbuild_add_test( TARGET  orcajedi_nemo_io_write_server.x
                   SOURCES test_nemo_io_write_server.cc
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   LIBS    orcamodel )
 
-ecbuild_add_test( TARGET  test_orcajedi_geometry.x
+ecbuild_add_test( TARGET  orcajedi_geometry.x
                   SOURCES test_geometry.cc
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   LIBS    orcamodel )
 
-ecbuild_add_test( TARGET  test_orcajedi_state.x
+ecbuild_add_test( TARGET  orcajedi_state.x
                   SOURCES test_state.cc
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  OMP     4
+                  CONDITION  eckit_HAVE_OMP
                   LIBS    orcamodel )
 
-ecbuild_add_test( TARGET  test_orcajedi_interpolator.x
+ecbuild_add_test( TARGET  orcajedi_interpolator.x
                   SOURCES test_interpolator.cc
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   LIBS    orcamodel )
 
-ecbuild_add_test( TARGET  test_orcajedi_increment.x
+ecbuild_add_test( TARGET  orcajedi_increment.x
                   SOURCES test_increment.cc
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   LIBS    orcamodel )

--- a/src/tests/orca-jedi/test_state.cc
+++ b/src/tests/orca-jedi/test_state.cc
@@ -109,14 +109,22 @@ CASE("test basic state") {
   state_config.set("output nemo field file", "../testoutput/orca2_t_output.nc");
   params.validateAndDeserialize(state_config);
   State state(geometry, params);
-  double iceNorm = 0.0032018269;
+  const double iceNorm = 0.41793347;
   SECTION("test constructor from state") {
     bool has_missing = state.stateFields()["sea_ice_area_fraction"].metadata()
       .has("missing_value");
     EXPECT_EQUAL(true, has_missing);
-    std::cout << std::setprecision(8) << state.norm<double>("sea_ice_area_fraction")
-              << std::setprecision(8) << iceNorm << std::endl;
+    std::cout << "ice norm calculated: "<< std::setprecision(8)
+              << state.norm<double>("sea_ice_area_fraction")
+              << " ice norm KGO: " << iceNorm << std::endl;
     EXPECT(std::abs(state.norm<double>("sea_ice_area_fraction") - iceNorm) < 1e-6);
+  }
+  SECTION("test many runs of norm") {
+    int count = 0;
+    while (count < 1000) {
+      EXPECT(std::abs(state.norm<double>("sea_ice_area_fraction") - iceNorm) < 1e-6);
+      count++;
+    }
   }
   SECTION("test state read") {
     state.read(params);

--- a/src/tests/testoutput/test_3dvar_sic.ref
+++ b/src/tests/testoutput/test_3dvar_sic.ref
@@ -16,8 +16,7 @@ CostFunction::addIncrement: Analysis:
  Model state valid at time: 2021-06-29T12:00:00Z
     1 variables: ice_area_fraction
     atlas field norms:
-        ice_area_fraction: 3.18249e-03
-
+        ice_area_fraction: 4.15409e-01
 CostJo   : Nonlinear Jo(Sea Ice) = 9.14840e-01, nobs = 47, Jo/n = 1.94647e-02, err = 2.00000e+00
 CostJb   : Nonlinear Jb = 0.00000e+00
 CostFunction: Nonlinear J = 9.14840e-01

--- a/src/tests/testoutput/test_3dvar_sic_identity.ref
+++ b/src/tests/testoutput/test_3dvar_sic_identity.ref
@@ -6,7 +6,7 @@ CostFunction::addIncrement: Analysis:
  Model state valid at time: 2021-06-29T12:00:00Z
     1 variables: ice_area_fraction
     atlas field norms:
-        ice_area_fraction: 3.20153e-03
+        ice_area_fraction: 4.17894e-01
 
 CostJo   : Nonlinear Jo(Sea Ice) = 1.13327e+00, nobs = 48, Jo/n = 2.36099e-02, err = 2.00000e+00
 CostJb   : Nonlinear Jb = 0.00000e+00

--- a/src/tests/testoutput/test_hofx3d_nc_potm.ref
+++ b/src/tests/testoutput/test_hofx3d_nc_potm.ref
@@ -2,9 +2,9 @@ Test     : State:
 Test     :  Model state valid at time: 2021-06-30T00:00:00Z
 Test     :     3 variables: sea_water_potential_temperature, sea_water_potential_temperature_background_error, depth
 Test     :     atlas field norms:
-Test     :         sea_water_potential_temperature: 9.73262e-02
-Test     :         sea_water_potential_temperature_background_error: 3.54323e-04
-Test     :         depth: 2.05589e-01
+Test     :         sea_water_potential_temperature: 1.79661e+01
+Test     :         sea_water_potential_temperature_background_error: 1.00000e-01
+Test     :         depth: 5.80230e+01
 
 Test     : H(x):
 Test     : Sea Temperature nobs= 6 Min=1.80417e+01, Max=1.81944e+01, RMS=1.81181e+01

--- a/src/tests/testoutput/test_hofx3d_nc_prof_2vars.ref
+++ b/src/tests/testoutput/test_hofx3d_nc_prof_2vars.ref
@@ -2,11 +2,11 @@ Test     : State:
 Test     :  Model state valid at time: 2021-06-30T00:00:00Z
 Test     :     5 variables: sea_water_potential_temperature, sea_water_potential_temperature_background_error, depth, salinity, salinity_background_error
 Test     :     atlas field norms:
-Test     :         sea_water_potential_temperature: 9.73262e-02
-Test     :         sea_water_potential_temperature_background_error: 3.54323e-04
-Test     :         depth: 2.05589e-01
-Test     :         salinity: 1.89413e-01
-Test     :         salinity_background_error: 3.54323e-04
+Test     :         sea_water_potential_temperature: 1.79661e+01
+Test     :         sea_water_potential_temperature_background_error: 1.00000e-01
+Test     :         depth: 5.80230e+01
+Test     :         salinity: 3.49650e+01
+Test     :         salinity_background_error: 1.00000e-01
 
 Test     : H(x):
 Test     : ARGO profiles nobs= 12 Min=1.81028e+01, Max=3.52000e+01, RMS=2.79784e+01

--- a/src/tests/testoutput/test_hofx3d_nc_sic.ref
+++ b/src/tests/testoutput/test_hofx3d_nc_sic.ref
@@ -2,8 +2,8 @@ Test     : State:
 Test     :  Model state valid at time: 2021-06-30T00:00:00Z
 Test     :     2 variables: ice_area_fraction, ice_area_fraction_background_error
 Test     :     atlas field norms:
-Test     :          ice_area_fraction: 3.20183e-03
-Test     :          ice_area_fraction_background_error: 3.06852e-03
+Test     :          ice_area_fraction: 4.17933e-01
+Test     :          ice_area_fraction_background_error: 0.5
 
 Test     : H(x):
 Test     : Sea Ice nobs= 4 Min=0, Max=0, RMS=0

--- a/src/tests/testoutput/test_hofx3d_nc_ssh_amm1.ref
+++ b/src/tests/testoutput/test_hofx3d_nc_ssh_amm1.ref
@@ -2,8 +2,8 @@ Test     : State:
 Test     :  Model state valid at time: 2021-06-29T23:00:00Z
 Test     :     2 variables: sea_surface_height_anomaly, sea_surface_height_anomaly_background_error
 Test     :     atlas field norms:
-Test     :         sea_surface_height_anomaly: 3.35877e-02
-Test     :         sea_surface_height_anomaly_background_error: 3.35877e-02
+Test     :         sea_surface_height_anomaly: 4.45591e-01
+Test     :         sea_surface_height_anomaly_background_error: 4.45591e-01
 
 Test     : H(x): 
 Test     : Sea Surface Height nobs= 19 Min=-4.86354e-01, Max=-1.43070e-01, RMS=4.07939e-01

--- a/src/tests/testoutput/test_hofx3d_nc_ssh_amm1r.ref
+++ b/src/tests/testoutput/test_hofx3d_nc_ssh_amm1r.ref
@@ -2,8 +2,8 @@ Test     : State:
 Test     :  Model state valid at time: 2021-06-29T23:00:00Z
 Test     :     2 variables: sea_surface_height_anomaly, sea_surface_height_anomaly_background_error
 Test     :     atlas field norms:
-Test     :         sea_surface_height_anomaly: 1.53649e-02
-Test     :         sea_surface_height_anomaly_background_error: 1.53649e-02
+Test     :         sea_surface_height_anomaly: 1.77197e-01
+Test     :         sea_surface_height_anomaly_background_error: 1.77197e-01
 Test     : H(x): 
 Test     : Sea Surface Height nobs= 15 Min=1.78300e-01, Max=1.82067e-01, RMS=1.80296e-01
 Test     : End H(x)

--- a/src/tests/testoutput/test_hofx3d_nc_sst.ref
+++ b/src/tests/testoutput/test_hofx3d_nc_sst.ref
@@ -2,8 +2,8 @@ Test     : State:
 Test     :  Model state valid at time: 2021-06-30T00:00:00Z
 Test     :     2 variables: sea_surface_temperature, sea_surface_temperature_background_error
 Test     :     atlas field norms:
-Test     :         sea_surface_temperature: 1.37607e-01
-Test     :         sea_surface_temperature_background_error: 6.13705e-04
+Test     :         sea_surface_temperature: 1.79617e+01 
+Test     :         sea_surface_temperature_background_error: 1.00000e-01
 
 Test     : H(x):
 

--- a/src/tests/testoutput/test_hofx_nc_potm_amm1r.ref
+++ b/src/tests/testoutput/test_hofx_nc_potm_amm1r.ref
@@ -2,14 +2,14 @@ Test     : Initial state:
 Test     :  Model state valid at time: 2021-06-28T23:00:00Z
 Test     :     2 variables: sea_water_potential_temperature, sea_water_potential_temperature_background_error
 Test     :     atlas field norms:
-Test     :         sea_water_potential_temperature: 1.58670e+00
-Test     :         sea_water_potential_temperature_background_error: 2.80065e+00
+Test     :         sea_water_potential_temperature: 1.82987e+01
+Test     :         sea_water_potential_temperature_background_error: 3.22987e+01
 Test     : Final state: 
 Test     :  Model state valid at time: 2021-06-30T23:00:00Z
 Test     :     2 variables: sea_water_potential_temperature, sea_water_potential_temperature_background_error
 Test     :     atlas field norms:
-Test     :         sea_water_potential_temperature: 1.58670e+00
-Test     :         sea_water_potential_temperature_background_error: 2.80065e+00
+Test     :         sea_water_potential_temperature: 1.82987e+01
+Test     :         sea_water_potential_temperature_background_error: 3.22987e+01
 Test     : H(x): 
 Test     : Sea Temperature nobs= 10 Min=1.83026e+01, Max=1.83026e+01, RMS=1.83026e+01
 Test     : End H(x)

--- a/src/tests/testoutput/test_hofx_nc_sic.ref
+++ b/src/tests/testoutput/test_hofx_nc_sic.ref
@@ -3,14 +3,14 @@ Test     :  Model state valid at time: 2021-06-28T23:00:00Z
 Test     :     2 variables: ice_area_fraction, ice_area_fraction_background_error
 Test     :     atlas field norms:
 Test     :         ice_area_fraction: 0.00000e+00
-Test     :         ice_area_fraction_background_error: 3.06852e-03
+Test     :         ice_area_fraction_background_error: 5.00000e-01
 
 Test     : Final state:
 Test     :  Model state valid at time: 2021-06-30T23:00:00Z
 Test     :     2 variables: ice_area_fraction, ice_area_fraction_background_error
 Test     :     atlas field norms:
-Test     :         ice_area_fraction: 3.16981e-03
-Test     :         ice_area_fraction_background_error: 3.06852e-03
+Test     :         ice_area_fraction: 4.13754e-01
+Test     :         ice_area_fraction_background_error: 5.00000e-01
 
 Test     : H(x):
 Test     : Sea Ice nobs= 7 Min=0.00000e+00, Max=5.41667e-01, RMS=2.04731e-01

--- a/src/tests/testoutput/test_hofx_nc_ssh.ref
+++ b/src/tests/testoutput/test_hofx_nc_ssh.ref
@@ -2,15 +2,15 @@ Test     : Initial state:
 Test     :  Model state valid at time: 2021-06-28T23:00:00Z
 Test     :     2 variables: sea_surface_height_anomaly, sea_surface_height_anomaly_background_error
 Test     :     atlas field norms:
-Test     :         sea_surface_height_anomaly: 1.36263e-03
-Test     :         sea_surface_height_anomaly_background_error: 6.13705e-04
+Test     :         sea_surface_height_anomaly: 1.77864e-01
+Test     :         sea_surface_height_anomaly_background_error: 1.00000e-01
 
 Test     : Final state:
 Test     :  Model state valid at time: 2021-06-30T23:00:00Z
 Test     :     2 variables: sea_surface_height_anomaly, sea_surface_height_anomaly_background_error
 Test     :     atlas field norms:
-Test     :         sea_surface_height_anomaly: 1.40693e-03
-Test     :         sea_surface_height_anomaly_background_error: 6.13705e-04
+Test     :         sea_surface_height_anomaly: 1.83647e-01
+Test     :         sea_surface_height_anomaly_background_error: 1.00000e-01
 
 Test     : H(x):
 Test     : Sea Surface Height nobs= 19 Min=1.65922e-01, Max=2.00264e-01, RMS=1.88765e-01

--- a/src/tests/testoutput/test_hofx_nc_ssh_amm1.ref
+++ b/src/tests/testoutput/test_hofx_nc_ssh_amm1.ref
@@ -2,15 +2,15 @@ Test     : Initial state:
 Test     :  Model state valid at time: 2021-06-28T23:00:00Z
 Test     :     2 variables: sea_surface_height_anomaly, sea_surface_height_anomaly_background_error
 Test     :     atlas field norms:
-Test     :         sea_surface_height_anomaly: 3.35877e-02
-Test     :         sea_surface_height_anomaly_background_error: 3.35877e-02
+Test     :         sea_surface_height_anomaly: 4.45591e-01
+Test     :         sea_surface_height_anomaly_background_error: 4.45591e-01
 
 Test     : Final state:
 Test     :  Model state valid at time: 2021-06-30T23:00:00Z
 Test     :     2 variables: sea_surface_height_anomaly, sea_surface_height_anomaly_background_error
 Test     :     atlas field norms:
-Test     :         sea_surface_height_anomaly: 3.35877e-02
-Test     :         sea_surface_height_anomaly_background_error: 3.35877e-02
+Test     :         sea_surface_height_anomaly: 4.45591e-01
+Test     :         sea_surface_height_anomaly_background_error: 4.45591e-01
 
 Test     : H(x):
 Test     : Sea Surface Height nobs= 19 Min=-4.86354e-01, Max=-1.43070e-01, RMS=4.07939e-01

--- a/src/tests/testoutput/test_hofx_nc_ssh_eorca025.ref
+++ b/src/tests/testoutput/test_hofx_nc_ssh_eorca025.ref
@@ -2,15 +2,15 @@ Test     : Initial state:
 Test     :  Model state valid at time: 2021-06-28T23:00:00Z
 Test     :     2 variables: sea_surface_height_anomaly, sea_surface_height_anomaly_background_error
 Test     :     atlas field norms:
-Test     :         sea_surface_height_anomaly: 4.30114e-04
-Test     :         sea_surface_height_anomaly_background_error: 4.30114e-04
+Test     :         sea_surface_height_anomaly: 4.10265e-01
+Test     :         sea_surface_height_anomaly_background_error: 4.10265e-01
 
 Test     : Final state:
 Test     :  Model state valid at time: 2021-06-30T23:00:00Z
 Test     :     2 variables: sea_surface_height_anomaly, sea_surface_height_anomaly_background_error
 Test     :     atlas field norms:
-Test     :         sea_surface_height_anomaly: 4.30114e-04
-Test     :         sea_surface_height_anomaly_background_error: 4.30114e-04
+Test     :         sea_surface_height_anomaly: 4.10265e-01
+Test     :         sea_surface_height_anomaly_background_error: 4.10265e-01
 
 Test     : H(x):
 Test     : Sea Surface Height nobs= 19 Min=-4.47000e-01, Max=4.48194e-01, RMS=4.45078e-01

--- a/src/tests/testoutput/test_hofx_nc_sst.ref
+++ b/src/tests/testoutput/test_hofx_nc_sst.ref
@@ -2,15 +2,15 @@ Test     : Initial state:
 Test     :  Model state valid at time: 2021-06-28T23:00:00Z
 Test     :     2 variables: sea_surface_temperature, sea_surface_temperature_background_error
 Test     :     atlas field norms:
-Test     :         sea_surface_temperature: 1.37673e-01
-Test     :         sea_surface_temperature_background_error: 6.13705e-04
+Test     :         sea_surface_temperature: 1.79705e+01
+Test     :         sea_surface_temperature_background_error: 1.00000e-01
 
 Test     : Final state:
 Test     :  Model state valid at time: 2021-06-30T23:00:00Z
 Test     :     2 variables: sea_surface_temperature, sea_surface_temperature_background_error
 Test     :     atlas field norms:
-Test     :         sea_surface_temperature: 1.37683e-01
-Test     :         sea_surface_temperature_background_error: 6.13705e-04
+Test     :         sea_surface_temperature: 1.79717e+01
+Test     :         sea_surface_temperature_background_error: 1.00000e-01
 
 Test     : H(x):
 


### PR DESCRIPTION
## Description

OOPS returns the Root Mean Square value from the `State::norm` method. This change is to put in a fix to conform to this standard.

I also took the opportunity to fixup the names of our tests to reflect recent discussions throughout JEDI on test naming conventions.

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [x] I have run [mo-bundle](https://cylchub/services/cylc-review/cycles/toby.searle/?suite=mobb-oj186) to check integration with the rest of JEDI and run the unit tests under all environments
