### PR TITLE
Fix for negative JoJc error

### DIFF
--- a/src/orca-jedi/increment/Increment.cc
+++ b/src/orca-jedi/increment/Increment.cc
@@ -82,12 +82,11 @@ Increment::Increment(const Increment & other, const bool copy)
 {
   oops::Log::debug() << "Increment(ORCA)::Increment copy " << copy << std::endl;
 
-  incrementFields_ = atlas::FieldSet();
-
-  setupIncrementFields();
-
   if (copy) {
-    copyIncFieldSet(other.incrementFields_, incrementFields_);
+    incrementFields_ = other.incrementFields_.clone();
+  } else {
+    incrementFields_ = atlas::FieldSet();
+    setupIncrementFields();
   }
 
   oops::Log::debug() << "Increment(ORCA)::Increment copied." << std::endl;
@@ -106,12 +105,7 @@ Increment & Increment::operator=(const Increment & other) {
   vars_ = other.vars_;
   geom_.reset();
   geom_ = other.geom_;
-
-  incrementFields_ = atlas::FieldSet();
-
-  setupIncrementFields();
-
-  copyIncFieldSet(other.incrementFields_, incrementFields_);
+  incrementFields_ = other.incrementFields_.clone();
 
   oops::Log::debug() << "Increment(ORCA)::= copy ended" << std::endl;
   return *this;
@@ -628,20 +622,6 @@ void Increment::setupIncrementFields() {
                          << std::endl;
       geom_->log_status();
     }
-  }
-}
-
-/// \brief Copy one increment fieldset to another fieldset.
-/// \param Source Atlas fieldset.
-/// \param Destination Atlas fieldset.
-void Increment::copyIncFieldSet(const atlas::FieldSet & source, atlas::FieldSet & dest) {
-  for (atlas::idx_t i=0; i < static_cast<atlas::idx_t>(vars_.size()); ++i) {
-    // copy variable from source to dest field set
-    oops::Log::debug() << "Copying increment field " << source[i].name() << std::endl;
-    auto field_view_dest = atlas::array::make_view<double, 2>(dest[i]);
-    auto field_view_source = atlas::array::make_view<double, 2>(source[i]);
-    field_view_dest.assign(field_view_source);
-    dest[i].metadata() = source[i].metadata();
   }
 }
 

--- a/src/orca-jedi/increment/Increment.cc
+++ b/src/orca-jedi/increment/Increment.cc
@@ -87,18 +87,7 @@ Increment::Increment(const Increment & other, const bool copy)
   setupIncrementFields();
 
   if (copy) {
-    for (atlas::idx_t i=0; i < static_cast<atlas::idx_t>(vars_.size()); ++i) {
-      // copy variable from _Fields to new field set
-      atlas::Field field = other.incrementFields_[i];
-      oops::Log::debug() << "Copying increment field " << field.name() << std::endl;
-      auto field_view = atlas::array::make_view<double, 2>(incrementFields_[i]);
-      auto field_view_other = atlas::array::make_view<double, 2>(field);
-      for (atlas::idx_t j = 0; j < field_view.shape(0); ++j) {
-        for (atlas::idx_t k = 0; k < field_view.shape(1); ++k) {
-          field_view(j, k) = field_view_other(j, k);
-        }
-      }
-    }
+    copyIncFieldSet(other.incrementFields_, incrementFields_);
   }
 
   oops::Log::debug() << "Increment(ORCA)::Increment copied." << std::endl;
@@ -110,12 +99,19 @@ Increment::Increment(const Increment & other, const bool copy)
 }
 
 // Basic operators
-Increment & Increment::operator=(const Increment & rhs) {
-  time_ = rhs.time_;
-  incrementFields_ = rhs.incrementFields_;
-  vars_ = rhs.vars_;
+Increment & Increment::operator=(const Increment & other) {
+  oops::Log::debug() << "Increment(ORCA)::= copy" << std::endl;
+
+  time_ = other.time_;
+  vars_ = other.vars_;
   geom_.reset();
-  geom_ = rhs.geom_;
+  geom_ = other.geom_;
+
+  incrementFields_ = atlas::FieldSet();
+
+  setupIncrementFields();
+
+  copyIncFieldSet(other.incrementFields_, incrementFields_);
 
   oops::Log::debug() << "Increment(ORCA)::= copy ended" << std::endl;
   return *this;
@@ -631,6 +627,24 @@ void Increment::setupIncrementFields() {
                          << ", " << (*(incrementFields_.end()-1)).shape(1) << ")"
                          << std::endl;
       geom_->log_status();
+    }
+  }
+}
+
+/// \brief Copy one increment fieldset to another fieldset.
+/// \param Source Atlas fieldset.
+/// \param Destination Atlas fieldset.
+void Increment::copyIncFieldSet(const atlas::FieldSet & source, atlas::FieldSet & dest) {
+  for (atlas::idx_t i=0; i < static_cast<atlas::idx_t>(vars_.size()); ++i) {
+    // copy variable from source to dest field set
+    atlas::Field field = source[i];
+    oops::Log::debug() << "Copying increment field " << field.name() << std::endl;
+    auto field_view_dest = atlas::array::make_view<double, 2>(dest[i]);
+    auto field_view_source = atlas::array::make_view<double, 2>(field);
+    for (atlas::idx_t j = 0; j < field_view_source.shape(0); ++j) {
+      for (atlas::idx_t k = 0; k < field_view_source.shape(1); ++k) {
+        field_view_dest(j, k) = field_view_source(j, k);
+      }
     }
   }
 }

--- a/src/orca-jedi/increment/Increment.cc
+++ b/src/orca-jedi/increment/Increment.cc
@@ -637,15 +637,11 @@ void Increment::setupIncrementFields() {
 void Increment::copyIncFieldSet(const atlas::FieldSet & source, atlas::FieldSet & dest) {
   for (atlas::idx_t i=0; i < static_cast<atlas::idx_t>(vars_.size()); ++i) {
     // copy variable from source to dest field set
-    atlas::Field field = source[i];
-    oops::Log::debug() << "Copying increment field " << field.name() << std::endl;
+    oops::Log::debug() << "Copying increment field " << source[i].name() << std::endl;
     auto field_view_dest = atlas::array::make_view<double, 2>(dest[i]);
-    auto field_view_source = atlas::array::make_view<double, 2>(field);
-    for (atlas::idx_t j = 0; j < field_view_source.shape(0); ++j) {
-      for (atlas::idx_t k = 0; k < field_view_source.shape(1); ++k) {
-        field_view_dest(j, k) = field_view_source(j, k);
-      }
-    }
+    auto field_view_source = atlas::array::make_view<double, 2>(source[i]);
+    field_view_dest.assign(field_view_source);
+    dest[i].metadata() = source[i].metadata();
   }
 }
 

--- a/src/orca-jedi/increment/Increment.h
+++ b/src/orca-jedi/increment/Increment.h
@@ -133,7 +133,6 @@ class Increment : public util::Printable,
 /// Data
  private:
   void setupIncrementFields();
-  void copyIncFieldSet(const atlas::FieldSet &, atlas::FieldSet &);
   void setval(const double &);
   std::shared_ptr<const Geometry> geom_;
   oops::Variables vars_;

--- a/src/orca-jedi/increment/Increment.h
+++ b/src/orca-jedi/increment/Increment.h
@@ -133,6 +133,7 @@ class Increment : public util::Printable,
 /// Data
  private:
   void setupIncrementFields();
+  void copyIncFieldSet(const atlas::FieldSet &, atlas::FieldSet &);
   void setval(const double &);
   std::shared_ptr<const Geometry> geom_;
   oops::Variables vars_;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -91,11 +91,10 @@ ecbuild_add_test( TARGET test_orcamodel_hofx3D_prof_2var
                   ARGS testinput/hofx3d_nc_prof_2vars.yaml
                   COMMAND orcamodel_hofx3D.x )
 
-# Not run until we resolve invalid cost function detected in oops#3054
-#ecbuild_add_test( TARGET test_orcamodel_3DVar_sic
-#                  OMP 1
-#                  ARGS testinput/3dvar_sic.yaml
-#                  COMMAND orcamodel_3DVar.x )
+ecbuild_add_test( TARGET test_orcamodel_3DVar_sic
+                  OMP 1
+                  ARGS testinput/3dvar_sic.yaml
+                  COMMAND orcamodel_3DVar.x )
 
 ecbuild_add_test( TARGET test_orcamodel_3DVar_sic_identity
                   OMP 1

--- a/src/tests/orca-jedi/test_increment.cc
+++ b/src/tests/orca-jedi/test_increment.cc
@@ -96,6 +96,18 @@ CASE("test increment") {
     increment.print(std::cout);
   }
 
+  SECTION("test copy") {
+    Increment increment1(geometry, oops_vars2, datetime);
+    Increment increment2(geometry, oops_vars2, datetime);
+    increment1.ones();
+    increment2 = increment1;
+    // Make sure copies are independent
+    // i.e. changing one version won't change the other
+    increment1 *= 3;
+    increment2.print(std::cout);
+    EXPECT_EQUAL(increment2.norm(), 1);
+  }
+
   SECTION("test dirac") {
     eckit::LocalConfiguration dirac_config;
     std::vector<int> ix = {20, 30};

--- a/src/tests/testinput/3dvar_sic.yaml
+++ b/src/tests/testinput/3dvar_sic.yaml
@@ -117,7 +117,7 @@ variational:
   minimizer:
     algorithm: DRPCG
   iterations:
-  - ninner: 1
+  - ninner: 2
     gradient norm reduction: 1e-30
     geometry: *Geom
     test: on

--- a/src/tests/testinput/3dvar_sic.yaml
+++ b/src/tests/testinput/3dvar_sic.yaml
@@ -99,18 +99,6 @@ cost function:
         name: Composite
         components:
         - name: Identity
-      obs post filters:
-      #- filter: Print Filter Data
-      #  variables:
-      #  - variable: HofX/ice_area_fraction
-      #  - variable: QCflagsData/ice_area_fraction
-      - filter: Domain Check
-        where:
-        - variable:
-            name: HofX/ice_area_fraction
-        value: is_valid
-        action:
-          name: reject
       obs error:
         covariance model: diagonal
 variational:

--- a/src/tests/testinput/3dvar_sic_identity.yaml
+++ b/src/tests/testinput/3dvar_sic_identity.yaml
@@ -52,20 +52,13 @@ cost function:
         time interpolation: linear
         atlas-interpolator:
           type: unstructured-bilinear-lonlat
-#          non_linear: missing-if-all-missing
+          non_linear: missing-if-all-missing
           max_fraction_elems_to_try: 0.0
           adjoint: true
       obs operator:
         name: Composite
         components:
         - name: Identity
-      obs filters:
-      - filter: Background Check
-        filter variables:
-        - name: ice_area_fraction
-        absolute threshold: 2.0
-        action:
-          name: reject
       obs error:
         covariance model: diagonal
 variational:

--- a/src/tests/testinput/3dvar_sic_identity.yaml
+++ b/src/tests/testinput/3dvar_sic_identity.yaml
@@ -72,7 +72,7 @@ variational:
   minimizer:
     algorithm: DRPCG
   iterations:
-  - ninner: 1
+  - ninner: 2
     gradient norm reduction: 1e-30
     geometry: *Geom
     test: on

--- a/src/tests/testoutput/test_3dvar_sic.ref
+++ b/src/tests/testoutput/test_3dvar_sic.ref
@@ -11,13 +11,13 @@ CostJo   : Nonlinear Jo(Sea Ice) = 1.4687500000000000e+00, nobs = 47, Jo/n = 3.1
              Level   1 ~>  0.100E+01 vert. coord.
 CostJb   : Nonlinear Jb = 0.0000000000000000e+00
 CostFunction: Nonlinear J = 1.4687500000000000e+00
-DRPCGMinimizer: reduction in residual norm = 1.4155891817936023e+02
+DRPCGMinimizer: reduction in residual norm = 6.3970226812739249e-04
 CostFunction::addIncrement: Analysis: 
  Model state valid at time: 2021-06-29T12:00:00Z
     1 variables: ice_area_fraction
     atlas field norms:
-        ice_area_fraction: 3.16815e-03
+        ice_area_fraction: 3.18249e-03
 
-CostJo   : Nonlinear Jo(Sea Ice) = 7.87621e-01, nobs = 47, Jo/n = 1.67579e-02, err = 2.00000e+00
+CostJo   : Nonlinear Jo(Sea Ice) = 9.14840e-01, nobs = 47, Jo/n = 1.94647e-02, err = 2.00000e+00
 CostJb   : Nonlinear Jb = 0.00000e+00
-CostFunction: Nonlinear J = 7.87621e-01
+CostFunction: Nonlinear J = 9.14840e-01

--- a/src/tests/testoutput/test_3dvar_sic_identity.ref
+++ b/src/tests/testoutput/test_3dvar_sic_identity.ref
@@ -1,13 +1,13 @@
 CostJo   : Nonlinear Jo(Sea Ice) = 1.4687500000000000e+00, nobs = 47, Jo/n = 3.1250000000000000e-02, err = 2.0000000000000000e+00
 CostJb   : Nonlinear Jb = 0.0000000000000000e+00
 CostFunction: Nonlinear J = 1.4687500000000000e+00
-DRPCGMinimizer: reduction in residual norm = 7.2399282392205355e-01
+DRPCGMinimizer: reduction in residual norm = 2.0545268101312842e-03
 CostFunction::addIncrement: Analysis: 
  Model state valid at time: 2021-06-29T12:00:00Z
     1 variables: ice_area_fraction
     atlas field norms:
-        ice_area_fraction: 3.20155e-03
+        ice_area_fraction: 3.20153e-03
 
-CostJo   : Nonlinear Jo(Sea Ice) = 1.10491e+00, nobs = 47, Jo/n = 2.35087e-02, err = 2.00000e+00
+CostJo   : Nonlinear Jo(Sea Ice) = 1.10338e+00, nobs = 47, Jo/n = 2.34762e-02, err = 2.00000e+00
 CostJb   : Nonlinear Jb = 0.00000e+00
-CostFunction: Nonlinear J = 1.10491e+00
+CostFunction: Nonlinear J = 1.10338e+00

--- a/src/tests/testoutput/test_3dvar_sic_identity.ref
+++ b/src/tests/testoutput/test_3dvar_sic_identity.ref
@@ -1,13 +1,13 @@
-CostJo   : Nonlinear Jo(Sea Ice) = 1.4687500000000000e+00, nobs = 47, Jo/n = 3.1250000000000000e-02, err = 2.0000000000000000e+00
+CostJo   : Nonlinear Jo(Sea Ice) = 1.5000000000000000e+00, nobs = 48, Jo/n = 3.1250000000000000e-02, err = 2.0000000000000000e+00
 CostJb   : Nonlinear Jb = 0.0000000000000000e+00
-CostFunction: Nonlinear J = 1.4687500000000000e+00
-DRPCGMinimizer: reduction in residual norm = 2.0545268101312842e-03
+CostFunction: Nonlinear J = 1.5000000000000000e+00
+DRPCGMinimizer: reduction in residual norm = 2.0461596355325884e-03
 CostFunction::addIncrement: Analysis: 
  Model state valid at time: 2021-06-29T12:00:00Z
     1 variables: ice_area_fraction
     atlas field norms:
         ice_area_fraction: 3.20153e-03
 
-CostJo   : Nonlinear Jo(Sea Ice) = 1.10338e+00, nobs = 47, Jo/n = 2.34762e-02, err = 2.00000e+00
+CostJo   : Nonlinear Jo(Sea Ice) = 1.13327e+00, nobs = 48, Jo/n = 2.36099e-02, err = 2.00000e+00
 CostJb   : Nonlinear Jb = 0.00000e+00
-CostFunction: Nonlinear J = 1.10338e+00
+CostFunction: Nonlinear J = 1.13327e+00


### PR DESCRIPTION

## Description

This fix involves updating increment copy to copy fields  rather than references which was causing different variables to become linked together. This fixes the negative JoJc error  that we saw in the (standard) 3DVar test ever since the check was added to OOPS. As it now works I have reactivated the 3DVar test.

## Issue(s) addressed

Resolves #158

## Dependencies

List the other PRs that this PR is dependent on:
- None

## Impact

Expected impact on downstream repositories or workflows: None

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] New functions are documented briefly via Doxygen comments in the code
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [x] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments
