### PR TITLE
Regridding for ORCA-to-ORCA scalar fields

### DIFF
--- a/examples/regrid_coarsen.yaml
+++ b/examples/regrid_coarsen.yaml
@@ -1,0 +1,30 @@
+geometry:
+  grid name: eORCA025_T
+  number levels: 3
+  nemo variables:
+  - name: sea_surface_temperature
+    nemo field name: votemper
+    model space: volume
+
+state:
+  date: 2021-06-30T00:00:00Z
+  state variables: [sea_surface_temperature]
+  nemo field file: regrid_eorca025_input.nc
+
+target geometry:
+  grid name: ORCA1_T
+  number levels: 3
+  nemo variables:
+  - name: sea_surface_temperature
+    nemo field name: votemper
+    model space: volume
+  land sea mask:
+    filepath: regrid_orca1_mask_source.nc
+    variable: t_tot_var
+
+interpolation method:
+  type: unstructured-bilinear-lonlat
+  non_linear: missing-if-all-missing
+
+output:
+  filepath: regrid_orca1_output.nc

--- a/examples/regrid_smoothen.yaml
+++ b/examples/regrid_smoothen.yaml
@@ -1,0 +1,37 @@
+geometry:
+  grid name: ORCA1_T
+  number levels: 3
+  nemo variables:
+  - name: sea_surface_temperature
+    nemo field name: votemper
+    model space: volume
+
+state:
+  date: 2021-06-30T00:00:00Z
+  state variables: [sea_surface_temperature]
+  nemo field file: regrid_orca1_input.nc
+
+target geometry:
+  grid name: eORCA025_T
+  number levels: 3
+  nemo variables:
+  - name: sea_surface_temperature
+    nemo field name: votemper
+    model space: volume
+  land sea mask:
+    filepath: regrid_eorca025_mask_source.nc
+    variable: t_tot_var
+
+interpolation method:
+  type: unstructured-bilinear-lonlat
+  non_linear: missing-if-all-missing
+
+source extension:
+  flood iterations: 2
+  smooth iterations: 50
+  smooth weight self: 0.35
+  adjacency: cell-based
+  output filepath: regrid_extended_source_diagnostic.nc
+
+output:
+  filepath: regrid_eorca025_output.nc

--- a/src/mains/CMakeLists.txt
+++ b/src/mains/CMakeLists.txt
@@ -39,3 +39,8 @@ ecbuild_add_executable( TARGET  orcamodel_ErrorCovarianceToolbox.x
                         SOURCES orcamodelErrorCovarianceToolbox.cc
                         LIBS    orcamodel
                       )
+
+ecbuild_add_executable( TARGET  orcamodel_regrid.x
+                        SOURCES orcamodelRegrid.cc
+                        LIBS    orcamodel
+                      )

--- a/src/mains/orcamodelRegrid.cc
+++ b/src/mains/orcamodelRegrid.cc
@@ -18,6 +18,7 @@
 #include "orca-jedi/geometry/Geometry.h"
 #include "orca-jedi/state/State.h"
 #include "orca-jedi/regridder/Regridder.h"
+#include "orca-jedi/regridder/SourceExtender.h"
 #include "orca-jedi/utilities/IOUtils.h"
 
 /// \brief Application to regrid ORCA model data to a target grid.
@@ -26,15 +27,23 @@
 /// (e.g. regular lon-lat, rotated pole, or another ORCA grid), and performs
 /// interpolation/regridding using the Atlas library.
 ///
+/// An optional source extension step can flood-fill missing-value (land) cells
+/// on the source grid before interpolation. This prevents target ocean points
+/// from receiving missing values when their entire interpolation stencil falls
+/// on source land. The approach is analogous to NEMOVAR's sim_ext module
+/// (VAR_SRC/SIM/sim_ext.F90), which iteratively fills coastal land cells with
+/// distance-weighted neighbour averages, then smooths the result.
+///
 /// Configuration is read from a YAML file specifying:
 /// - geometry: source ORCA grid configuration
 /// - state: source state to regrid
 /// - target geometry: target ORCA grid configuration (for ORCA-to-ORCA)
 ///   OR target grid: atlas grid spec (for ORCA to structured grid)
 /// - interpolation method: atlas interpolation configuration
+/// - source extension (optional): flood-fill and smoothing parameters
 /// - output: output file path
 ///
-/// Example YAML (ORCA-to-ORCA):
+/// Example YAML (ORCA-to-ORCA with source extension):
 /// \code{.yaml}
 /// geometry:
 ///   grid name: ORCA1_T
@@ -55,11 +64,16 @@
 /// interpolation method:
 ///   type: unstructured-bilinear-lonlat
 ///   non_linear: missing-if-all-missing
+/// source extension:
+///   flood iterations: 2          # cells deep to flood into land (default: 2)
+///   smooth iterations: 50        # smoothing passes on flooded cells (default: 50)
+///   smooth weight self: 0.35     # self-weight in smoothing (default: 0.35)
+///   adjacency: cell-based        # "cell-based" (default) or "edge-based"
 /// output:
 ///   filepath: path/to/output.nc
 /// \endcode
 ///
-/// Example YAML (ORCA to structured grid):
+/// Example YAML (ORCA to structured grid, no source extension):
 /// \code{.yaml}
 /// geometry:
 ///   grid name: ORCA2_T
@@ -76,6 +90,18 @@
 ///   type: finite-element
 ///   non_linear: missing-if-all-missing
 /// \endcode
+///
+/// \note The "source extension" section is optional. Without it, regridding
+///   relies solely on Atlas's non_linear missing-value handling, which may
+///   leave missing values on target ocean points near coastlines.
+///
+/// \note Two adjacency types are supported:
+///   - "cell-based" (default): neighbours are all nodes sharing a mesh cell.
+///     On a quad mesh this gives 8 neighbours (4 edge + 4 corner), matching
+///     the stencil used by NEMOVAR's sim_ext.
+///   - "edge-based": neighbours are nodes connected by a mesh edge only.
+///     Typically 4–6 neighbours; a sparser but more geometrically principled
+///     stencil on unstructured meshes.
 
 class OrcaModelRegrid : public oops::Application {
  public:
@@ -120,19 +146,45 @@ class OrcaModelRegrid : public oops::Application {
           Here());
     }
 
-    // 3. Build regridder
+    // 3. Optionally extend source fields into land (flood-fill)
+    atlas::FieldSet sourceFields;
+    for (atlas::idx_t i = 0; i < state.stateFields().size(); ++i) {
+      sourceFields.add(state.stateFields()[i].clone());
+    }
+
+    if (conf.has("source extension")) {
+      const eckit::LocalConfiguration extConf(conf, "source extension");
+      int nFlood = extConf.getInt("flood iterations", 2);
+      int nSmooth = extConf.getInt("smooth iterations", 50);
+      double selfWeight = extConf.getDouble("smooth weight self", 0.35);
+      std::string adjStr = extConf.getString("adjacency", "cell-based");
+      orcamodel::AdjacencyType adjType =
+          (adjStr == "edge-based") ? orcamodel::AdjacencyType::EdgeBased
+                                   : orcamodel::AdjacencyType::CellBased;
+
+      orcamodel::SourceExtender extender(
+          geom.mesh(), geom.functionSpace(),
+          nFlood, nSmooth, selfWeight, adjType);
+      extender.extend(sourceFields);
+
+      oops::Log::info() << "Source extension applied: " << nFlood
+                        << " flood + " << nSmooth << " smooth iterations ("
+                        << adjStr << " adjacency)" << std::endl;
+    }
+
+    // 4. Build regridder
     const eckit::LocalConfiguration interpConf(conf, "interpolation method");
     orcamodel::Regridder regridder(interpConf,
                                    geom.functionSpace(),
                                    targetFunctionSpace);
 
-    // 4. Execute regridding
-    atlas::FieldSet result = regridder.execute(state.stateFields());
+    // 5. Execute regridding
+    atlas::FieldSet result = regridder.execute(sourceFields);
 
     oops::Log::info() << "Regridding complete. Output fields: "
                       << result.size() << std::endl;
 
-    // 5. Write output
+    // 6. Write output
     if (conf.has("output")) {
       const eckit::LocalConfiguration outputConf(conf, "output");
       const std::string outputPath = outputConf.getString("filepath");
@@ -157,6 +209,71 @@ class OrcaModelRegrid : public oops::Application {
 };
 
 int main(int argc, char** argv) {
+  // Custom help: intercept --help before oops::Run
+  for (int i = 1; i < argc; ++i) {
+    std::string arg(argv[i]);
+    if (arg == "-h" || arg == "--help") {
+      std::cout <<
+R"(OrcaModelRegrid — regrid ORCA model data to a target grid.
+
+Usage:
+  orcamodel_regrid.x <config.yaml> [output-file]
+  orcamodel_regrid.x --help
+
+The YAML configuration file specifies the source geometry, state, target grid,
+interpolation method, optional source extension (flood-fill), and output path.
+
+Configuration sections:
+
+  geometry:                        # Source ORCA grid
+    grid name: ORCA1_T
+    number levels: 3
+    nemo variables:
+    - {name: sea_water_potential_temperature, nemo field name: votemper,
+       model space: volume}
+
+  state:                           # Source state to regrid
+    date: 2021-06-30T00:00:00Z
+    state variables: [sea_water_potential_temperature]
+    nemo field file: /path/to/input.nc
+
+  target geometry:                 # Target ORCA grid (ORCA-to-ORCA)
+    grid name: ORCA2_T
+    number levels: 3
+    nemo variables:
+    - {name: sea_water_potential_temperature, nemo field name: votemper,
+       model space: volume}
+
+  # OR use 'target grid' for ORCA-to-structured:
+  # target grid:
+  #   name: L90
+
+  interpolation method:            # Atlas interpolation configuration
+    type: unstructured-bilinear-lonlat
+    non_linear: missing-if-all-missing
+
+  source extension:                # Optional: flood-fill land cells before regridding
+    flood iterations: 2            #   Number of cells to flood into land (default: 2)
+    smooth iterations: 50          #   Smoothing passes on flooded cells (default: 50)
+    smooth weight self: 0.35       #   Self-weight in smoothing, 0-1 (default: 0.35)
+    adjacency: cell-based          #   "cell-based" (default, 8-neighbour, NEMOVAR-like)
+                                   #   or "edge-based" (sparser, edge-connected only)
+
+  output:
+    filepath: /path/to/output.nc
+
+Notes:
+  - 'target geometry' (ORCA target) or 'target grid' (structured) must be specified.
+  - Source extension floods missing-value (land) cells on the source grid with
+    neighbour-averaged values before interpolation, preventing missing values on
+    target ocean points whose interpolation stencil falls entirely on source land.
+    This is analogous to NEMOVAR's sim_ext module.
+  - Output writing is currently only supported for ORCA target grids.
+)" << std::endl;
+      return 0;
+    }
+  }
+
   oops::Run run(argc, argv);
   atlas::Library::instance().initialise();
   OrcaModelRegrid regrid;

--- a/src/mains/orcamodelRegrid.cc
+++ b/src/mains/orcamodelRegrid.cc
@@ -1,0 +1,166 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#include "atlas/grid.h"
+#include "atlas/functionspace.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/library/Library.h"
+
+#include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
+
+#include "oops/runs/Application.h"
+#include "oops/runs/Run.h"
+#include "oops/util/Logger.h"
+
+#include "orca-jedi/geometry/Geometry.h"
+#include "orca-jedi/state/State.h"
+#include "orca-jedi/regridder/Regridder.h"
+#include "orca-jedi/utilities/IOUtils.h"
+
+/// \brief Application to regrid ORCA model data to a target grid.
+///
+/// Reads model state from ORCA grid files, constructs a target grid
+/// (e.g. regular lon-lat, rotated pole, or another ORCA grid), and performs
+/// interpolation/regridding using the Atlas library.
+///
+/// Configuration is read from a YAML file specifying:
+/// - geometry: source ORCA grid configuration
+/// - state: source state to regrid
+/// - target geometry: target ORCA grid configuration (for ORCA-to-ORCA)
+///   OR target grid: atlas grid spec (for ORCA to structured grid)
+/// - interpolation method: atlas interpolation configuration
+/// - output: output file path
+///
+/// Example YAML (ORCA-to-ORCA):
+/// \code{.yaml}
+/// geometry:
+///   grid name: ORCA1_T
+///   number levels: 3
+///   nemo variables:
+///   - {name: sea_ice_area_fraction, nemo field name: iiceconc, model space: surface}
+///   - {name: sea_water_potential_temperature, nemo field name: votemper, model space: volume}
+/// state:
+///   date: 2021-06-30T00:00:00Z
+///   state variables: [sea_ice_area_fraction, sea_water_potential_temperature]
+///   nemo field file: path/to/input.nc
+/// target geometry:
+///   grid name: ORCA2_T
+///   number levels: 3
+///   nemo variables:
+///   - {name: sea_ice_area_fraction, nemo field name: iiceconc, model space: surface}
+///   - {name: sea_water_potential_temperature, nemo field name: votemper, model space: volume}
+/// interpolation method:
+///   type: unstructured-bilinear-lonlat
+///   non_linear: missing-if-all-missing
+/// output:
+///   filepath: path/to/output.nc
+/// \endcode
+///
+/// Example YAML (ORCA to structured grid):
+/// \code{.yaml}
+/// geometry:
+///   grid name: ORCA2_T
+///   number levels: 3
+///   nemo variables:
+///   - {name: sea_water_potential_temperature, nemo field name: votemper, model space: volume}
+/// state:
+///   date: 2021-06-30T00:00:00Z
+///   state variables: [sea_water_potential_temperature]
+///   nemo field file: path/to/input.nc
+/// target grid:
+///   name: L90
+/// interpolation method:
+///   type: finite-element
+///   non_linear: missing-if-all-missing
+/// \endcode
+
+class OrcaModelRegrid : public oops::Application {
+ public:
+  explicit OrcaModelRegrid(const eckit::mpi::Comm& comm = eckit::mpi::comm())
+      : Application(comm) {}
+
+  int execute(const eckit::Configuration& conf) const override {
+    oops::Log::info() << "=== OrcaModelRegrid ===" << std::endl;
+
+    // 1. Build source geometry and read state
+    const eckit::LocalConfiguration geomConf(conf, "geometry");
+    const orcamodel::Geometry geom(geomConf, getComm());
+
+    const eckit::LocalConfiguration stateConf(conf, "state");
+    const orcamodel::State state(geom, stateConf);
+
+    oops::Log::info() << "Source state read: " << state << std::endl;
+
+    // 2. Build target function space
+    atlas::FunctionSpace targetFunctionSpace;
+    std::unique_ptr<orcamodel::Geometry> targetGeomPtr;
+
+    if (conf.has("target geometry")) {
+      // ORCA target: build full geometry (enables writing via NemoFieldWriter)
+      const eckit::LocalConfiguration targetGeomConf(conf, "target geometry");
+      targetGeomPtr = std::make_unique<orcamodel::Geometry>(targetGeomConf, getComm());
+      targetFunctionSpace = targetGeomPtr->functionSpace();
+      oops::Log::info() << "Target geometry: " << *targetGeomPtr << std::endl;
+    } else if (conf.has("target grid")) {
+      // Structured grid target
+      const eckit::LocalConfiguration targetGridConf(conf, "target grid");
+      const std::string targetGridName = targetGridConf.getString("name");
+      atlas::Grid targetGrid(targetGridName);
+      atlas::MeshGenerator meshgen("structured");
+      atlas::Mesh targetMesh = meshgen.generate(targetGrid);
+      targetFunctionSpace = atlas::functionspace::NodeColumns(targetMesh);
+      oops::Log::info() << "Target grid: " << targetGridName
+                        << " (" << targetGrid.size() << " points)" << std::endl;
+    } else {
+      throw eckit::BadParameter(
+          "OrcaModelRegrid: must specify either 'target geometry' or 'target grid'",
+          Here());
+    }
+
+    // 3. Build regridder
+    const eckit::LocalConfiguration interpConf(conf, "interpolation method");
+    orcamodel::Regridder regridder(interpConf,
+                                   geom.functionSpace(),
+                                   targetFunctionSpace);
+
+    // 4. Execute regridding
+    atlas::FieldSet result = regridder.execute(state.stateFields());
+
+    oops::Log::info() << "Regridding complete. Output fields: "
+                      << result.size() << std::endl;
+
+    // 5. Write output
+    if (conf.has("output")) {
+      const eckit::LocalConfiguration outputConf(conf, "output");
+      const std::string outputPath = outputConf.getString("filepath");
+
+      if (targetGeomPtr) {
+        // ORCA target: use existing writeFieldsToFile infrastructure
+        const util::DateTime validDate(stateConf.getString("date"));
+        orcamodel::writeFieldsToFile(outputPath, *targetGeomPtr, validDate, result);
+        oops::Log::info() << "Output written to: " << outputPath << std::endl;
+      } else {
+        oops::Log::warning() << "Output writing for non-ORCA target grids "
+                             << "is not yet implemented. File: " << outputPath
+                             << std::endl;
+      }
+    }
+
+    return 0;
+  }
+
+ private:
+  std::string appname() const override { return "orcamodel::OrcaModelRegrid"; }
+};
+
+int main(int argc, char** argv) {
+  oops::Run run(argc, argv);
+  atlas::Library::instance().initialise();
+  OrcaModelRegrid regrid;
+  int result = run.execute(regrid);
+  atlas::Library::instance().finalise();
+  return result;
+}

--- a/src/mains/orcamodelRegrid.cc
+++ b/src/mains/orcamodelRegrid.cc
@@ -20,7 +20,6 @@
 #include "orca-jedi/state/State.h"
 #include "orca-jedi/regridder/Regridder.h"
 #include "orca-jedi/regridder/SourceExtender.h"
-#include "orca-jedi/nemo_io/ReadServer.h"
 #include "orca-jedi/utilities/IOUtils.h"
 #include "orca-jedi/utilities/MaskUtils.h"
 
@@ -40,12 +39,11 @@
 /// Configuration is read from a YAML file specifying:
 /// - geometry: source ORCA grid configuration
 /// - state: source state to regrid
-/// - target geometry: target ORCA grid configuration (for ORCA-to-ORCA)
+/// - target geometry: target ORCA grid configuration (for ORCA-to-ORCA);
+///   may include a "land sea mask" section for re-masking regridded fields
 ///   OR target grid: atlas grid spec (for ORCA to structured grid)
 /// - interpolation method: atlas interpolation configuration
 /// - source extension (optional): flood-fill and smoothing parameters
-/// - target mask (optional): re-mask regridded fields using a volumetric
-///   ancillary field on the target grid (builds a 3D vol_mask)
 /// - output: output file path
 ///
 /// Example YAML (ORCA-to-ORCA with source extension and target mask):
@@ -66,6 +64,9 @@
 ///   nemo variables:
 ///   - {name: sea_ice_area_fraction, nemo field name: iiceconc, model space: surface}
 ///   - {name: sea_water_potential_temperature, nemo field name: votemper, model space: volume}
+///   land sea mask:                # optional: build 3D vol_mask from ancillary
+///     filepath: path/to/target_ancillary.nc
+///     variable: votemper          # field whose missing values define land
 /// interpolation method:
 ///   type: unstructured-bilinear-lonlat
 ///   non_linear: missing-if-all-missing
@@ -74,9 +75,7 @@
 ///   smooth iterations: 50        # smoothing passes on flooded cells (default: 50)
 ///   smooth weight self: 0.35     # self-weight in smoothing (default: 0.35)
 ///   adjacency: cell-based        # "cell-based" (default) or "edge-based"
-/// target mask:                   # optional: re-mask regridded fields on target grid
-///   filepath: path/to/target_ancillary.nc
-///   variable: votemper           # volumetric field whose missing values define land
+///   output filepath: path/to/extended.nc  # optional: dump extended fields
 /// output:
 ///   filepath: path/to/output.nc
 /// \endcode
@@ -103,12 +102,12 @@
 ///   relies solely on Atlas's non_linear missing-value handling, which may
 ///   leave missing values on target ocean points near coastlines.
 ///
-/// \note The "target mask" section is optional (requires "target geometry").
-///   It reads a volumetric field from a NetCDF ancillary on the target grid,
+/// \note The "land sea mask" section is optional within a geometry config.
+///   It reads a volumetric field from a NetCDF ancillary on the grid,
 ///   derives a 3D land-sea mask (vol_mask) from that field's missing values,
-///   and applies it to the regridded result. This ensures that regridded
-///   ocean points that should be land on the target grid are correctly set
-///   to missing_value at each depth level.
+///   and stores it in the geometry's extra fields. When present on the
+///   target geometry, regridded results are automatically re-masked per
+///   depth level. This also works in the State resolution-change constructor.
 ///
 /// \note Two adjacency types are supported:
 ///   - "cell-based" (default): neighbours are all nodes sharing a mesh cell.
@@ -152,8 +151,11 @@ class OrcaModelRegrid : public oops::Application {
 
     if (conf.has("target geometry")) {
       // ORCA target: build full geometry (enables writing via NemoFieldWriter)
-      const eckit::LocalConfiguration targetGeomConf(conf, "target geometry");
-      targetGeomPtr = std::make_unique<orcamodel::Geometry>(targetGeomConf, getComm());
+      // If the target geometry config contains a "land sea mask" section,
+      // the Geometry constructor reads the ancillary and populates vol_mask.
+      eckit::LocalConfiguration targetGeomConf(conf, "target geometry");
+      targetGeomPtr = std::make_unique<orcamodel::Geometry>(
+          targetGeomConf, getComm());
       targetFunctionSpace = targetGeomPtr->functionSpace();
       oops::Log::info() << "Target geometry: " << *targetGeomPtr << std::endl;
     } else if (conf.has("target grid")) {
@@ -198,6 +200,22 @@ class OrcaModelRegrid : public oops::Application {
       oops::Log::info() << "Source extension applied: " << nFlood
                         << " flood + " << nSmooth << " smooth iterations ("
                         << adjStr << " adjacency)" << std::endl;
+
+      // Optionally dump extended source fields for diagnostics
+      if (extConf.has("output filepath")) {
+        const std::string extOutPath = extConf.getString("output filepath");
+        const util::DateTime validDate(stateConf.getString("date"));
+        eckit::PathName extOut(extOutPath);
+        if (extOut.exists()) {
+          oops::Log::info() << "Removing existing source extension output: "
+                            << extOutPath << std::endl;
+          extOut.unlink();
+        }
+        orcamodel::writeFieldsToFile(
+            extOutPath, geom, validDate, sourceFields);
+        oops::Log::info() << "Source extension output written to: "
+                          << extOutPath << std::endl;
+      }
     }
 
     // 4. Build regridder
@@ -225,38 +243,11 @@ class OrcaModelRegrid : public oops::Application {
                         << " datatype=" << f.datatype().str() << std::endl;
     }
 
-    // 5b. Optionally apply target 3D land-sea mask (vol_mask).
-    //     Reads a volumetric field from an ancillary on the target grid,
-    //     derives a per-level mask from its missing values, and sets
-    //     regridded result to missing where the target grid is land.
-    if (conf.has("target mask") && targetGeomPtr) {
-      const eckit::LocalConfiguration maskConf(conf, "target mask");
-      const std::string maskFile = maskConf.getString("filepath");
-      const std::string maskVar = maskConf.getString("variable");
-      oops::Log::info() << "Applying target mask from '" << maskFile
-                        << "' variable '" << maskVar << "'" << std::endl;
-
-      // Read the mask-defining field on the target geometry (all levels)
-      const atlas::idx_t nLevels =
-          targetGeomPtr->extraFields().field("vol_mask").shape(1);
-      atlas::Field maskField = targetGeomPtr->functionSpace().createField<float>(
-          atlas::option::name(maskVar) | atlas::option::levels(nLevels));
-      {
-        orcamodel::ReadServer reader(targetGeomPtr->timer(),
-                                     eckit::PathName(maskFile),
-                                     targetGeomPtr->mesh());
-        auto field_view = atlas::array::make_view<float, 2>(maskField);
-        reader.read_var<float>(maskVar, 0, field_view);
-        float fill = reader.read_fillvalue<float>(maskVar);
-        maskField.metadata().set("missing_value", fill);
-        maskField.metadata().set("missing_value_type", "approximately-equals");
-        maskField.metadata().set("missing_value_epsilon", 1e-6);
-      }
-
-      // Derive vol_mask from the mask field's missing values
-      targetGeomPtr->set_vol_mask(maskField);
-
-      // Apply vol_mask to regridded result
+    // 5b. Apply target vol_mask if the target geometry has one configured.
+    //     The Geometry constructor reads the ancillary and populates vol_mask
+    //     when a "land sea mask" section is present in the geometry config.
+    if (targetGeomPtr
+        && targetGeomPtr->extraFields().has("vol_mask")) {
       orcamodel::applyMaskToFields(
           targetGeomPtr->extraFields().field("vol_mask"), result);
     }
@@ -326,6 +317,9 @@ Configuration sections:
     nemo variables:
     - {name: sea_water_potential_temperature, nemo field name: votemper,
        model space: volume}
+    land sea mask:                 #   Optional: build 3D vol_mask from ancillary
+      filepath: /path/to/ancillary.nc  # NetCDF file on this grid
+      variable: votemper           #   Field whose missing values define land
 
   # OR use 'target grid' for ORCA-to-structured:
   # target grid:
@@ -341,11 +335,7 @@ Configuration sections:
     smooth weight self: 0.35       #   Self-weight in smoothing, 0-1 (default: 0.35)
     adjacency: cell-based          #   "cell-based" (default, 8-neighbour, NEMOVAR-like)
                                    #   or "edge-based" (sparser, edge-connected only)
-
-  target mask:                     # Optional: re-mask regridded result on target grid
-    filepath: /path/to/target_ancillary.nc  # NetCDF file on the target grid
-    variable: votemper             #   Volumetric field whose missing values define land
-                                   #   (read at all target levels to build 3D vol_mask)
+    output filepath: /path/to/extended.nc  # Optional: write extended fields for diagnostics
 
   output:
     filepath: /path/to/output.nc
@@ -356,11 +346,11 @@ Notes:
     neighbour-averaged values before interpolation, preventing missing values on
     target ocean points whose interpolation stencil falls entirely on source land.
     This is analogous to NEMOVAR's sim_ext module.
-  - Target mask reads a volumetric field from an ancillary file on the target grid
-    and derives a 3D land-sea mask (vol_mask). Where the field has missing values,
-    the corresponding (node, level) position is masked. This is applied per-level
-    to the regridded result, correctly handling bathymetry differences between grids.
-    Requires 'target geometry' (not supported with 'target grid').
+  - The 'land sea mask' section can be added to any geometry configuration. It reads
+    a volumetric field from an ancillary file and derives a 3D land-sea mask (vol_mask)
+    from its missing values. When present on a target geometry, regridded results are
+    automatically re-masked per depth level. This also applies in the State
+    resolution-change constructor for JEDI DA workflows.
   - Output writing is currently only supported for ORCA target grids.
 )" << std::endl;
       return 0;

--- a/src/mains/orcamodelRegrid.cc
+++ b/src/mains/orcamodelRegrid.cc
@@ -20,7 +20,9 @@
 #include "orca-jedi/state/State.h"
 #include "orca-jedi/regridder/Regridder.h"
 #include "orca-jedi/regridder/SourceExtender.h"
+#include "orca-jedi/nemo_io/ReadServer.h"
 #include "orca-jedi/utilities/IOUtils.h"
+#include "orca-jedi/utilities/MaskUtils.h"
 
 /// \brief Application to regrid ORCA model data to a target grid.
 ///
@@ -211,6 +213,39 @@ class OrcaModelRegrid : public oops::Application {
                         << " datatype=" << f.datatype().str() << std::endl;
     }
 
+    // 5b. Optionally apply target land-sea mask
+    if (conf.has("target mask") && targetGeomPtr) {
+      const eckit::LocalConfiguration maskConf(conf, "target mask");
+      const std::string maskFile = maskConf.getString("filepath");
+      const std::string maskVar = maskConf.getString("variable");
+      oops::Log::info() << "Applying target mask from '" << maskFile
+                        << "' variable '" << maskVar << "'" << std::endl;
+
+      // Read the mask-defining field on the target geometry (all levels)
+      const atlas::idx_t nLevels =
+          targetGeomPtr->extraFields().field("vol_mask").shape(1);
+      atlas::Field maskField = targetGeomPtr->functionSpace().createField<float>(
+          atlas::option::name(maskVar) | atlas::option::levels(nLevels));
+      {
+        orcamodel::ReadServer reader(targetGeomPtr->timer(),
+                                     eckit::PathName(maskFile),
+                                     targetGeomPtr->mesh());
+        auto field_view = atlas::array::make_view<float, 2>(maskField);
+        reader.read_var<float>(maskVar, 0, field_view);
+        float fill = reader.read_fillvalue<float>(maskVar);
+        maskField.metadata().set("missing_value", fill);
+        maskField.metadata().set("missing_value_type", "approximately-equals");
+        maskField.metadata().set("missing_value_epsilon", 1e-6);
+      }
+
+      // Derive vol_mask from the mask field's missing values
+      targetGeomPtr->set_vol_mask(maskField);
+
+      // Apply vol_mask to regridded result
+      orcamodel::applyMaskToFields(
+          targetGeomPtr->extraFields().field("vol_mask"), result);
+    }
+
     // 6. Write output
     if (conf.has("output")) {
       const eckit::LocalConfiguration outputConf(conf, "output");
@@ -250,7 +285,7 @@ int main(int argc, char** argv) {
 R"(OrcaModelRegrid — regrid ORCA model data to a target grid.
 
 Usage:
-  orcamodel_regrid.x <config.yaml> [output-file]
+  orcamodel_regrid.x <config.yaml> [output-log-file]
   orcamodel_regrid.x --help
 
 The YAML configuration file specifies the source geometry, state, target grid,

--- a/src/mains/orcamodelRegrid.cc
+++ b/src/mains/orcamodelRegrid.cc
@@ -44,9 +44,11 @@
 ///   OR target grid: atlas grid spec (for ORCA to structured grid)
 /// - interpolation method: atlas interpolation configuration
 /// - source extension (optional): flood-fill and smoothing parameters
+/// - target mask (optional): re-mask regridded fields using a volumetric
+///   ancillary field on the target grid (builds a 3D vol_mask)
 /// - output: output file path
 ///
-/// Example YAML (ORCA-to-ORCA with source extension):
+/// Example YAML (ORCA-to-ORCA with source extension and target mask):
 /// \code{.yaml}
 /// geometry:
 ///   grid name: ORCA1_T
@@ -72,6 +74,9 @@
 ///   smooth iterations: 50        # smoothing passes on flooded cells (default: 50)
 ///   smooth weight self: 0.35     # self-weight in smoothing (default: 0.35)
 ///   adjacency: cell-based        # "cell-based" (default) or "edge-based"
+/// target mask:                   # optional: re-mask regridded fields on target grid
+///   filepath: path/to/target_ancillary.nc
+///   variable: votemper           # volumetric field whose missing values define land
 /// output:
 ///   filepath: path/to/output.nc
 /// \endcode
@@ -97,6 +102,13 @@
 /// \note The "source extension" section is optional. Without it, regridding
 ///   relies solely on Atlas's non_linear missing-value handling, which may
 ///   leave missing values on target ocean points near coastlines.
+///
+/// \note The "target mask" section is optional (requires "target geometry").
+///   It reads a volumetric field from a NetCDF ancillary on the target grid,
+///   derives a 3D land-sea mask (vol_mask) from that field's missing values,
+///   and applies it to the regridded result. This ensures that regridded
+///   ocean points that should be land on the target grid are correctly set
+///   to missing_value at each depth level.
 ///
 /// \note Two adjacency types are supported:
 ///   - "cell-based" (default): neighbours are all nodes sharing a mesh cell.
@@ -213,7 +225,10 @@ class OrcaModelRegrid : public oops::Application {
                         << " datatype=" << f.datatype().str() << std::endl;
     }
 
-    // 5b. Optionally apply target land-sea mask
+    // 5b. Optionally apply target 3D land-sea mask (vol_mask).
+    //     Reads a volumetric field from an ancillary on the target grid,
+    //     derives a per-level mask from its missing values, and sets
+    //     regridded result to missing where the target grid is land.
     if (conf.has("target mask") && targetGeomPtr) {
       const eckit::LocalConfiguration maskConf(conf, "target mask");
       const std::string maskFile = maskConf.getString("filepath");
@@ -327,6 +342,11 @@ Configuration sections:
     adjacency: cell-based          #   "cell-based" (default, 8-neighbour, NEMOVAR-like)
                                    #   or "edge-based" (sparser, edge-connected only)
 
+  target mask:                     # Optional: re-mask regridded result on target grid
+    filepath: /path/to/target_ancillary.nc  # NetCDF file on the target grid
+    variable: votemper             #   Volumetric field whose missing values define land
+                                   #   (read at all target levels to build 3D vol_mask)
+
   output:
     filepath: /path/to/output.nc
 
@@ -336,6 +356,11 @@ Notes:
     neighbour-averaged values before interpolation, preventing missing values on
     target ocean points whose interpolation stencil falls entirely on source land.
     This is analogous to NEMOVAR's sim_ext module.
+  - Target mask reads a volumetric field from an ancillary file on the target grid
+    and derives a 3D land-sea mask (vol_mask). Where the field has missing values,
+    the corresponding (node, level) position is masked. This is applied per-level
+    to the regridded result, correctly handling bathymetry differences between grids.
+    Requires 'target geometry' (not supported with 'target grid').
   - Output writing is currently only supported for ORCA target grids.
 )" << std::endl;
       return 0;

--- a/src/mains/orcamodelRegrid.cc
+++ b/src/mains/orcamodelRegrid.cc
@@ -10,6 +10,7 @@
 
 #include "eckit/config/LocalConfiguration.h"
 #include "eckit/exception/Exceptions.h"
+#include "eckit/filesystem/PathName.h"
 
 #include "oops/runs/Application.h"
 #include "oops/runs/Run.h"
@@ -120,6 +121,17 @@ class OrcaModelRegrid : public oops::Application {
 
     oops::Log::info() << "Source state read: " << state << std::endl;
 
+    // Diagnostics: source fields
+    oops::Log::info() << "=== Source field diagnostics ===" << std::endl;
+    for (atlas::idx_t i = 0; i < state.stateFields().size(); ++i) {
+      const auto& f = state.stateFields()[i];
+      oops::Log::info() << "  [" << i << "] name=" << f.name()
+                        << " shape=(" << f.shape(0) << "," << f.shape(1) << ")"
+                        << " levels=" << f.levels()
+                        << " rank=" << f.rank()
+                        << " datatype=" << f.datatype().str() << std::endl;
+    }
+
     // 2. Build target function space
     atlas::FunctionSpace targetFunctionSpace;
     std::unique_ptr<orcamodel::Geometry> targetGeomPtr;
@@ -165,7 +177,9 @@ class OrcaModelRegrid : public oops::Application {
       orcamodel::SourceExtender extender(
           geom.mesh(), geom.functionSpace(),
           nFlood, nSmooth, selfWeight, adjType);
+      geom.log_status();
       extender.extend(sourceFields);
+      geom.log_status();
 
       oops::Log::info() << "Source extension applied: " << nFlood
                         << " flood + " << nSmooth << " smooth iterations ("
@@ -177,12 +191,25 @@ class OrcaModelRegrid : public oops::Application {
     orcamodel::Regridder regridder(interpConf,
                                    geom.functionSpace(),
                                    targetFunctionSpace);
+    geom.log_status();
 
     // 5. Execute regridding
     atlas::FieldSet result = regridder.execute(sourceFields);
+    geom.log_status();
 
     oops::Log::info() << "Regridding complete. Output fields: "
                       << result.size() << std::endl;
+
+    // Diagnostics: regridded result fields
+    oops::Log::info() << "=== Regridded result field diagnostics ===" << std::endl;
+    for (atlas::idx_t i = 0; i < result.size(); ++i) {
+      const auto& f = result[i];
+      oops::Log::info() << "  [" << i << "] name=" << f.name()
+                        << " shape=(" << f.shape(0) << "," << f.shape(1) << ")"
+                        << " levels=" << f.levels()
+                        << " rank=" << f.rank()
+                        << " datatype=" << f.datatype().str() << std::endl;
+    }
 
     // 6. Write output
     if (conf.has("output")) {
@@ -192,6 +219,12 @@ class OrcaModelRegrid : public oops::Application {
       if (targetGeomPtr) {
         // ORCA target: use existing writeFieldsToFile infrastructure
         const util::DateTime validDate(stateConf.getString("date"));
+        eckit::PathName outPath(outputPath);
+        if (outPath.exists()) {
+          oops::Log::info() << "Removing existing output file: "
+                            << outputPath << std::endl;
+          outPath.unlink();
+        }
         orcamodel::writeFieldsToFile(outputPath, *targetGeomPtr, validDate, result);
         oops::Log::info() << "Output written to: " << outputPath << std::endl;
       } else {

--- a/src/mains/orcamodelRegrid.cc
+++ b/src/mains/orcamodelRegrid.cc
@@ -2,6 +2,10 @@
  * (C) British Crown Copyright 2026 Met Office
  */
 
+#include <iostream>
+#include <memory>
+#include <string>
+
 #include "atlas/grid.h"
 #include "atlas/functionspace.h"
 #include "atlas/mesh.h"

--- a/src/orca-jedi/CMakeLists.txt
+++ b/src/orca-jedi/CMakeLists.txt
@@ -35,6 +35,8 @@ utilities/OrcaModelTraits.h
 utilities/Types.h
 utilities/IOUtils.h
 utilities/IOUtils.cc
+utilities/MaskUtils.h
+utilities/MaskUtils.cc
 utilities/ModelData.h
 utilities/ModelData.cc
 variablechanges/VariableChangeParameters.h

--- a/src/orca-jedi/CMakeLists.txt
+++ b/src/orca-jedi/CMakeLists.txt
@@ -42,6 +42,8 @@ variablechanges/VariableChange.h
 variablechanges/LinearVariableChange.h
 variablechanges/LinearVariableChange.cc
 variablechanges/LinearVariableChangeParameters.h
+regridder/Regridder.h
+regridder/Regridder.cc
 )
 
 

--- a/src/orca-jedi/CMakeLists.txt
+++ b/src/orca-jedi/CMakeLists.txt
@@ -44,6 +44,8 @@ variablechanges/LinearVariableChange.cc
 variablechanges/LinearVariableChangeParameters.h
 regridder/Regridder.h
 regridder/Regridder.cc
+regridder/SourceExtender.h
+regridder/SourceExtender.cc
 )
 
 

--- a/src/orca-jedi/geometry/Geometry.cc
+++ b/src/orca-jedi/geometry/Geometry.cc
@@ -3,11 +3,13 @@
  */
 
 #include "orca-jedi/geometry/Geometry.h"
-#include "orca-jedi/utilities/Types.h"
+
+#include <algorithm>
 
 #include "atlas/field/Field.h"
 #include "atlas/field/FieldSet.h"
 #include "atlas/field/MissingValue.h"
+#include "atlas/array/DataType.h"
 #include "atlas/functionspace/StructuredColumns.h"  // IWYU pragma: keep
 #include "atlas/mesh.h"  // IWYU pragma: keep
 #include "atlas/meshgenerator.h"  // IWYU pragma: keep
@@ -22,6 +24,8 @@
 
 #include "oops/base/Variables.h"
 #include "oops/util/Logger.h"
+
+#include "orca-jedi/utilities/Types.h"
 
 namespace {
 /// \brief Construct an atlas grid given a string containing either a grid name
@@ -207,6 +211,26 @@ void Geometry::create_extrafields() {
   oops::Log::debug() << "orcamodel::Geometry: adding gmask (set to all ocean except halo)."
                      << std::endl;
   extraFields_->add(gmask);
+
+  // Create volumetric land-sea mask (nNodes, nLevels).
+  // Initialised to all-ocean (1) except ghost/edge nodes (0).
+  // Refined later via set_vol_mask() using a volumetric field's missing values.
+  atlas::Field vol_mask = funcSpace_.createField<int32_t>(
+    atlas::option::name("vol_mask") | atlas::option::levels(n_levels_));
+  auto vol_mask_view = atlas::array::make_view<int32_t, 2>(vol_mask);
+  for (atlas::idx_t j = 0; j < vol_mask_view.shape(0); ++j) {
+    int x = ij(j, 0) + 1;
+    int y = ij(j, 1) + 1;
+    int32_t val = (ghost(j) || x >= nx - 1 || y >= ny - 1) ? 0 : 1;
+    for (atlas::idx_t k = 0; k < vol_mask_view.shape(1); ++k) {
+      vol_mask_view(j, k) = val;
+    }
+  }
+  oops::Log::debug() << "orcamodel::Geometry: adding vol_mask "
+                     << "(set to all ocean except halo, "
+                     << vol_mask_view.shape(0) << " nodes, "
+                     << vol_mask_view.shape(1) << " levels)." << std::endl;
+  extraFields_->add(vol_mask);
 
   // Create grid cell area field /m^2 - the value used is not tuned.
   // Curerently ~= area of 2 degree square grid cell at the equator.
@@ -424,6 +448,60 @@ void Geometry::set_gmask(atlas::Field & field) const {
                     fieldPrecision(field.name()),
                     std::string("orcamodel::Geometry::set_gmask ")
                     + field.name() + "' field type not recognised");
+  log_status();
+}
+
+/// \brief Set vol_mask extra field from a volumetric field's missing values.
+///
+/// Where the input field has missing values, the corresponding (node, level)
+/// entry in vol_mask is set to 0 (masked). Only entries currently marked as
+/// ocean (1) can be masked; already-masked entries are never unmasked.
+///
+/// \param[in] field  A volumetric atlas::Field on the same function space.
+///                   Must have missing_value metadata set.
+void Geometry::set_vol_mask(atlas::Field & field) const {
+  oops::Log::debug() << "orcamodel::Geometry setting vol_mask from field "
+                     << field.name() << " missing values" << std::endl;
+
+  atlas::Field vol_mask = extraFields_.field("vol_mask");
+  auto mask_view = atlas::array::make_view<int32_t, 2>(vol_mask);
+
+  atlas::field::MissingValue mv(field);
+  if (!mv) {
+    oops::Log::warning() << "orcamodel::Geometry::set_vol_mask: field '"
+                         << field.name()
+                         << "' has no missing_value metadata, skipping"
+                         << std::endl;
+    return;
+  }
+
+  const auto setMask = [&](auto typeVal) {
+    using T = decltype(typeVal);
+    auto field_view = atlas::array::make_view<T, 2>(field);
+    // Handle shape mismatch: if field has fewer levels than vol_mask,
+    // only mask the levels that exist in the field.
+    const atlas::idx_t nLevels = std::min(field_view.shape(1),
+                                          mask_view.shape(1));
+    ASSERT(field_view.shape(0) == mask_view.shape(0));
+    for (atlas::idx_t j = 0; j < field_view.shape(0); ++j) {
+      for (atlas::idx_t k = 0; k < nLevels; ++k) {
+        if (mask_view(j, k) == 1 && mv(field_view(j, k))) {
+          mask_view(j, k) = 0;
+        }
+      }
+    }
+  };
+
+  if (field.datatype() == atlas::array::DataType::real64()) {
+    setMask(double{});
+  } else if (field.datatype() == atlas::array::DataType::real32()) {
+    setMask(float{});
+  } else {
+    oops::Log::warning() << "orcamodel::Geometry::set_vol_mask: field '"
+                         << field.name()
+                         << "' has unsupported datatype, skipping"
+                         << std::endl;
+  }
   log_status();
 }
 

--- a/src/orca-jedi/geometry/Geometry.cc
+++ b/src/orca-jedi/geometry/Geometry.cc
@@ -9,7 +9,7 @@
 #include "atlas/field/Field.h"
 #include "atlas/field/FieldSet.h"
 #include "atlas/field/MissingValue.h"
-#include "atlas/array/DataType.h"
+#include "atlas/array/DataType.h"  // IWYU pragma: keep
 #include "atlas/functionspace/StructuredColumns.h"  // IWYU pragma: keep
 #include "atlas/mesh.h"  // IWYU pragma: keep
 #include "atlas/meshgenerator.h"  // IWYU pragma: keep
@@ -20,11 +20,13 @@
 #include "eckit/mpi/Comm.h"
 #include "eckit/config/Configuration.h"
 #include "eckit/exception/Exceptions.h"
+#include "eckit/filesystem/PathName.h"
 #include "eckit/system/ResourceUsage.h"
 
 #include "oops/base/Variables.h"
 #include "oops/util/Logger.h"
 
+#include "orca-jedi/nemo_io/ReadServer.h"
 #include "orca-jedi/utilities/Types.h"
 
 namespace {
@@ -121,6 +123,37 @@ Geometry::Geometry(const eckit::Configuration & config,
       // Fill extra geometry fields for BUMP / SABER
       create_extrafields();
     }
+
+    // If a land-sea mask ancillary is configured, create and populate vol_mask
+    if (params_.landSeaMask.value()) {
+      if (!params_.extraFieldsInit.value().value_or(false)) {
+        create_extrafields();
+      }
+      const auto& lsm = *params_.landSeaMask.value();
+      const std::string maskFile = lsm.filepath.value();
+      const std::string maskVar = lsm.variable.value();
+      oops::Log::info() << "Geometry: reading land-sea mask from '"
+                        << maskFile << "' variable '" << maskVar
+                        << "'" << std::endl;
+
+      atlas::Field maskField = funcSpace_.createField<float>(
+          atlas::option::name(maskVar)
+          | atlas::option::levels(n_levels_));
+      {
+        ReadServer reader(eckit_timer_,
+                          eckit::PathName(maskFile), mesh_);
+        auto field_view = atlas::array::make_view<float, 2>(maskField);
+        reader.read_var<float>(maskVar, 0, field_view);
+        float fill = reader.read_fillvalue<float>(maskVar);
+        maskField.metadata().set("missing_value", fill);
+        maskField.metadata().set("missing_value_type",
+                                 "approximately-equals");
+        maskField.metadata().set("missing_value_epsilon", 1e-6);
+      }
+      set_vol_mask(maskField);
+      oops::Log::info() << "Geometry: vol_mask derived from '"
+                        << maskVar << "'" << std::endl;
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -211,26 +244,6 @@ void Geometry::create_extrafields() {
   oops::Log::debug() << "orcamodel::Geometry: adding gmask (set to all ocean except halo)."
                      << std::endl;
   extraFields_->add(gmask);
-
-  // Create volumetric land-sea mask (nNodes, nLevels).
-  // Initialised to all-ocean (1) except ghost/edge nodes (0).
-  // Refined later via set_vol_mask() using a volumetric field's missing values.
-  atlas::Field vol_mask = funcSpace_.createField<int32_t>(
-    atlas::option::name("vol_mask") | atlas::option::levels(n_levels_));
-  auto vol_mask_view = atlas::array::make_view<int32_t, 2>(vol_mask);
-  for (atlas::idx_t j = 0; j < vol_mask_view.shape(0); ++j) {
-    int x = ij(j, 0) + 1;
-    int y = ij(j, 1) + 1;
-    int32_t val = (ghost(j) || x >= nx - 1 || y >= ny - 1) ? 0 : 1;
-    for (atlas::idx_t k = 0; k < vol_mask_view.shape(1); ++k) {
-      vol_mask_view(j, k) = val;
-    }
-  }
-  oops::Log::debug() << "orcamodel::Geometry: adding vol_mask "
-                     << "(set to all ocean except halo, "
-                     << vol_mask_view.shape(0) << " nodes, "
-                     << vol_mask_view.shape(1) << " levels)." << std::endl;
-  extraFields_->add(vol_mask);
 
   // Create grid cell area field /m^2 - the value used is not tuned.
   // Curerently ~= area of 2 degree square grid cell at the equator.
@@ -451,17 +464,48 @@ void Geometry::set_gmask(atlas::Field & field) const {
   log_status();
 }
 
-/// \brief Set vol_mask extra field from a volumetric field's missing values.
+/// \brief Create or update the vol_mask extra field from a volumetric field's
+///        missing values.
 ///
-/// Where the input field has missing values, the corresponding (node, level)
-/// entry in vol_mask is set to 0 (masked). Only entries currently marked as
-/// ocean (1) can be masked; already-masked entries are never unmasked.
+/// If vol_mask does not yet exist in extraFields, it is created with shape
+/// (nNodes, nLevels) and initialised to 1 (ocean) for owned nodes and 0 for
+/// ghost/edge nodes.  Then, wherever the input field has a missing value, the
+/// corresponding (node, level) entry is set to 0 (masked).
 ///
 /// \param[in] field  A volumetric atlas::Field on the same function space.
 ///                   Must have missing_value metadata set.
-void Geometry::set_vol_mask(atlas::Field & field) const {
+void Geometry::set_vol_mask(atlas::Field & field) {
   oops::Log::debug() << "orcamodel::Geometry setting vol_mask from field "
                      << field.name() << " missing values" << std::endl;
+
+  // Create vol_mask if it doesn't exist yet
+  if (!extraFields_.has("vol_mask")) {
+    atlas::OrcaGrid orcaGrid = mesh_.grid();
+    int nx = orcaGrid.nx() + orcaGrid.haloWest() + orcaGrid.haloEast();
+    int ny = orcaGrid.ny() + orcaGrid.haloNorth();
+    auto ghost = atlas::array::make_view<int32_t, 1>(
+        mesh_.nodes().ghost());
+    auto ij = atlas::array::make_view<int32_t, 2>(
+        mesh_.nodes().field("ij"));
+
+    atlas::Field vol_mask = funcSpace_.createField<int32_t>(
+        atlas::option::name("vol_mask")
+        | atlas::option::levels(n_levels_));
+    auto vm = atlas::array::make_view<int32_t, 2>(vol_mask);
+    for (atlas::idx_t j = 0; j < vm.shape(0); ++j) {
+      int x = ij(j, 0) + 1;
+      int y = ij(j, 1) + 1;
+      int32_t val =
+          (ghost(j) || x >= nx - 1 || y >= ny - 1) ? 0 : 1;
+      for (atlas::idx_t k = 0; k < vm.shape(1); ++k) {
+        vm(j, k) = val;
+      }
+    }
+    extraFields_->add(vol_mask);
+    oops::Log::debug() << "orcamodel::Geometry: created vol_mask ("
+                       << vm.shape(0) << " nodes, "
+                       << vm.shape(1) << " levels)." << std::endl;
+  }
 
   atlas::Field vol_mask = extraFields_.field("vol_mask");
   auto mask_view = atlas::array::make_view<int32_t, 2>(vol_mask);
@@ -478,8 +522,6 @@ void Geometry::set_vol_mask(atlas::Field & field) const {
   const auto setMask = [&](auto typeVal) {
     using T = decltype(typeVal);
     auto field_view = atlas::array::make_view<T, 2>(field);
-    // Handle shape mismatch: if field has fewer levels than vol_mask,
-    // only mask the levels that exist in the field.
     const atlas::idx_t nLevels = std::min(field_view.shape(1),
                                           mask_view.shape(1));
     ASSERT(field_view.shape(0) == mask_view.shape(0));

--- a/src/orca-jedi/geometry/Geometry.cc
+++ b/src/orca-jedi/geometry/Geometry.cc
@@ -366,7 +366,11 @@ FieldDType Geometry::fieldPrecision(std::string variable_name) const {
 }
 
 void Geometry::print(std::ostream & os) const {
-  os << "Not Implemented";
+  os << "Geometry[grid=" << grid_.name()
+     << ", nodes=" << funcSpace_.size()
+     << ", levels=" << n_levels_
+     << ", partitioner=" << params_.partitioner.value()
+     << "]";
 }
 
 void Geometry::log_status() const {

--- a/src/orca-jedi/geometry/Geometry.cc
+++ b/src/orca-jedi/geometry/Geometry.cc
@@ -274,8 +274,8 @@ std::vector<size_t> Geometry::variableSizes(const oops::Variables & vars) const
     }
     if (varSizes[i] == 0) {
       std::stringstream err_stream;
-      err_stream << "orcamodel::Geometry::variableSizes variable name \" ";
-      err_stream << "\" " << vars[i].name() << " not recognised. " << std::endl;
+      err_stream << "orcamodel::Geometry::variableSizes variable name \"";
+      err_stream << vars[i].name() << "\" not recognised. " << std::endl;
       throw eckit::BadValue(err_stream.str(), Here());
     }
   }

--- a/src/orca-jedi/geometry/Geometry.h
+++ b/src/orca-jedi/geometry/Geometry.h
@@ -75,6 +75,7 @@ class Geometry : public util::Printable,
   std::shared_ptr<eckit::Timer> timer() const {return eckit_timer_;}
   void log_status() const;
   void set_gmask(atlas::Field &) const;
+  void set_vol_mask(atlas::Field &) const;
 
  private:
   void print(std::ostream &) const;

--- a/src/orca-jedi/geometry/Geometry.h
+++ b/src/orca-jedi/geometry/Geometry.h
@@ -75,7 +75,7 @@ class Geometry : public util::Printable,
   std::shared_ptr<eckit::Timer> timer() const {return eckit_timer_;}
   void log_status() const;
   void set_gmask(atlas::Field &) const;
-  void set_vol_mask(atlas::Field &) const;
+  void set_vol_mask(atlas::Field &);
 
  private:
   void print(std::ostream &) const;

--- a/src/orca-jedi/geometry/GeometryParameters.h
+++ b/src/orca-jedi/geometry/GeometryParameters.h
@@ -35,6 +35,20 @@ class NemoFieldParameters : public oops::Parameters {
     this};
 };
 
+/// \brief Optional parameters for reading a land-sea mask ancillary.
+///
+/// When specified in the geometry configuration, a volumetric field is read
+/// from the given NetCDF file and its missing values are used to populate
+/// the 3D vol_mask extra field. This makes the mask available to any code
+/// that uses the geometry (e.g. State resolution-change constructor).
+class LandSeaMaskParameters : public oops::Parameters {
+  OOPS_CONCRETE_PARAMETERS(LandSeaMaskParameters, oops::Parameters)
+
+ public:
+  oops::RequiredParameter<std::string> filepath {"filepath", this};
+  oops::RequiredParameter<std::string> variable {"variable", this};
+};
+
 class OrcaGeometryParameters : public oops::Parameters {
   OOPS_CONCRETE_PARAMETERS(OrcaGeometryParameters, oops::Parameters)
 
@@ -55,7 +69,10 @@ class OrcaGeometryParameters : public oops::Parameters {
         " The default will not distribute the data ('serial').",
       "serial",
       this};
-  oops::OptionalParameter<bool> extraFieldsInit{"initialise extra fields", this};
+  oops::OptionalParameter<bool> extraFieldsInit{
+      "initialise extra fields", this};
+  oops::OptionalParameter<LandSeaMaskParameters> landSeaMask{
+      "land sea mask", this};
 };
 
 }  //  namespace orcamodel

--- a/src/orca-jedi/interpolator/Interpolator.cc
+++ b/src/orca-jedi/interpolator/Interpolator.cc
@@ -104,8 +104,8 @@ Interpolator::Interpolator(const eckit::Configuration& conf,
     oops::Log::debug() << "  gmask shape: (" << gmask_view.shape(0) << ", "
                        << gmask_view.shape(1) << ")" << std::endl;
   } else if (comm_.rank() == 0) {
-    oops::Log::warning() << "orcamodel::Interpolator: gmask field not found in geometry"
-                         << " and land masking will not be applied" << std::endl;
+    oops::Log::debug() << "orcamodel::Interpolator: gmask field not found in geometry"
+                       << " and land masking will not be applied" << std::endl;
   }
 }
 
@@ -301,8 +301,8 @@ void Interpolator::apply(const oops::Variables& vars, const Increment& inc,
       // No mask available, use increment field directly
       src_field = inc.incrementFields()[gv_varname];
       if (comm_.rank() == 0) {
-        oops::Log::warning() << "orcamodel::Interpolator::apply(increment): No gmask available for "
-                             << gv_varname << std::endl;
+        oops::Log::debug() << "orcamodel::Interpolator::apply(increment): No gmask available for "
+                           << gv_varname << std::endl;
       }
     }
 

--- a/src/orca-jedi/regridder/Regridder.cc
+++ b/src/orca-jedi/regridder/Regridder.cc
@@ -1,0 +1,43 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#include "orca-jedi/regridder/Regridder.h"
+
+#include <string>
+#include <vector>
+
+#include "atlas/field.h"
+#include "atlas/functionspace.h"
+#include "atlas/interpolation.h"
+#include "eckit/config/Configuration.h"
+#include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
+
+namespace orcamodel {
+
+Regridder::Regridder(const eckit::Configuration& conf,
+                     const atlas::FunctionSpace& sourceFunctionSpace,
+                     const atlas::FunctionSpace& targetFunctionSpace)
+    : sourceFunctionSpace_(sourceFunctionSpace),
+      targetFunctionSpace_(targetFunctionSpace),
+      interpolation_(conf, sourceFunctionSpace_, targetFunctionSpace_) {}
+
+atlas::FieldSet Regridder::execute(const atlas::FieldSet& source) const {
+  atlas::FieldSet target;
+  for (atlas::idx_t i = 0; i < source.size(); ++i) {
+    target.add(execute(source[i]));
+  }
+  return target;
+}
+
+atlas::Field Regridder::execute(const atlas::Field& source) const {
+  atlas::Field target = targetFunctionSpace_.createField(
+      atlas::option::name(source.name()) |
+      atlas::option::levels(source.levels()) |
+      atlas::option::datatype(source.datatype()));
+  interpolation_.execute(source, target);
+  return target;
+}
+
+}  // namespace orcamodel

--- a/src/orca-jedi/regridder/Regridder.cc
+++ b/src/orca-jedi/regridder/Regridder.cc
@@ -14,6 +14,8 @@
 #include "eckit/config/LocalConfiguration.h"
 #include "eckit/exception/Exceptions.h"
 
+#include "oops/util/Logger.h"
+
 namespace orcamodel {
 
 Regridder::Regridder(const eckit::Configuration& conf,
@@ -36,6 +38,8 @@ atlas::Field Regridder::execute(const atlas::Field& source) const {
       atlas::option::name(source.name()) |
       atlas::option::levels(source.levels()) |
       atlas::option::datatype(source.datatype()));
+  oops::Log::trace() << "orcamodel::Regridder::execute field '"
+      << source.name() << "'" << std::endl;
   interpolation_.execute(source, target);
   return target;
 }

--- a/src/orca-jedi/regridder/Regridder.cc
+++ b/src/orca-jedi/regridder/Regridder.cc
@@ -38,6 +38,10 @@ atlas::Field Regridder::execute(const atlas::Field& source) const {
       atlas::option::name(source.name()) |
       atlas::option::levels(source.levels()) |
       atlas::option::datatype(source.datatype()));
+
+  // Preserve metadata (e.g. missing_value) for downstream masking/IO.
+  target.metadata() = source.metadata();
+
   oops::Log::trace() << "orcamodel::Regridder::execute field '"
       << source.name() << "'" << std::endl;
   interpolation_.execute(source, target);

--- a/src/orca-jedi/regridder/Regridder.h
+++ b/src/orca-jedi/regridder/Regridder.h
@@ -1,0 +1,62 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "atlas/field.h"
+#include "atlas/functionspace.h"
+#include "atlas/grid.h"
+#include "atlas/interpolation.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/mesh.h"
+#include "eckit/config/Configuration.h"
+
+namespace orcamodel {
+
+/// \brief Atlas-only regridder class.
+///
+/// Performs interpolation/regridding between any two atlas FunctionSpaces.
+/// No OOPS dependency — designed to be extractable to a standalone tool.
+///
+/// Configuration example:
+/// \code{.yaml}
+/// interpolation method:
+///   type: finite-element
+///   non_linear: missing-if-all-missing
+/// target grid:
+///   name: L90
+/// \endcode
+class Regridder {
+ public:
+  /// \brief Construct a Regridder from source/target FunctionSpaces and config.
+  /// \param conf Configuration specifying interpolation method and options.
+  /// \param sourceFunctionSpace The source function space (already constructed).
+  /// \param targetFunctionSpace The target function space (already constructed).
+  Regridder(const eckit::Configuration& conf,
+            const atlas::FunctionSpace& sourceFunctionSpace,
+            const atlas::FunctionSpace& targetFunctionSpace);
+
+  /// \brief Execute regridding on a FieldSet.
+  /// \param source Source fields to regrid.
+  /// \return A new FieldSet on the target function space.
+  atlas::FieldSet execute(const atlas::FieldSet& source) const;
+
+  /// \brief Execute regridding on a single Field.
+  /// \param source Source field to regrid.
+  /// \return A new Field on the target function space.
+  atlas::Field execute(const atlas::Field& source) const;
+
+  /// \brief Access the underlying atlas Interpolation object.
+  const atlas::Interpolation& interpolation() const { return interpolation_; }
+
+ private:
+  atlas::FunctionSpace sourceFunctionSpace_;
+  atlas::FunctionSpace targetFunctionSpace_;
+  atlas::Interpolation interpolation_;
+};
+
+}  // namespace orcamodel

--- a/src/orca-jedi/regridder/SourceExtender.cc
+++ b/src/orca-jedi/regridder/SourceExtender.cc
@@ -7,8 +7,8 @@
 #include <set>
 #include <vector>
 
-#include "atlas/array/MakeView.h"
-#include "atlas/array/DataType.h"
+#include "atlas/array/MakeView.h"  // IWYU pragma: keep
+#include "atlas/array/DataType.h"  // IWYU pragma: keep
 #include "atlas/field/MissingValue.h"
 #include "atlas/mesh/Connectivity.h"
 #include "atlas/mesh/Nodes.h"
@@ -168,6 +168,8 @@ void SourceExtender::extendTyped(atlas::Field& field) const {
   const atlas::idx_t nLevels = field.levels() > 0 ? field.levels() : 1;
 
   auto view = atlas::array::make_view<T, 2>(field);
+  auto ghost = atlas::array::make_view<int32_t, 1>(
+      funcSpace_.ghost());
 
   // Track which nodes were originally missing (per level).
   // These are the nodes eligible for flooding and smoothing.
@@ -202,6 +204,7 @@ void SourceExtender::extendTyped(atlas::Field& field) const {
 
     for (atlas::idx_t k = 0; k < nLevels; ++k) {
       for (atlas::idx_t j = 0; j < nNodes; ++j) {
+        if (ghost(j)) continue;  // ghost nodes filled via haloExchange
         if (validSnapshot[k][j]) continue;  // already valid
 
         // Check neighbours for valid values
@@ -226,6 +229,19 @@ void SourceExtender::extendTyped(atlas::Field& field) const {
 
     // Halo exchange after each flood iteration
     funcSpace_.haloExchange(field);
+
+    // Re-sync isValid for ghost nodes from the actual field values,
+    // since haloExchange may have updated ghost values.
+    for (atlas::idx_t k = 0; k < nLevels; ++k) {
+      for (atlas::idx_t j = 0; j < nNodes; ++j) {
+        if (!ghost(j)) continue;
+        bool nowValid = !mv(view(j, k));
+        isValid[k][j] = nowValid;
+        if (nowValid && originallyMissing[k][j]) {
+          wasFlooded[k][j] = true;
+        }
+      }
+    }
   }
 
   // --- Smoothing on flooded cells only ---
@@ -239,6 +255,7 @@ void SourceExtender::extendTyped(atlas::Field& field) const {
     for (int iter = 0; iter < nSmoothIterations_; ++iter) {
       for (atlas::idx_t k = 0; k < nLevels; ++k) {
         for (atlas::idx_t j = 0; j < nNodes; ++j) {
+          if (ghost(j)) continue;             // ghost nodes via haloExchange
           if (!wasFlooded[k][j]) continue;  // only smooth flooded cells
 
           double neighbourSum = 0.0;

--- a/src/orca-jedi/regridder/SourceExtender.cc
+++ b/src/orca-jedi/regridder/SourceExtender.cc
@@ -223,6 +223,7 @@ void SourceExtender::extendTyped(atlas::Field& field) const {
           int neighbourCount = 0;
           for (atlas::idx_t neighbour : adjacency_[j]) {
             if (neighbour >= nNodes) continue;
+            if (!isValid[k][neighbour]) continue;  // skip still-missing cells
             neighbourSum += view(neighbour, k);
             ++neighbourCount;
           }

--- a/src/orca-jedi/regridder/SourceExtender.cc
+++ b/src/orca-jedi/regridder/SourceExtender.cc
@@ -1,0 +1,237 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#include "orca-jedi/regridder/SourceExtender.h"
+
+#include <set>
+#include <vector>
+
+#include "atlas/array/MakeView.h"
+#include "atlas/field/MissingValue.h"
+#include "atlas/mesh/Connectivity.h"
+#include "atlas/mesh/Nodes.h"
+#include "atlas/mesh/actions/BuildEdges.h"
+#include "atlas/mesh/actions/BuildNode2CellConnectivity.h"
+
+#include "eckit/exception/Exceptions.h"
+
+#include "oops/util/Logger.h"
+
+namespace orcamodel {
+
+namespace {
+
+/// Build node-to-node adjacency via shared cells (includes diagonal neighbours).
+std::vector<std::vector<atlas::idx_t>> buildCellBasedAdjacency(
+    atlas::Mesh& mesh) {
+  // Ensure node-to-cell connectivity is built
+  atlas::mesh::actions::build_node_to_cell_connectivity(mesh);
+
+  const auto& node2cell = mesh.nodes().cell_connectivity();
+  const auto& cell2node = mesh.cells().node_connectivity();
+  const atlas::idx_t nNodes = mesh.nodes().size();
+
+  std::vector<std::vector<atlas::idx_t>> adj(nNodes);
+  for (atlas::idx_t jnode = 0; jnode < nNodes; ++jnode) {
+    std::set<atlas::idx_t> neighbours;
+    for (atlas::idx_t jc = 0; jc < node2cell.cols(jnode); ++jc) {
+      atlas::idx_t icell = node2cell(jnode, jc);
+      if (icell < 0) continue;  // missing connectivity entry
+      for (atlas::idx_t jn = 0; jn < cell2node.cols(icell); ++jn) {
+        atlas::idx_t candidate = cell2node(icell, jn);
+        if (candidate != jnode && candidate >= 0) {
+          neighbours.insert(candidate);
+        }
+      }
+    }
+    adj[jnode].assign(neighbours.begin(), neighbours.end());
+  }
+  return adj;
+}
+
+/// Build node-to-node adjacency via edges (edge-connected neighbours only).
+std::vector<std::vector<atlas::idx_t>> buildEdgeBasedAdjacency(
+    atlas::Mesh& mesh) {
+  // Ensure edges and node-to-edge connectivity are built
+  atlas::mesh::actions::build_edges(mesh);
+  atlas::mesh::actions::build_node_to_edge_connectivity(mesh);
+
+  const auto& node2edge = mesh.nodes().edge_connectivity();
+  const auto& edge2node = mesh.edges().node_connectivity();
+  const atlas::idx_t nNodes = mesh.nodes().size();
+
+  std::vector<std::vector<atlas::idx_t>> adj(nNodes);
+  for (atlas::idx_t jnode = 0; jnode < nNodes; ++jnode) {
+    std::set<atlas::idx_t> neighbours;
+    for (atlas::idx_t je = 0; je < node2edge.cols(jnode); ++je) {
+      atlas::idx_t iedge = node2edge(jnode, je);
+      if (iedge < 0) continue;
+      atlas::idx_t n_a = edge2node(iedge, 0);
+      atlas::idx_t n_b = edge2node(iedge, 1);
+      atlas::idx_t neighbour = (n_a == jnode) ? n_b : n_a;
+      if (neighbour >= 0) {
+        neighbours.insert(neighbour);
+      }
+    }
+    adj[jnode].assign(neighbours.begin(), neighbours.end());
+  }
+  return adj;
+}
+
+}  // namespace
+
+SourceExtender::SourceExtender(const atlas::Mesh& mesh,
+                               const atlas::FunctionSpace& funcSpace,
+                               int nFloodIterations,
+                               int nSmoothIterations,
+                               double smoothWeightSelf,
+                               AdjacencyType adjacency)
+    : funcSpace_(funcSpace),
+      nFloodIterations_(nFloodIterations),
+      nSmoothIterations_(nSmoothIterations),
+      smoothWeightSelf_(smoothWeightSelf) {
+  ASSERT(nFloodIterations >= 0);
+  ASSERT(nSmoothIterations >= 0);
+  ASSERT(smoothWeightSelf >= 0.0 && smoothWeightSelf <= 1.0);
+
+  // Take a non-const copy via atlas handle semantics (cheap, shared data)
+  atlas::Mesh mutableMesh(mesh);
+
+  if (adjacency == AdjacencyType::CellBased) {
+    oops::Log::info() << "SourceExtender: building cell-based adjacency"
+                      << std::endl;
+    adjacency_ = buildCellBasedAdjacency(mutableMesh);
+  } else {
+    oops::Log::info() << "SourceExtender: building edge-based adjacency"
+                      << std::endl;
+    adjacency_ = buildEdgeBasedAdjacency(mutableMesh);
+  }
+  oops::Log::info() << "SourceExtender: adjacency built for "
+                    << adjacency_.size() << " nodes" << std::endl;
+}
+
+void SourceExtender::extend(atlas::FieldSet& fields) const {
+  for (atlas::idx_t i = 0; i < fields.size(); ++i) {
+    extend(fields[i]);
+  }
+}
+
+void SourceExtender::extend(atlas::Field& field) const {
+  if (nFloodIterations_ == 0) return;
+
+  // Determine missing value from field metadata
+  atlas::field::MissingValue mv(field);
+  if (!mv) {
+    oops::Log::warning()
+        << "SourceExtender::extend: field '" << field.name()
+        << "' has no missing_value metadata, skipping" << std::endl;
+    return;
+  }
+
+  const atlas::idx_t nNodes = field.shape(0);
+  const atlas::idx_t nLevels = field.levels() > 0 ? field.levels() : 1;
+
+  auto view = atlas::array::make_view<double, 2>(field);
+
+  // Track which nodes were originally missing (per level).
+  // These are the nodes eligible for flooding and smoothing.
+  std::vector<std::vector<bool>> originallyMissing(
+      nLevels, std::vector<bool>(nNodes, false));
+  for (atlas::idx_t k = 0; k < nLevels; ++k) {
+    for (atlas::idx_t j = 0; j < nNodes; ++j) {
+      originallyMissing[k][j] = mv(view(j, k));
+    }
+  }
+
+  // Working mask: true = currently valid (ocean). Updated as we flood.
+  std::vector<std::vector<bool>> isValid(
+      nLevels, std::vector<bool>(nNodes, false));
+  for (atlas::idx_t k = 0; k < nLevels; ++k) {
+    for (atlas::idx_t j = 0; j < nNodes; ++j) {
+      isValid[k][j] = !originallyMissing[k][j];
+    }
+  }
+
+  // Track which nodes were flooded (for selective smoothing)
+  std::vector<std::vector<bool>> wasFlooded(
+      nLevels, std::vector<bool>(nNodes, false));
+
+  // --- Flood-fill iterations ---
+  for (int iter = 0; iter < nFloodIterations_; ++iter) {
+    // Snapshot the current validity for this iteration
+    auto validSnapshot = isValid;
+
+    for (atlas::idx_t k = 0; k < nLevels; ++k) {
+      for (atlas::idx_t j = 0; j < nNodes; ++j) {
+        if (validSnapshot[k][j]) continue;  // already valid
+
+        // Check neighbours for valid values
+        double weightedSum = 0.0;
+        double totalWeight = 0.0;
+        for (atlas::idx_t neighbour : adjacency_[j]) {
+          if (neighbour >= nNodes) continue;
+          if (validSnapshot[k][neighbour]) {
+            weightedSum += view(neighbour, k);
+            totalWeight += 1.0;
+          }
+        }
+
+        if (totalWeight > 0.0) {
+          // At least one valid neighbour: fill this cell
+          view(j, k) = weightedSum / totalWeight;
+          isValid[k][j] = true;
+          wasFlooded[k][j] = true;
+        }
+      }
+    }
+
+    // Halo exchange after each flood iteration
+    funcSpace_.haloExchange(field);
+  }
+
+  // --- Smoothing on flooded cells only ---
+  if (nSmoothIterations_ > 0) {
+    const double neighbourWeight = 1.0 - smoothWeightSelf_;
+    std::vector<double> tmp(nNodes);
+
+    for (int iter = 0; iter < nSmoothIterations_; ++iter) {
+      for (atlas::idx_t k = 0; k < nLevels; ++k) {
+        for (atlas::idx_t j = 0; j < nNodes; ++j) {
+          if (!wasFlooded[k][j]) continue;  // only smooth flooded cells
+
+          double neighbourSum = 0.0;
+          int neighbourCount = 0;
+          for (atlas::idx_t neighbour : adjacency_[j]) {
+            if (neighbour >= nNodes) continue;
+            neighbourSum += view(neighbour, k);
+            ++neighbourCount;
+          }
+
+          if (neighbourCount > 0) {
+            tmp[j] = smoothWeightSelf_ * view(j, k)
+                   + neighbourWeight * neighbourSum / neighbourCount;
+          } else {
+            tmp[j] = view(j, k);
+          }
+        }
+        // Apply smoothed values
+        for (atlas::idx_t j = 0; j < nNodes; ++j) {
+          if (wasFlooded[k][j]) {
+            view(j, k) = tmp[j];
+          }
+        }
+      }
+
+      // Halo exchange after each smoothing iteration
+      funcSpace_.haloExchange(field);
+    }
+  }
+
+  oops::Log::debug() << "SourceExtender::extend: extended field '"
+                     << field.name() << "' with " << nFloodIterations_
+                     << " flood + " << nSmoothIterations_
+                     << " smooth iterations" << std::endl;
+}
+
+}  // namespace orcamodel

--- a/src/orca-jedi/regridder/SourceExtender.cc
+++ b/src/orca-jedi/regridder/SourceExtender.cc
@@ -92,6 +92,7 @@ SourceExtender::SourceExtender(const atlas::Mesh& mesh,
       nFloodIterations_(nFloodIterations),
       nSmoothIterations_(nSmoothIterations),
       smoothWeightSelf_(smoothWeightSelf) {
+  oops::Log::trace() << "orcamodel::SourceExtender constructor starting" << std::endl;
   ASSERT(nFloodIterations >= 0);
   ASSERT(nSmoothIterations >= 0);
   ASSERT(smoothWeightSelf >= 0.0 && smoothWeightSelf <= 1.0);
@@ -110,16 +111,25 @@ SourceExtender::SourceExtender(const atlas::Mesh& mesh,
   }
   oops::Log::info() << "SourceExtender: adjacency built for "
                     << adjacency_.size() << " nodes" << std::endl;
+  oops::Log::trace() << "orcamodel::SourceExtender constructor finished" << std::endl;
 }
 
 void SourceExtender::extend(atlas::FieldSet& fields) const {
+  oops::Log::trace() << "orcamodel::SourceExtender extend fieldset starting" << std::endl;
   for (atlas::idx_t i = 0; i < fields.size(); ++i) {
     extend(fields[i]);
   }
+  oops::Log::trace() << "orcamodel::SourceExtender extend fieldset finished" << std::endl;
 }
 
 void SourceExtender::extend(atlas::Field& field) const {
-  if (nFloodIterations_ == 0) return;
+  oops::Log::trace() << "orcamodel::SourceExtender extend field '"
+      << field.name() << "' starting" << std::endl;
+  if (nFloodIterations_ == 0) {
+    oops::Log::trace() << "orcamodel::SourceExtender extend field '"
+        << field.name() << "' finished (no flooding)" << std::endl;
+    return;
+  }
 
   // Determine missing value from field metadata
   atlas::field::MissingValue mv(field);
@@ -127,6 +137,8 @@ void SourceExtender::extend(atlas::Field& field) const {
     oops::Log::warning()
         << "SourceExtender::extend: field '" << field.name()
         << "' has no missing_value metadata, skipping" << std::endl;
+    oops::Log::trace() << "orcamodel::SourceExtender extend field '"
+        << field.name() << "' finished (no missing values)" << std::endl;
     return;
   }
 
@@ -140,8 +152,12 @@ void SourceExtender::extend(atlas::Field& field) const {
         << "SourceExtender::extend: field '" << field.name()
         << "' has unsupported datatype (kind="
         << field.datatype().kind() << "), skipping" << std::endl;
+    oops::Log::trace() << "orcamodel::SourceExtender extend field '"
+        << field.name() << "' finished (unsupported datatype)" << std::endl;
     return;
   }
+  oops::Log::trace() << "orcamodel::SourceExtender extend field '"
+      << field.name() << "' finished" << std::endl;
 }
 
 template <typename T>
@@ -177,6 +193,9 @@ void SourceExtender::extendTyped(atlas::Field& field) const {
       nLevels, std::vector<bool>(nNodes, false));
 
   // --- Flood-fill iterations ---
+  oops::Log::debug() << "SourceExtender::extend: flooding field '"
+                     << field.name() << "' with " << nFloodIterations_
+                     << " flood iterations" << std::endl;
   for (int iter = 0; iter < nFloodIterations_; ++iter) {
     // Snapshot the current validity for this iteration
     auto validSnapshot = isValid;
@@ -213,6 +232,9 @@ void SourceExtender::extendTyped(atlas::Field& field) const {
   if (nSmoothIterations_ > 0) {
     const double neighbourWeight = 1.0 - smoothWeightSelf_;
     std::vector<T> tmp(nNodes);
+    oops::Log::debug() << "SourceExtender::extend: smoothing field '"
+                       << field.name() << "' with " << nSmoothIterations_
+                       << " smooth iterations" << std::endl;
 
     for (int iter = 0; iter < nSmoothIterations_; ++iter) {
       for (atlas::idx_t k = 0; k < nLevels; ++k) {

--- a/src/orca-jedi/regridder/SourceExtender.cc
+++ b/src/orca-jedi/regridder/SourceExtender.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "atlas/array/MakeView.h"
+#include "atlas/array/DataType.h"
 #include "atlas/field/MissingValue.h"
 #include "atlas/mesh/Connectivity.h"
 #include "atlas/mesh/Nodes.h"
@@ -129,10 +130,28 @@ void SourceExtender::extend(atlas::Field& field) const {
     return;
   }
 
+  // Dispatch based on field datatype
+  if (field.datatype() == atlas::array::DataType::real64()) {
+    extendTyped<double>(field);
+  } else if (field.datatype() == atlas::array::DataType::real32()) {
+    extendTyped<float>(field);
+  } else {
+    oops::Log::warning()
+        << "SourceExtender::extend: field '" << field.name()
+        << "' has unsupported datatype (kind="
+        << field.datatype().kind() << "), skipping" << std::endl;
+    return;
+  }
+}
+
+template <typename T>
+void SourceExtender::extendTyped(atlas::Field& field) const {
+  atlas::field::MissingValue mv(field);
+
   const atlas::idx_t nNodes = field.shape(0);
   const atlas::idx_t nLevels = field.levels() > 0 ? field.levels() : 1;
 
-  auto view = atlas::array::make_view<double, 2>(field);
+  auto view = atlas::array::make_view<T, 2>(field);
 
   // Track which nodes were originally missing (per level).
   // These are the nodes eligible for flooding and smoothing.
@@ -179,7 +198,7 @@ void SourceExtender::extend(atlas::Field& field) const {
 
         if (totalWeight > 0.0) {
           // At least one valid neighbour: fill this cell
-          view(j, k) = weightedSum / totalWeight;
+          view(j, k) = static_cast<T>(weightedSum / totalWeight);
           isValid[k][j] = true;
           wasFlooded[k][j] = true;
         }
@@ -193,7 +212,7 @@ void SourceExtender::extend(atlas::Field& field) const {
   // --- Smoothing on flooded cells only ---
   if (nSmoothIterations_ > 0) {
     const double neighbourWeight = 1.0 - smoothWeightSelf_;
-    std::vector<double> tmp(nNodes);
+    std::vector<T> tmp(nNodes);
 
     for (int iter = 0; iter < nSmoothIterations_; ++iter) {
       for (atlas::idx_t k = 0; k < nLevels; ++k) {
@@ -209,8 +228,8 @@ void SourceExtender::extend(atlas::Field& field) const {
           }
 
           if (neighbourCount > 0) {
-            tmp[j] = smoothWeightSelf_ * view(j, k)
-                   + neighbourWeight * neighbourSum / neighbourCount;
+            tmp[j] = static_cast<T>(smoothWeightSelf_ * view(j, k)
+                   + neighbourWeight * neighbourSum / neighbourCount);
           } else {
             tmp[j] = view(j, k);
           }

--- a/src/orca-jedi/regridder/SourceExtender.h
+++ b/src/orca-jedi/regridder/SourceExtender.h
@@ -71,6 +71,10 @@ class SourceExtender {
   void extend(atlas::Field& field) const;
 
  private:
+  /// Templated implementation of extend for a specific scalar type.
+  template <typename T>
+  void extendTyped(atlas::Field& field) const;
+
   /// Pre-computed node-to-node adjacency list.
   std::vector<std::vector<atlas::idx_t>> adjacency_;
 

--- a/src/orca-jedi/regridder/SourceExtender.h
+++ b/src/orca-jedi/regridder/SourceExtender.h
@@ -1,0 +1,83 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "atlas/field.h"
+#include "atlas/functionspace.h"
+#include "atlas/mesh.h"
+
+namespace orcamodel {
+
+/// \brief Connectivity type for computing node-to-node adjacency.
+enum class AdjacencyType {
+  /// Cell-based: neighbours are all nodes sharing a cell with a given node.
+  /// On a quad mesh this gives the 8 surrounding nodes (4 edge + 4 corner),
+  /// matching the stencil used by NEMOVAR's sim_ext.
+  CellBased,
+  /// Edge-based: neighbours are nodes connected by a mesh edge.
+  /// Typically 4–6 neighbours on a quad mesh. More geometrically principled
+  /// but a sparser stencil than NEMOVAR.
+  EdgeBased
+};
+
+/// \brief Extends source field data into missing-value (land) regions.
+///
+/// Before regridding from a coarser to a finer grid, target ocean points
+/// whose entire interpolation stencil falls on source land will receive
+/// missing values. This class fills ("floods") missing-value cells on the
+/// source grid by iteratively averaging from valid neighbours, then
+/// smooths the newly-flooded cells to remove discontinuities.
+///
+/// This is analogous to NEMOVAR's sim_ext module (VAR_SRC/SIM/sim_ext.F90).
+///
+/// Configuration example:
+/// \code{.yaml}
+/// source extension:
+///   flood iterations: 2
+///   smooth iterations: 50
+///   smooth weight self: 0.35
+///   adjacency: cell-based   # or "edge-based"
+/// \endcode
+class SourceExtender {
+ public:
+  /// \brief Construct a SourceExtender.
+  /// \param mesh The atlas Mesh for the source grid. Connectivity structures
+  ///             may be built on the mesh (non-const copy is taken internally
+  ///             via atlas's handle semantics).
+  /// \param funcSpace The NodeColumns function space (for halo exchange).
+  /// \param nFloodIterations Number of flood-fill iterations (cells deep).
+  /// \param nSmoothIterations Smoothing iterations on flooded cells.
+  /// \param smoothWeightSelf Self-weight in smoothing (NEMOVAR uses 0.35).
+  /// \param adjacency Connectivity type for neighbour lookup.
+  SourceExtender(const atlas::Mesh& mesh,
+                 const atlas::FunctionSpace& funcSpace,
+                 int nFloodIterations = 2,
+                 int nSmoothIterations = 50,
+                 double smoothWeightSelf = 0.35,
+                 AdjacencyType adjacency = AdjacencyType::CellBased);
+
+  /// \brief Extend all fields in a FieldSet in-place.
+  ///
+  /// For each field, missing-value cells adjacent to valid cells are
+  /// iteratively filled, then the newly-filled cells are smoothed.
+  /// Fields must have "missing_value" metadata set.
+  void extend(atlas::FieldSet& fields) const;
+
+  /// \brief Extend a single Field in-place.
+  void extend(atlas::Field& field) const;
+
+ private:
+  /// Pre-computed node-to-node adjacency list.
+  std::vector<std::vector<atlas::idx_t>> adjacency_;
+
+  atlas::FunctionSpace funcSpace_;
+  int nFloodIterations_;
+  int nSmoothIterations_;
+  double smoothWeightSelf_;
+};
+
+}  // namespace orcamodel

--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -38,6 +38,7 @@
 #include "orca-jedi/regridder/SourceExtender.h"
 #include "orca-jedi/state/State.h"
 #include "orca-jedi/utilities/IOUtils.h"
+#include "orca-jedi/utilities/MaskUtils.h"
 #include "orca-jedi/utilities/Types.h"
 
 
@@ -143,6 +144,11 @@ State::State(const Geometry & resol, const State & other)
                         resol.functionSpace());
 
     stateFields_ = regridder.execute(extendedSource);
+
+    // 4. Re-mask with target geometry's land-sea mask
+    if (resol.extraFields().has("vol_mask")) {
+      applyMaskToFields(resol.extraFields().field("vol_mask"), stateFields_);
+    }
 
     oops::Log::trace() << "State(ORCA)::State resolution change: "
                        << "regridded from " << other.geom_->grid().name()

--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -34,6 +34,7 @@
 #include "orca-jedi/geometry/Geometry.h"
 #include "orca-jedi/variablechanges/VariableChange.h"
 #include "orca-jedi/increment/Increment.h"
+#include "orca-jedi/regridder/Regridder.h"
 #include "orca-jedi/state/State.h"
 #include "orca-jedi/utilities/IOUtils.h"
 #include "orca-jedi/utilities/Types.h"
@@ -110,10 +111,28 @@ State::State(const Geometry & resol, const State & other)
     , params_(other.params_)
     , vars_(other.vars_)
     , time_(other.time_)
-    , stateFields_(other.stateFields_) {
-  ASSERT(other.geom_->grid().uid() == resol.grid().uid());
-  oops::Log::trace() << "State(ORCA)::State resolution change: "
-                     << " copied as there is no change" << std::endl;
+    , stateFields_() {
+  if (other.geom_->grid().uid() == resol.grid().uid()) {
+    // Same grid: just copy fields
+    stateFields_ = other.stateFields_;
+    oops::Log::trace() << "State(ORCA)::State resolution change: "
+                       << " copied as there is no change" << std::endl;
+  } else {
+    // Different grid: regrid from other's geometry to the new geometry
+    eckit::LocalConfiguration interpConf;
+    interpConf.set("type", "unstructured-bilinear-lonlat");
+    interpConf.set("non_linear", "missing-if-all-missing");
+
+    Regridder regridder(interpConf,
+                        other.geom_->functionSpace(),
+                        resol.functionSpace());
+
+    stateFields_ = regridder.execute(other.stateFields_);
+
+    oops::Log::trace() << "State(ORCA)::State resolution change: "
+                       << "regridded from " << other.geom_->grid().name()
+                       << " to " << resol.grid().name() << std::endl;
+  }
 }
 
 State::State(const oops::Variables & variables, const State & other)

--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -35,6 +35,7 @@
 #include "orca-jedi/variablechanges/VariableChange.h"
 #include "orca-jedi/increment/Increment.h"
 #include "orca-jedi/regridder/Regridder.h"
+#include "orca-jedi/regridder/SourceExtender.h"
 #include "orca-jedi/state/State.h"
 #include "orca-jedi/utilities/IOUtils.h"
 #include "orca-jedi/utilities/Types.h"
@@ -119,6 +120,20 @@ State::State(const Geometry & resol, const State & other)
                        << " copied as there is no change" << std::endl;
   } else {
     // Different grid: regrid from other's geometry to the new geometry
+
+    // 1. Clone source fields so we can extend without modifying the original
+    atlas::FieldSet extendedSource;
+    for (atlas::idx_t i = 0; i < other.stateFields_.size(); ++i) {
+      atlas::Field clone = other.stateFields_[i].clone();
+      extendedSource.add(clone);
+    }
+
+    // 2. Flood-fill source fields to extend data into masked regions
+    SourceExtender extender(other.geom_->mesh(),
+                            other.geom_->functionSpace());
+    extender.extend(extendedSource);
+
+    // 3. Regrid the extended source to the target geometry
     eckit::LocalConfiguration interpConf;
     interpConf.set("type", "unstructured-bilinear-lonlat");
     interpConf.set("non_linear", "missing-if-all-missing");
@@ -127,7 +142,7 @@ State::State(const Geometry & resol, const State & other)
                         other.geom_->functionSpace(),
                         resol.functionSpace());
 
-    stateFields_ = regridder.execute(other.stateFields_);
+    stateFields_ = regridder.execute(extendedSource);
 
     oops::Log::trace() << "State(ORCA)::State resolution change: "
                        << "regridded from " << other.geom_->grid().name()

--- a/src/orca-jedi/utilities/MaskUtils.cc
+++ b/src/orca-jedi/utilities/MaskUtils.cc
@@ -1,0 +1,91 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#include "orca-jedi/utilities/MaskUtils.h"
+
+#include <algorithm>
+
+#include "atlas/array/MakeView.h"
+#include "atlas/array/DataType.h"
+#include "atlas/field/MissingValue.h"
+
+#include "eckit/exception/Exceptions.h"
+#include "oops/util/Logger.h"
+
+namespace orcamodel {
+
+/// \brief Apply a mask to a FieldSet, setting masked points to missing value.
+///
+/// For each field in the FieldSet, where mask==0, the field value is set to
+/// the field's missing_value. Fields without missing_value metadata are skipped.
+///
+/// The mask may be:
+/// - Surface (nNodes, 1): broadcast to all levels of each field.
+/// - Volumetric (nNodes, nLevels): applied per-level. If the field has fewer
+///   levels than the mask, only the relevant levels are used.
+///
+/// \param mask    An int32 mask field (shape nNodes x nLevels).
+///               Values: 0=masked, 1=valid.
+/// \param fields  The FieldSet to mask in-place.
+void applyMaskToFields(
+  const atlas::Field & mask,
+  atlas::FieldSet & fields) {
+  auto mask_view = atlas::array::make_view<int32_t, 2>(mask);
+  const atlas::idx_t maskLevels = mask_view.shape(1);
+
+  for (atlas::idx_t i = 0; i < fields.size(); ++i) {
+    atlas::Field& field = fields[i];
+    atlas::field::MissingValue mv(field);
+    if (!mv) {
+      oops::Log::debug() << "applyMaskToFields: field '" << field.name()
+                         << "' has no missing_value metadata, skipping"
+                         << std::endl;
+      continue;
+    }
+
+    const auto applyMask = [&](auto typeVal) {
+      using T = decltype(typeVal);
+      auto field_view = atlas::array::make_view<T, 2>(field);
+      T fill = field.metadata().get<T>("missing_value");
+      const atlas::idx_t nNodes = field_view.shape(0);
+      const atlas::idx_t nLevels = field_view.shape(1);
+      ASSERT(field_view.shape(0) == mask_view.shape(0));
+
+      if (maskLevels == 1) {
+        // Surface mask: broadcast level 0 to all field levels
+        for (atlas::idx_t j = 0; j < nNodes; ++j) {
+          if (mask_view(j, 0) == 0) {
+            for (atlas::idx_t k = 0; k < nLevels; ++k) {
+              field_view(j, k) = fill;
+            }
+          }
+        }
+      } else {
+        // Volumetric mask: apply per-level
+        const atlas::idx_t levelsToMask = std::min(nLevels, maskLevels);
+        for (atlas::idx_t j = 0; j < nNodes; ++j) {
+          for (atlas::idx_t k = 0; k < levelsToMask; ++k) {
+            if (mask_view(j, k) == 0) {
+              field_view(j, k) = fill;
+            }
+          }
+        }
+      }
+    };
+
+    if (field.datatype() == atlas::array::DataType::real64()) {
+      applyMask(double{});
+    } else if (field.datatype() == atlas::array::DataType::real32()) {
+      applyMask(float{});
+    } else {
+      oops::Log::warning() << "applyMaskToFields: field '" << field.name()
+                           << "' has unsupported datatype, skipping"
+                           << std::endl;
+    }
+  }
+  oops::Log::info() << "applyMaskToFields: applied mask to "
+                    << fields.size() << " fields" << std::endl;
+}
+
+}  // namespace orcamodel

--- a/src/orca-jedi/utilities/MaskUtils.h
+++ b/src/orca-jedi/utilities/MaskUtils.h
@@ -1,0 +1,22 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#pragma once
+
+#include "atlas/field.h"
+
+namespace orcamodel {
+
+/// \brief Apply a mask field to a FieldSet, setting masked points to missing.
+///
+/// The mask field should be int32 with values 0=masked, 1=valid.
+/// - If the mask has 1 level (surface), it is broadcast to all field levels.
+/// - If the mask has the same number of levels as the field, per-level masking
+///   is applied.
+/// Fields without missing_value metadata are skipped.
+void applyMaskToFields(
+  const atlas::Field & mask,
+  atlas::FieldSet & fields);
+
+}  // namespace orcamodel

--- a/src/tests/orca-jedi/CMakeLists.txt
+++ b/src/tests/orca-jedi/CMakeLists.txt
@@ -56,3 +56,8 @@ ecbuild_add_test( TARGET  orcajedi_regridder.x
                   SOURCES test_regridder.cc
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   LIBS    orcamodel )
+
+ecbuild_add_test( TARGET  orcajedi_source_extender.x
+                  SOURCES test_source_extender.cc
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  LIBS    orcamodel )

--- a/src/tests/orca-jedi/CMakeLists.txt
+++ b/src/tests/orca-jedi/CMakeLists.txt
@@ -51,3 +51,8 @@ ecbuild_add_test( TARGET  orcajedi_increment.x
                   SOURCES test_increment.cc
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   LIBS    orcamodel )
+
+ecbuild_add_test( TARGET  orcajedi_regridder.x
+                  SOURCES test_regridder.cc
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  LIBS    orcamodel )

--- a/src/tests/orca-jedi/CMakeLists.txt
+++ b/src/tests/orca-jedi/CMakeLists.txt
@@ -61,3 +61,8 @@ ecbuild_add_test( TARGET  orcajedi_source_extender.x
                   SOURCES test_source_extender.cc
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   LIBS    orcamodel )
+
+ecbuild_add_test( TARGET  orcajedi_mask_utils.x
+                  SOURCES test_mask_utils.cc
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  LIBS    orcamodel )

--- a/src/tests/orca-jedi/test_geometry.cc
+++ b/src/tests/orca-jedi/test_geometry.cc
@@ -151,7 +151,6 @@ CASE("test basic geometry") {
         "vunit",
         "owned",
         "gmask",
-        "vol_mask",
         "area"};
     size_t num_matches = 0;
     std::cout << "extraField list: ";
@@ -173,7 +172,7 @@ CASE("test basic geometry") {
     EXPECT(extraFieldNames.size() == num_matches);
   }
 
-  SECTION("test vol_mask initialised and has correct shape") {
+  SECTION("test vol_mask not created without land sea mask config") {
     eckit::LocalConfiguration config2;
     config2.set("nemo variables", nemo_var_mappings);
     config2.set("grid name", "ORCA2_T");
@@ -181,29 +180,19 @@ CASE("test basic geometry") {
     config2.set("initialise extra fields", true);
     Geometry geometry2(config2, eckit::mpi::comm());
     const atlas::FieldSet& ef = geometry2.extraFields();
-    EXPECT(ef.has("vol_mask"));
-
-    const atlas::Field& vm = ef.field("vol_mask");
-    EXPECT(vm.rank() == 2);
-    EXPECT(vm.shape(1) == 10);
-    EXPECT(vm.datatype() == atlas::array::DataType::int32());
-
-    // All values should be 0 or 1
-    auto view = atlas::array::make_view<int32_t, 2>(vm);
-    for (atlas::idx_t j = 0; j < view.shape(0); ++j) {
-      for (atlas::idx_t k = 0; k < view.shape(1); ++k) {
-        EXPECT(view(j, k) == 0 || view(j, k) == 1);
-      }
-    }
+    EXPECT(!ef.has("vol_mask"));
   }
 
-  SECTION("test set_vol_mask marks missing values") {
+  SECTION("test set_vol_mask creates and populates vol_mask") {
     eckit::LocalConfiguration config2;
     config2.set("nemo variables", nemo_var_mappings);
     config2.set("grid name", "ORCA2_T");
     config2.set("number levels", 3);
     config2.set("initialise extra fields", true);
     Geometry geometry2(config2, eckit::mpi::comm());
+
+    // vol_mask should not exist yet
+    EXPECT(!geometry2.extraFields().has("vol_mask"));
 
     // Create a field with missing values at certain (node,level) entries
     atlas::Field field =
@@ -231,21 +220,19 @@ CASE("test basic geometry") {
     EXPECT(testNode >= 0);
     fview(testNode, 1) = fill;  // mark level 1 as missing
 
-    // Check vol_mask is initially 1 at this point
-    auto vmBefore = atlas::array::make_view<int32_t, 2>(
-        geometry2.extraFields().field("vol_mask"));
-    EXPECT(vmBefore(testNode, 0) == 1);
-    EXPECT(vmBefore(testNode, 1) == 1);
-    EXPECT(vmBefore(testNode, 2) == 1);
-
+    // set_vol_mask should create and populate the field
     geometry2.set_vol_mask(field);
 
-    // After set_vol_mask: level 1 should now be masked (0)
-    auto vmAfter = atlas::array::make_view<int32_t, 2>(
+    // vol_mask should now exist
+    EXPECT(geometry2.extraFields().has("vol_mask"));
+    auto vm = atlas::array::make_view<int32_t, 2>(
         geometry2.extraFields().field("vol_mask"));
-    EXPECT(vmAfter(testNode, 0) == 1);
-    EXPECT(vmAfter(testNode, 1) == 0);
-    EXPECT(vmAfter(testNode, 2) == 1);
+    EXPECT(vm.shape(1) == 3);
+
+    // testNode: levels 0,2 should be ocean (1), level 1 masked (0)
+    EXPECT(vm(testNode, 0) == 1);
+    EXPECT(vm(testNode, 1) == 0);
+    EXPECT(vm(testNode, 2) == 1);
   }
 }
 

--- a/src/tests/orca-jedi/test_geometry.cc
+++ b/src/tests/orca-jedi/test_geometry.cc
@@ -150,6 +150,7 @@ CASE("test basic geometry") {
         "vunit",
         "owned",
         "gmask",
+        "vol_mask",
         "area"};
     size_t num_matches = 0;
     std::cout << "extraField list: ";

--- a/src/tests/orca-jedi/test_geometry.cc
+++ b/src/tests/orca-jedi/test_geometry.cc
@@ -11,6 +11,7 @@
 
 #include "oops/base/Variables.h"
 
+#include "atlas/array.h"
 #include "atlas/library/Library.h"
 #include "atlas/mesh.h"
 
@@ -164,10 +165,87 @@ CASE("test basic geometry") {
       }
     }
     std::cout << std::endl;
-    std::cout << "Number of extraFields " << extraFields.size() << std::endl;
-    std::cout << "Number matches to expected names " << num_matches << std::endl;
+    std::cout << "Number of extraFields " << extraFields.size()
+              << std::endl;
+    std::cout << "Number matches to expected names " << num_matches
+              << std::endl;
     EXPECT(static_cast<size_t>(extraFields.size()) == num_matches);
     EXPECT(extraFieldNames.size() == num_matches);
+  }
+
+  SECTION("test vol_mask initialised and has correct shape") {
+    eckit::LocalConfiguration config2;
+    config2.set("nemo variables", nemo_var_mappings);
+    config2.set("grid name", "ORCA2_T");
+    config2.set("number levels", 10);
+    config2.set("initialise extra fields", true);
+    Geometry geometry2(config2, eckit::mpi::comm());
+    const atlas::FieldSet& ef = geometry2.extraFields();
+    EXPECT(ef.has("vol_mask"));
+
+    const atlas::Field& vm = ef.field("vol_mask");
+    EXPECT(vm.rank() == 2);
+    EXPECT(vm.shape(1) == 10);
+    EXPECT(vm.datatype() == atlas::array::DataType::int32());
+
+    // All values should be 0 or 1
+    auto view = atlas::array::make_view<int32_t, 2>(vm);
+    for (atlas::idx_t j = 0; j < view.shape(0); ++j) {
+      for (atlas::idx_t k = 0; k < view.shape(1); ++k) {
+        EXPECT(view(j, k) == 0 || view(j, k) == 1);
+      }
+    }
+  }
+
+  SECTION("test set_vol_mask marks missing values") {
+    eckit::LocalConfiguration config2;
+    config2.set("nemo variables", nemo_var_mappings);
+    config2.set("grid name", "ORCA2_T");
+    config2.set("number levels", 3);
+    config2.set("initialise extra fields", true);
+    Geometry geometry2(config2, eckit::mpi::comm());
+
+    // Create a field with missing values at certain (node,level) entries
+    atlas::Field field =
+        geometry2.functionSpace().createField<double>(
+            atlas::option::name("test_field")
+            | atlas::option::levels(3));
+    const double fill = -999.0;
+    field.metadata().set("missing_value", fill);
+    field.metadata().set("missing_value_type", "equals");
+
+    auto fview = atlas::array::make_view<double, 2>(field);
+    for (atlas::idx_t j = 0; j < fview.shape(0); ++j) {
+      for (atlas::idx_t k = 0; k < 3; ++k) {
+        fview(j, k) = 1.0;  // valid everywhere initially
+      }
+    }
+
+    // Find a non-ghost node to mark as missing at level 1
+    auto ghost = atlas::array::make_view<int32_t, 1>(
+        geometry2.mesh().nodes().ghost());
+    atlas::idx_t testNode = -1;
+    for (atlas::idx_t j = 0; j < fview.shape(0); ++j) {
+      if (ghost(j) == 0) { testNode = j; break; }
+    }
+    EXPECT(testNode >= 0);
+    fview(testNode, 1) = fill;  // mark level 1 as missing
+
+    // Check vol_mask is initially 1 at this point
+    auto vmBefore = atlas::array::make_view<int32_t, 2>(
+        geometry2.extraFields().field("vol_mask"));
+    EXPECT(vmBefore(testNode, 0) == 1);
+    EXPECT(vmBefore(testNode, 1) == 1);
+    EXPECT(vmBefore(testNode, 2) == 1);
+
+    geometry2.set_vol_mask(field);
+
+    // After set_vol_mask: level 1 should now be masked (0)
+    auto vmAfter = atlas::array::make_view<int32_t, 2>(
+        geometry2.extraFields().field("vol_mask"));
+    EXPECT(vmAfter(testNode, 0) == 1);
+    EXPECT(vmAfter(testNode, 1) == 0);
+    EXPECT(vmAfter(testNode, 2) == 1);
   }
 }
 

--- a/src/tests/orca-jedi/test_mask_utils.cc
+++ b/src/tests/orca-jedi/test_mask_utils.cc
@@ -1,0 +1,285 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include "eckit/testing/Test.h"
+
+#include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/functionspace.h"
+#include "atlas/grid.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+
+#include "orca-jedi/utilities/MaskUtils.h"
+
+#include "tests/orca-jedi/OrcaModelTestEnvironment.h"
+
+namespace orcamodel {
+namespace test {
+
+// Helper: create a simple structured mesh and NodeColumns function space
+static atlas::functionspace::NodeColumns makeNodeColumns() {
+  atlas::StructuredGrid grid("L8");
+  atlas::MeshGenerator meshgen("structured");
+  atlas::Mesh mesh = meshgen.generate(grid);
+  return atlas::functionspace::NodeColumns(mesh);
+}
+
+// ---------------------------------------------------------------------------
+CASE("test applyMaskToFields surface mask broadcasts to all levels") {
+  auto funcSpace = makeNodeColumns();
+  const atlas::idx_t nNodes = funcSpace.size();
+  const atlas::idx_t nLevels = 3;
+  const double missing = -999.0;
+
+  // Create a surface mask (nNodes, 1): mask out every other node
+  atlas::Field mask = funcSpace.createField<int32_t>(
+      atlas::option::name("mask") | atlas::option::levels(1));
+  auto mask_view = atlas::array::make_view<int32_t, 2>(mask);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    mask_view(j, 0) = (j % 2 == 0) ? 1 : 0;  // even=ocean, odd=land
+  }
+
+  // Create a volumetric field with 3 levels, all values = 42.0
+  atlas::Field field = funcSpace.createField<double>(
+      atlas::option::name("temperature") | atlas::option::levels(nLevels));
+  field.metadata().set("missing_value", missing);
+  field.metadata().set("missing_value_type", "equals");
+  auto field_view = atlas::array::make_view<double, 2>(field);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    for (atlas::idx_t k = 0; k < nLevels; ++k) {
+      field_view(j, k) = 42.0;
+    }
+  }
+
+  atlas::FieldSet fields;
+  fields.add(field);
+  orcamodel::applyMaskToFields(mask, fields);
+
+  // Verify: masked (odd) nodes should have missing at ALL levels
+  //         valid (even) nodes should remain 42.0
+  auto result = atlas::array::make_view<double, 2>(fields[0]);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    for (atlas::idx_t k = 0; k < nLevels; ++k) {
+      if (j % 2 == 0) {
+        EXPECT(result(j, k) == 42.0);
+      } else {
+        EXPECT(result(j, k) == missing);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+CASE("test applyMaskToFields volumetric mask per-level") {
+  auto funcSpace = makeNodeColumns();
+  const atlas::idx_t nNodes = funcSpace.size();
+  const atlas::idx_t nLevels = 3;
+  const double missing = -999.0;
+
+  // Create a volumetric mask (nNodes, 3):
+  // level 0: all ocean (1), level 1: mask odd nodes, level 2: all masked (0)
+  atlas::Field mask = funcSpace.createField<int32_t>(
+      atlas::option::name("vol_mask") | atlas::option::levels(nLevels));
+  auto mask_view = atlas::array::make_view<int32_t, 2>(mask);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    mask_view(j, 0) = 1;                         // level 0: all ocean
+    mask_view(j, 1) = (j % 2 == 0) ? 1 : 0;     // level 1: even=ocean
+    mask_view(j, 2) = 0;                         // level 2: all land
+  }
+
+  // Create field, all values = 10.0
+  atlas::Field field = funcSpace.createField<double>(
+      atlas::option::name("salinity") | atlas::option::levels(nLevels));
+  field.metadata().set("missing_value", missing);
+  field.metadata().set("missing_value_type", "equals");
+  auto field_view = atlas::array::make_view<double, 2>(field);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    for (atlas::idx_t k = 0; k < nLevels; ++k) {
+      field_view(j, k) = 10.0;
+    }
+  }
+
+  atlas::FieldSet fields;
+  fields.add(field);
+  orcamodel::applyMaskToFields(mask, fields);
+
+  auto result = atlas::array::make_view<double, 2>(fields[0]);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    // Level 0: all should remain valid
+    EXPECT(result(j, 0) == 10.0);
+    // Level 1: even nodes valid, odd nodes masked
+    if (j % 2 == 0) {
+      EXPECT(result(j, 1) == 10.0);
+    } else {
+      EXPECT(result(j, 1) == missing);
+    }
+    // Level 2: all should be masked
+    EXPECT(result(j, 2) == missing);
+  }
+}
+
+// ---------------------------------------------------------------------------
+CASE("test applyMaskToFields with float (real32) fields") {
+  auto funcSpace = makeNodeColumns();
+  const atlas::idx_t nNodes = funcSpace.size();
+  const float missing = -999.0f;
+
+  // Surface mask: mask node 0 only
+  atlas::Field mask = funcSpace.createField<int32_t>(
+      atlas::option::name("mask") | atlas::option::levels(1));
+  auto mask_view = atlas::array::make_view<int32_t, 2>(mask);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    mask_view(j, 0) = (j == 0) ? 0 : 1;
+  }
+
+  // Create a float field
+  atlas::Field field = funcSpace.createField<float>(
+      atlas::option::name("sst") | atlas::option::levels(1));
+  field.metadata().set("missing_value", missing);
+  field.metadata().set("missing_value_type", "equals");
+  auto field_view = atlas::array::make_view<float, 2>(field);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    field_view(j, 0) = 25.0f;
+  }
+
+  atlas::FieldSet fields;
+  fields.add(field);
+  orcamodel::applyMaskToFields(mask, fields);
+
+  auto result = atlas::array::make_view<float, 2>(fields[0]);
+  EXPECT(result(0, 0) == missing);
+  for (atlas::idx_t j = 1; j < nNodes; ++j) {
+    EXPECT(result(j, 0) == 25.0f);
+  }
+}
+
+// ---------------------------------------------------------------------------
+CASE("test applyMaskToFields skips fields without missing_value") {
+  auto funcSpace = makeNodeColumns();
+  const atlas::idx_t nNodes = funcSpace.size();
+
+  // Mask that would mask everything
+  atlas::Field mask = funcSpace.createField<int32_t>(
+      atlas::option::name("mask") | atlas::option::levels(1));
+  auto mask_view = atlas::array::make_view<int32_t, 2>(mask);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    mask_view(j, 0) = 0;
+  }
+
+  // Field with no missing_value metadata
+  atlas::Field field = funcSpace.createField<double>(
+      atlas::option::name("no_mv") | atlas::option::levels(1));
+  auto field_view = atlas::array::make_view<double, 2>(field);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    field_view(j, 0) = 7.0;
+  }
+
+  atlas::FieldSet fields;
+  fields.add(field);
+  orcamodel::applyMaskToFields(mask, fields);
+
+  // Field should be unchanged (all 7.0) since it has no missing_value
+  auto result = atlas::array::make_view<double, 2>(fields[0]);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    EXPECT(result(j, 0) == 7.0);
+  }
+}
+
+// ---------------------------------------------------------------------------
+CASE("test applyMaskToFields vol mask with fewer field levels") {
+  auto funcSpace = makeNodeColumns();
+  const atlas::idx_t nNodes = funcSpace.size();
+  const double missing = -999.0;
+
+  // Volumetric mask with 5 levels
+  atlas::Field mask = funcSpace.createField<int32_t>(
+      atlas::option::name("vol_mask") | atlas::option::levels(5));
+  auto mask_view = atlas::array::make_view<int32_t, 2>(mask);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    for (atlas::idx_t k = 0; k < 5; ++k) {
+      // Mask level 2 for all nodes
+      mask_view(j, k) = (k == 2) ? 0 : 1;
+    }
+  }
+
+  // Field with only 2 levels (fewer than mask)
+  atlas::Field field = funcSpace.createField<double>(
+      atlas::option::name("shallow") | atlas::option::levels(2));
+  field.metadata().set("missing_value", missing);
+  field.metadata().set("missing_value_type", "equals");
+  auto field_view = atlas::array::make_view<double, 2>(field);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    field_view(j, 0) = 1.0;
+    field_view(j, 1) = 2.0;
+  }
+
+  atlas::FieldSet fields;
+  fields.add(field);
+  orcamodel::applyMaskToFields(mask, fields);
+
+  // Field levels 0,1 are valid in the mask — should be unchanged
+  auto result = atlas::array::make_view<double, 2>(fields[0]);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    EXPECT(result(j, 0) == 1.0);
+    EXPECT(result(j, 1) == 2.0);
+  }
+}
+
+// ---------------------------------------------------------------------------
+CASE("test applyMaskToFields multiple fields mixed types") {
+  auto funcSpace = makeNodeColumns();
+  const atlas::idx_t nNodes = funcSpace.size();
+  const double missing_d = -999.0;
+  const float missing_f = -999.0f;
+
+  // Surface mask: mask node 0
+  atlas::Field mask = funcSpace.createField<int32_t>(
+      atlas::option::name("mask") | atlas::option::levels(1));
+  auto mask_view = atlas::array::make_view<int32_t, 2>(mask);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) {
+    mask_view(j, 0) = (j == 0) ? 0 : 1;
+  }
+
+  // Double field
+  atlas::Field field_d = funcSpace.createField<double>(
+      atlas::option::name("temp") | atlas::option::levels(1));
+  field_d.metadata().set("missing_value", missing_d);
+  field_d.metadata().set("missing_value_type", "equals");
+  auto view_d = atlas::array::make_view<double, 2>(field_d);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) view_d(j, 0) = 5.0;
+
+  // Float field
+  atlas::Field field_f = funcSpace.createField<float>(
+      atlas::option::name("salt") | atlas::option::levels(1));
+  field_f.metadata().set("missing_value", missing_f);
+  field_f.metadata().set("missing_value_type", "equals");
+  auto view_f = atlas::array::make_view<float, 2>(field_f);
+  for (atlas::idx_t j = 0; j < nNodes; ++j) view_f(j, 0) = 35.0f;
+
+  atlas::FieldSet fields;
+  fields.add(field_d);
+  fields.add(field_f);
+  orcamodel::applyMaskToFields(mask, fields);
+
+  // Node 0 should be masked in both fields
+  auto res_d = atlas::array::make_view<double, 2>(fields[0]);
+  auto res_f = atlas::array::make_view<float, 2>(fields[1]);
+  EXPECT(res_d(0, 0) == missing_d);
+  EXPECT(res_f(0, 0) == missing_f);
+  // Node 1 should be valid in both
+  EXPECT(res_d(1, 0) == 5.0);
+  EXPECT(res_f(1, 0) == 35.0f);
+}
+
+}  // namespace test
+}  // namespace orcamodel
+
+int main(int argc, char** argv) {
+  return orcamodel::test::run(argc, argv);
+}

--- a/src/tests/orca-jedi/test_regridder.cc
+++ b/src/tests/orca-jedi/test_regridder.cc
@@ -2,10 +2,14 @@
  * (C) British Crown Copyright 2026 Met Office
  */
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <vector>
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 #include "eckit/config/LocalConfiguration.h"
 #include "eckit/mpi/Comm.h"
 #include "eckit/testing/Test.h"

--- a/src/tests/orca-jedi/test_regridder.cc
+++ b/src/tests/orca-jedi/test_regridder.cc
@@ -1,0 +1,312 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include "eckit/config/LocalConfiguration.h"
+#include "eckit/mpi/Comm.h"
+#include "eckit/testing/Test.h"
+
+#include "atlas/field.h"
+#include "atlas/functionspace.h"
+#include "atlas/grid.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/array.h"
+
+#include "orca-jedi/geometry/Geometry.h"
+#include "orca-jedi/state/State.h"
+#include "orca-jedi/regridder/Regridder.h"
+
+#include "tests/orca-jedi/OrcaModelTestEnvironment.h"
+
+namespace orcamodel {
+namespace test {
+
+// ---------------------------------------------------------------------------
+CASE("test regridder structured-to-structured") {
+  // Source: coarse regular lon-lat grid
+  atlas::StructuredGrid sourceGrid("L24");  // ~7.5 degree global
+  atlas::MeshGenerator meshgen("structured");
+  atlas::Mesh sourceMesh = meshgen.generate(sourceGrid);
+  atlas::functionspace::NodeColumns sourceFunctionSpace(sourceMesh);
+
+  // Target: finer regular lon-lat grid
+  atlas::StructuredGrid targetGrid("L48");  // ~3.75 degree global
+  atlas::Mesh targetMesh = meshgen.generate(targetGrid);
+  atlas::functionspace::NodeColumns targetFunctionSpace(targetMesh);
+
+  // Create a source field with a smooth analytic function (cosine of latitude)
+  atlas::Field sourceField = sourceFunctionSpace.createField<double>(
+      atlas::option::name("temperature") | atlas::option::levels(1));
+  auto source_view = atlas::array::make_view<double, 2>(sourceField);
+  auto lonlat = atlas::array::make_view<double, 2>(sourceFunctionSpace.nodes().lonlat());
+  for (atlas::idx_t i = 0; i < sourceFunctionSpace.nodes().size(); ++i) {
+    double lat_rad = lonlat(i, 1) * M_PI / 180.0;
+    source_view(i, 0) = std::cos(lat_rad);
+  }
+
+  // Configure interpolation: finite-element method
+  eckit::LocalConfiguration interpConf;
+  interpConf.set("type", "finite-element");
+
+  // Build regridder and execute
+  orcamodel::Regridder regridder(interpConf, sourceFunctionSpace, targetFunctionSpace);
+  atlas::Field targetField = regridder.execute(sourceField);
+
+  // Verify: check that interpolated values are reasonable
+  // Skip pole nodes (|lat| > 85) where FE interpolation on structured grids
+  // is unreliable due to degenerate triangular elements at the pole cap.
+  auto target_view = atlas::array::make_view<double, 2>(targetField);
+  auto target_lonlat = atlas::array::make_view<double, 2>(
+      targetFunctionSpace.nodes().lonlat());
+  auto target_ghost = atlas::array::make_view<int, 1>(
+      targetFunctionSpace.nodes().ghost());
+
+  double max_error = 0.0;
+  int checked_points = 0;
+  for (atlas::idx_t i = 0; i < targetFunctionSpace.nodes().size(); ++i) {
+    if (target_ghost(i)) continue;  // skip ghost/halo nodes
+    double lat = target_lonlat(i, 1);
+    if (std::abs(lat) > 85.0) continue;  // skip pole caps
+    double lat_rad = lat * M_PI / 180.0;
+    double expected = std::cos(lat_rad);
+    double error = std::abs(target_view(i, 0) - expected);
+    max_error = std::max(max_error, error);
+    ++checked_points;
+  }
+
+  // For cos(lat) on a ~7.5 degree source grid, interpolation error should be small
+  eckit::Log::info() << "Max interpolation error: " << max_error
+                     << " (checked " << checked_points << " points)" << std::endl;
+  EXPECT(checked_points > 0);
+  EXPECT(max_error < 0.05);
+}
+
+// ---------------------------------------------------------------------------
+CASE("test regridder fieldset") {
+  // Source grid
+  atlas::StructuredGrid sourceGrid("L24");
+  atlas::MeshGenerator meshgen("structured");
+  atlas::Mesh sourceMesh = meshgen.generate(sourceGrid);
+  atlas::functionspace::NodeColumns sourceFunctionSpace(sourceMesh);
+
+  // Target grid
+  atlas::StructuredGrid targetGrid("L48");
+  atlas::Mesh targetMesh = meshgen.generate(targetGrid);
+  atlas::functionspace::NodeColumns targetFunctionSpace(targetMesh);
+
+  // Create two source fields
+  atlas::FieldSet sourceFields;
+  atlas::Field field1 = sourceFunctionSpace.createField<double>(
+      atlas::option::name("temperature") | atlas::option::levels(1));
+  atlas::Field field2 = sourceFunctionSpace.createField<double>(
+      atlas::option::name("salinity") | atlas::option::levels(1));
+
+  auto view1 = atlas::array::make_view<double, 2>(field1);
+  auto view2 = atlas::array::make_view<double, 2>(field2);
+  for (atlas::idx_t i = 0; i < sourceFunctionSpace.nodes().size(); ++i) {
+    view1(i, 0) = 1.0;  // uniform field
+    view2(i, 0) = 2.0;  // uniform field
+  }
+  sourceFields.add(field1);
+  sourceFields.add(field2);
+
+  // Configure and execute
+  eckit::LocalConfiguration interpConf;
+  interpConf.set("type", "finite-element");
+
+  orcamodel::Regridder regridder(interpConf, sourceFunctionSpace, targetFunctionSpace);
+  atlas::FieldSet targetFields = regridder.execute(sourceFields);
+
+  // Verify both fields were regridded
+  EXPECT(targetFields.size() == 2);
+  EXPECT(targetFields[0].name() == "temperature");
+  EXPECT(targetFields[1].name() == "salinity");
+
+  // Uniform fields should remain uniform after interpolation (skip ghost nodes)
+  auto tgt_view1 = atlas::array::make_view<double, 2>(targetFields[0]);
+  auto tgt_view2 = atlas::array::make_view<double, 2>(targetFields[1]);
+  auto tgt_ghost = atlas::array::make_view<int, 1>(
+      targetFunctionSpace.nodes().ghost());
+  for (atlas::idx_t i = 0; i < targetFunctionSpace.nodes().size(); ++i) {
+    if (tgt_ghost(i)) continue;
+    EXPECT(std::abs(tgt_view1(i, 0) - 1.0) < 1e-7);
+    EXPECT(std::abs(tgt_view2(i, 0) - 2.0) < 1e-7);
+  }
+}
+
+// ---------------------------------------------------------------------------
+CASE("test regridder with nonlinear missing value handling") {
+  // Source grid
+  atlas::StructuredGrid sourceGrid("L24");
+  atlas::MeshGenerator meshgen("structured");
+  atlas::Mesh sourceMesh = meshgen.generate(sourceGrid);
+  atlas::functionspace::NodeColumns sourceFunctionSpace(sourceMesh);
+
+  // Target grid
+  atlas::StructuredGrid targetGrid("L48");
+  atlas::Mesh targetMesh = meshgen.generate(targetGrid);
+  atlas::functionspace::NodeColumns targetFunctionSpace(targetMesh);
+
+  // Create source field with missing values (simulating land mask)
+  atlas::Field sourceField = sourceFunctionSpace.createField<double>(
+      atlas::option::name("sst") | atlas::option::levels(1));
+  auto source_view = atlas::array::make_view<double, 2>(sourceField);
+  const double missing = 9999.0;
+
+  // Set metadata for missing value
+  sourceField.metadata().set("missing_value", missing);
+  sourceField.metadata().set("missing_value_type", "equals");
+
+  auto lonlat = atlas::array::make_view<double, 2>(sourceFunctionSpace.nodes().lonlat());
+  for (atlas::idx_t i = 0; i < sourceFunctionSpace.nodes().size(); ++i) {
+    double lat = lonlat(i, 1);
+    // "Land" above 60N — set to missing
+    if (lat > 60.0) {
+      source_view(i, 0) = missing;
+    } else {
+      source_view(i, 0) = 20.0 - 0.3 * std::abs(lat);  // simple SST-like profile
+    }
+  }
+
+  // Configure with nonlinear missing value handling
+  eckit::LocalConfiguration interpConf;
+  interpConf.set("type", "finite-element");
+  interpConf.set("non_linear", "missing-if-all-missing");
+
+  orcamodel::Regridder regridder(interpConf, sourceFunctionSpace, targetFunctionSpace);
+  atlas::Field targetField = regridder.execute(sourceField);
+
+  // Verify: points well within "ocean" should have valid values
+  auto target_view = atlas::array::make_view<double, 2>(targetField);
+  auto target_lonlat = atlas::array::make_view<double, 2>(
+      targetFunctionSpace.nodes().lonlat());
+  auto target_ghost = atlas::array::make_view<int, 1>(
+      targetFunctionSpace.nodes().ghost());
+
+  int valid_ocean_points = 0;
+  for (atlas::idx_t i = 0; i < targetFunctionSpace.nodes().size(); ++i) {
+    if (target_ghost(i)) continue;
+    double lat = target_lonlat(i, 1);
+    if (lat < 50.0 && lat > -50.0) {
+      // Well within ocean — should have valid interpolated value
+      EXPECT(target_view(i, 0) != missing);
+      valid_ocean_points++;
+    }
+  }
+  EXPECT(valid_ocean_points > 0);
+  eckit::Log::info() << "Verified " << valid_ocean_points
+                     << " valid ocean target points" << std::endl;
+}
+
+// ---------------------------------------------------------------------------
+CASE("test regridder ORCA1_T to ORCA2_T") {
+  // Source: ORCA1_T geometry
+  eckit::LocalConfiguration sourceGeomConf;
+  sourceGeomConf.set("grid name", "ORCA1_T");
+  sourceGeomConf.set("number levels", 3);
+  std::vector<eckit::LocalConfiguration> srcVarMappings(2);
+  srcVarMappings[0].set("name", "sea_ice_area_fraction")
+    .set("nemo field name", "iiceconc")
+    .set("model space", "surface");
+  srcVarMappings[1].set("name", "sea_water_potential_temperature")
+    .set("nemo field name", "votemper")
+    .set("model space", "volume");
+  sourceGeomConf.set("nemo variables", srcVarMappings);
+
+  orcamodel::Geometry sourceGeom(sourceGeomConf, eckit::mpi::comm());
+
+  // Read source state from test data
+  eckit::LocalConfiguration stateConf;
+  stateConf.set("state variables",
+      std::vector<std::string>{"sea_ice_area_fraction",
+                               "sea_water_potential_temperature"});
+  stateConf.set("date", "2021-06-30T00:00:00Z");
+  stateConf.set("nemo field file", "../Data/orca1_t_nemo.nc");
+  orcamodel::State sourceState(sourceGeom, stateConf);
+
+  eckit::Log::info() << "Source state (ORCA1_T): " << sourceState << std::endl;
+
+  // Target: ORCA2_T geometry
+  eckit::LocalConfiguration targetGeomConf;
+  targetGeomConf.set("grid name", "ORCA2_T");
+  targetGeomConf.set("number levels", 3);
+  std::vector<eckit::LocalConfiguration> tgtVarMappings(2);
+  tgtVarMappings[0].set("name", "sea_ice_area_fraction")
+    .set("nemo field name", "iiceconc")
+    .set("model space", "surface");
+  tgtVarMappings[1].set("name", "sea_water_potential_temperature")
+    .set("nemo field name", "votemper")
+    .set("model space", "volume");
+  targetGeomConf.set("nemo variables", tgtVarMappings);
+
+  orcamodel::Geometry targetGeom(targetGeomConf, eckit::mpi::comm());
+
+  // Configure interpolation: unstructured-bilinear-lonlat with missing value handling
+  eckit::LocalConfiguration interpConf;
+  interpConf.set("type", "unstructured-bilinear-lonlat");
+  interpConf.set("non_linear", "missing-if-all-missing");
+
+  // Build regridder: ORCA1_T function space -> ORCA2_T function space
+  orcamodel::Regridder regridder(interpConf,
+                                 sourceGeom.functionSpace(),
+                                 targetGeom.functionSpace());
+
+  // Execute regridding
+  atlas::FieldSet result = regridder.execute(sourceState.stateFields());
+
+  eckit::Log::info() << "Regridded " << result.size() << " fields from ORCA1_T to ORCA2_T"
+                     << std::endl;
+
+  // Verify: we got fields out with the right names and sizes
+  EXPECT(result.size() == sourceState.stateFields().size());
+
+  for (atlas::idx_t f = 0; f < result.size(); ++f) {
+    const atlas::Field& field = result[f];
+    eckit::Log::info() << "  Field '" << field.name()
+                       << "' shape: (" << field.shape(0)
+                       << ", " << field.shape(1) << ")" << std::endl;
+    // Target field should have ORCA2_T number of nodes
+    EXPECT(field.shape(0) == targetGeom.functionSpace().size());
+  }
+
+  // Verify: sea_ice_area_fraction values should be broadly reasonable.
+  // Bilinear interpolation near coastlines (ocean/land boundaries) can
+  // produce overshoot/undershoot when missing-if-all-missing allows
+  // partial stencils, so we use a generous tolerance.
+  // Note: ORCA fields are stored as float (real32) in atlas
+  auto sic_view = atlas::array::make_view<float, 2>(result["sea_ice_area_fraction"]);
+  atlas::functionspace::NodeColumns tgtNodeColumns(targetGeom.functionSpace());
+  auto tgt_ghost = atlas::array::make_view<int, 1>(
+      tgtNodeColumns.nodes().ghost());
+  int valid_sic_points = 0;
+  float sic_min = std::numeric_limits<float>::max();
+  float sic_max = std::numeric_limits<float>::lowest();
+  for (atlas::idx_t i = 0; i < tgtNodeColumns.size(); ++i) {
+    if (tgt_ghost(i)) continue;
+    float val = sic_view(i, 0);
+    if (val != 0.0f) {  // non-zero means it was interpolated
+      valid_sic_points++;
+      sic_min = std::min(sic_min, val);
+      sic_max = std::max(sic_max, val);
+    }
+  }
+  eckit::Log::info() << "  sea_ice_area_fraction: " << valid_sic_points
+                     << " valid points, range [" << sic_min << ", "
+                     << sic_max << "]" << std::endl;
+  EXPECT(valid_sic_points > 0);
+  // Values should not be wildly out of physical range (allow interpolation overshoot)
+  EXPECT(sic_min > -0.5f);
+  EXPECT(sic_max < 1.5f);
+}
+
+}  // namespace test
+}  // namespace orcamodel
+
+int main(int argc, char** argv) {
+  return orcamodel::test::run(argc, argv);
+}

--- a/src/tests/orca-jedi/test_source_extender.cc
+++ b/src/tests/orca-jedi/test_source_extender.cc
@@ -1,0 +1,271 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include "eckit/testing/Test.h"
+
+#include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/functionspace.h"
+#include "atlas/grid.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+
+#include "orca-jedi/regridder/SourceExtender.h"
+
+#include "tests/orca-jedi/OrcaModelTestEnvironment.h"
+
+namespace orcamodel {
+namespace test {
+
+// ---------------------------------------------------------------------------
+CASE("test source extender flood fill cell-based") {
+  // Create a structured mesh with NodeColumns function space
+  atlas::StructuredGrid grid("L24");
+  atlas::MeshGenerator meshgen("structured");
+  atlas::Mesh mesh = meshgen.generate(grid);
+  atlas::functionspace::NodeColumns funcSpace(mesh);
+
+  // Create a source field: "ocean" where |lat| < 60, "land" elsewhere
+  atlas::Field field = funcSpace.createField<double>(
+      atlas::option::name("temperature") | atlas::option::levels(1));
+  const double missing = 9999.0;
+  field.metadata().set("missing_value", missing);
+  field.metadata().set("missing_value_type", "equals");
+
+  auto view = atlas::array::make_view<double, 2>(field);
+  auto lonlat = atlas::array::make_view<double, 2>(funcSpace.nodes().lonlat());
+  auto ghost = atlas::array::make_view<int, 1>(funcSpace.nodes().ghost());
+
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    double lat = lonlat(i, 1);
+    if (std::abs(lat) > 60.0) {
+      view(i, 0) = missing;  // land
+    } else {
+      view(i, 0) = 20.0 - 0.3 * std::abs(lat);  // SST-like
+    }
+  }
+
+  // Count initial missing points (non-ghost)
+  int initialMissing = 0;
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    if (ghost(i)) continue;
+    if (view(i, 0) == missing) ++initialMissing;
+  }
+  eckit::Log::info() << "Initial missing (non-ghost): " << initialMissing
+                     << std::endl;
+  EXPECT(initialMissing > 0);
+
+  // Apply cell-based flood fill with 2 iterations
+  orcamodel::SourceExtender extender(
+      mesh, funcSpace,
+      /*nFloodIterations=*/2,
+      /*nSmoothIterations=*/10,
+      /*smoothWeightSelf=*/0.35,
+      orcamodel::AdjacencyType::CellBased);
+  extender.extend(field);
+
+  // Count remaining missing points (should be fewer)
+  int remainingMissing = 0;
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    if (ghost(i)) continue;
+    if (view(i, 0) == missing) ++remainingMissing;
+  }
+  eckit::Log::info() << "Remaining missing (non-ghost): " << remainingMissing
+                     << std::endl;
+  EXPECT(remainingMissing < initialMissing);
+
+  // Points that were flooded should have reasonable values (not missing, not NaN)
+  int floodedValid = 0;
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    if (ghost(i)) continue;
+    double val = view(i, 0);
+    if (val != missing && std::abs(lonlat(i, 1)) > 60.0) {
+      // Was originally land, now has a value
+      EXPECT(!std::isnan(val));
+      EXPECT(std::isfinite(val));
+      ++floodedValid;
+    }
+  }
+  eckit::Log::info() << "Flooded valid points: " << floodedValid << std::endl;
+  EXPECT(floodedValid > 0);
+}
+
+// ---------------------------------------------------------------------------
+CASE("test source extender flood fill edge-based") {
+  atlas::StructuredGrid grid("L24");
+  atlas::MeshGenerator meshgen("structured");
+  atlas::Mesh mesh = meshgen.generate(grid);
+  atlas::functionspace::NodeColumns funcSpace(mesh);
+
+  atlas::Field field = funcSpace.createField<double>(
+      atlas::option::name("temperature") | atlas::option::levels(1));
+  const double missing = 9999.0;
+  field.metadata().set("missing_value", missing);
+  field.metadata().set("missing_value_type", "equals");
+
+  auto view = atlas::array::make_view<double, 2>(field);
+  auto lonlat = atlas::array::make_view<double, 2>(funcSpace.nodes().lonlat());
+  auto ghost = atlas::array::make_view<int, 1>(funcSpace.nodes().ghost());
+
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    double lat = lonlat(i, 1);
+    if (std::abs(lat) > 60.0) {
+      view(i, 0) = missing;
+    } else {
+      view(i, 0) = 20.0 - 0.3 * std::abs(lat);
+    }
+  }
+
+  int initialMissing = 0;
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    if (ghost(i)) continue;
+    if (view(i, 0) == missing) ++initialMissing;
+  }
+
+  // Apply edge-based flood fill
+  orcamodel::SourceExtender extender(
+      mesh, funcSpace,
+      /*nFloodIterations=*/2,
+      /*nSmoothIterations=*/10,
+      /*smoothWeightSelf=*/0.35,
+      orcamodel::AdjacencyType::EdgeBased);
+  extender.extend(field);
+
+  int remainingMissing = 0;
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    if (ghost(i)) continue;
+    if (view(i, 0) == missing) ++remainingMissing;
+  }
+  eckit::Log::info() << "Edge-based remaining missing (non-ghost): "
+                     << remainingMissing << std::endl;
+  EXPECT(remainingMissing < initialMissing);
+}
+
+// ---------------------------------------------------------------------------
+CASE("test source extender no-op when no missing values") {
+  atlas::StructuredGrid grid("L24");
+  atlas::MeshGenerator meshgen("structured");
+  atlas::Mesh mesh = meshgen.generate(grid);
+  atlas::functionspace::NodeColumns funcSpace(mesh);
+
+  // Field with no missing values — should be unchanged
+  atlas::Field field = funcSpace.createField<double>(
+      atlas::option::name("temperature") | atlas::option::levels(1));
+  const double missing = 9999.0;
+  field.metadata().set("missing_value", missing);
+  field.metadata().set("missing_value_type", "equals");
+
+  auto view = atlas::array::make_view<double, 2>(field);
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    view(i, 0) = 15.0;  // all valid
+  }
+
+  orcamodel::SourceExtender extender(mesh, funcSpace);
+  extender.extend(field);
+
+  // All values should remain 15.0
+  auto ghost = atlas::array::make_view<int, 1>(funcSpace.nodes().ghost());
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    if (ghost(i)) continue;
+    EXPECT(std::abs(view(i, 0) - 15.0) < 1e-10);
+  }
+}
+
+// ---------------------------------------------------------------------------
+CASE("test source extender skips field without missing value metadata") {
+  atlas::StructuredGrid grid("L24");
+  atlas::MeshGenerator meshgen("structured");
+  atlas::Mesh mesh = meshgen.generate(grid);
+  atlas::functionspace::NodeColumns funcSpace(mesh);
+
+  // Field without missing_value metadata — should be skipped
+  atlas::Field field = funcSpace.createField<double>(
+      atlas::option::name("temperature") | atlas::option::levels(1));
+  auto view = atlas::array::make_view<double, 2>(field);
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    view(i, 0) = 42.0;
+  }
+
+  orcamodel::SourceExtender extender(mesh, funcSpace);
+  extender.extend(field);  // should not crash
+
+  // Value unchanged
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    EXPECT(std::abs(view(i, 0) - 42.0) < 1e-10);
+  }
+}
+
+// ---------------------------------------------------------------------------
+CASE("test source extender fieldset") {
+  atlas::StructuredGrid grid("L24");
+  atlas::MeshGenerator meshgen("structured");
+  atlas::Mesh mesh = meshgen.generate(grid);
+  atlas::functionspace::NodeColumns funcSpace(mesh);
+
+  const double missing = 9999.0;
+
+  // Two fields with different land patterns
+  atlas::Field field1 = funcSpace.createField<double>(
+      atlas::option::name("sst") | atlas::option::levels(1));
+  field1.metadata().set("missing_value", missing);
+  field1.metadata().set("missing_value_type", "equals");
+
+  atlas::Field field2 = funcSpace.createField<double>(
+      atlas::option::name("salinity") | atlas::option::levels(1));
+  field2.metadata().set("missing_value", missing);
+  field2.metadata().set("missing_value_type", "equals");
+
+  auto view1 = atlas::array::make_view<double, 2>(field1);
+  auto view2 = atlas::array::make_view<double, 2>(field2);
+  auto lonlat = atlas::array::make_view<double, 2>(funcSpace.nodes().lonlat());
+
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    double lat = lonlat(i, 1);
+    if (std::abs(lat) > 60.0) {
+      view1(i, 0) = missing;
+      view2(i, 0) = missing;
+    } else {
+      view1(i, 0) = 20.0;
+      view2(i, 0) = 35.0;
+    }
+  }
+
+  atlas::FieldSet fields;
+  fields.add(field1);
+  fields.add(field2);
+
+  orcamodel::SourceExtender extender(mesh, funcSpace);
+  extender.extend(fields);
+
+  // Both fields should have fewer missing values
+  auto ghost = atlas::array::make_view<int, 1>(funcSpace.nodes().ghost());
+  int missing1 = 0, missing2 = 0;
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    if (ghost(i)) continue;
+    if (view1(i, 0) == missing) ++missing1;
+    if (view2(i, 0) == missing) ++missing2;
+  }
+  eckit::Log::info() << "FieldSet remaining missing: sst=" << missing1
+                     << " salinity=" << missing2 << std::endl;
+
+  // Count original missing for comparison
+  int origMissing = 0;
+  for (atlas::idx_t i = 0; i < funcSpace.nodes().size(); ++i) {
+    if (ghost(i)) continue;
+    if (std::abs(lonlat(i, 1)) > 60.0) ++origMissing;
+  }
+  EXPECT(missing1 < origMissing);
+  EXPECT(missing2 < origMissing);
+}
+
+}  // namespace test
+}  // namespace orcamodel
+
+int main(int argc, char** argv) {
+  return orcamodel::test::run(argc, argv);
+}

--- a/src/tests/orca-jedi/test_state.cc
+++ b/src/tests/orca-jedi/test_state.cc
@@ -183,6 +183,65 @@ CASE("test basic state") {
   }
 }
 
+//-----------------------------------------------------------------------------
+
+CASE("test state resolution change ORCA1_T to ORCA2_T") {
+  // Source geometry: ORCA1_T
+  eckit::LocalConfiguration sourceGeomConf;
+  sourceGeomConf.set("grid name", "ORCA1_T");
+  sourceGeomConf.set("number levels", 3);
+  std::vector<eckit::LocalConfiguration> srcVarMappings(2);
+  srcVarMappings[0].set("name", "sea_ice_area_fraction")
+    .set("nemo field name", "iiceconc")
+    .set("model space", "surface");
+  srcVarMappings[1].set("name", "sea_water_potential_temperature")
+    .set("nemo field name", "votemper")
+    .set("model space", "volume");
+  sourceGeomConf.set("nemo variables", srcVarMappings);
+  Geometry sourceGeom(sourceGeomConf, eckit::mpi::comm());
+
+  // Read source state
+  eckit::LocalConfiguration stateConf;
+  stateConf.set("state variables",
+      std::vector<std::string>{"sea_ice_area_fraction",
+                               "sea_water_potential_temperature"});
+  stateConf.set("date", "2021-06-30T00:00:00Z");
+  stateConf.set("nemo field file", "../Data/orca1_t_nemo.nc");
+  State sourceState(sourceGeom, stateConf);
+
+  // Target geometry: ORCA2_T
+  eckit::LocalConfiguration targetGeomConf;
+  targetGeomConf.set("grid name", "ORCA2_T");
+  targetGeomConf.set("number levels", 3);
+  std::vector<eckit::LocalConfiguration> tgtVarMappings(2);
+  tgtVarMappings[0].set("name", "sea_ice_area_fraction")
+    .set("nemo field name", "iiceconc")
+    .set("model space", "surface");
+  tgtVarMappings[1].set("name", "sea_water_potential_temperature")
+    .set("nemo field name", "votemper")
+    .set("model space", "volume");
+  targetGeomConf.set("nemo variables", tgtVarMappings);
+  Geometry targetGeom(targetGeomConf, eckit::mpi::comm());
+
+  // Exercise the resolution-change constructor
+  State regridded(targetGeom, sourceState);
+
+  // Verify: state is on the target geometry
+  EXPECT(regridded.geometry()->grid().uid() == targetGeom.grid().uid());
+  EXPECT(regridded.variables().size() == sourceState.variables().size());
+  EXPECT(regridded.validTime() == sourceState.validTime());
+
+  // Verify: fields have the correct target size
+  const atlas::FieldSet& fields = regridded.stateFields();
+  EXPECT(fields.size() > 0);
+  for (atlas::idx_t f = 0; f < fields.size(); ++f) {
+    EXPECT(fields[f].shape(0) == targetGeom.functionSpace().size());
+    eckit::Log::info() << "  Regridded field '" << fields[f].name()
+                       << "' shape: (" << fields[f].shape(0)
+                       << ", " << fields[f].shape(1) << ")" << std::endl;
+  }
+}
+
 }  // namespace test
 }  // namespace orcamodel
 


### PR DESCRIPTION
## Description

Add a general-purpose Regridder class and orcamodel_regrid.x application for interpolating/regridding model data between grids using Atlas.

Only an initial attempt that would need much further work to handle the cubed-sphere, and vector field interpolation.

co-authored by github enterprise copilot.

## Key changes:

### New Regridder class (`src/orca-jedi/regridder/`)

A thin, Atlas-only wrapper around `atlas::Interpolation` that takes source/target `FunctionSpace` objects and a configuration, and executes interpolation on a `Field` or `FieldSet`. Has no OOPS dependency, making it extractable to a standalone tool in future.

### New SourceExtender class (`src/orca-jedi/regridder/SourceExtender.h`)

Extends valid ocean data into land (missing-value) cells on the source grid before interpolation, preventing gaps in regridded fields near coastlines where the interpolation stencil falls entirely on source land. Analogous to NEMOVAR's `sim_ext` module.

The algorithm has two phases:
1. **Flood-fill**: iteratively fills missing-value nodes with the mean of valid neighbours, extending data *N* cells into land. Halo-exchanged each iteration for MPI correctness.
2. **Smoothing**: Jacobi-style relaxation (`f = α·f_self + (1-α)·mean(f_neighbours)`, α=0.35) applied only to flooded cells to remove discontinuities. Original ocean values are never modified.

Two adjacency types are supported: **cell-based** (default, ~8 neighbours via shared cells, matching NEMOVAR's stencil) and **edge-based** (~4–6 neighbours via mesh edges, sparser but more geometrically principled). Key differences from NEMOVAR: uniform neighbour weights (vs distance-weighted), bilinear interpolation (vs nearest-neighbour + Shapiro), and operation on unstructured atlas meshes (vs structured i,j grids).

Configurable via `source extension:` YAML block in `orcamodel_regrid.x`; always applied with defaults in the `State` resolution-change constructor.

### New `orcamodel_regrid.x` executable (`src/mains/orcamodelRegrid.cc`) 

An OOPS Application that reads ORCA state, constructs a target grid (either another ORCA geometry or a structured Atlas grid), regrids all fields, and writes output using the existing `writeFieldsToFile` infrastructure for ORCA targets.

### Implemented resolution-change State constructor (`src/orca-jedi/state/State.cc`)

The `State(const Geometry&, const State&)` constructor now performs actual regridding when the source and target grids differ, using `unstructured-bilinear-lonlat` with `missing-if-all-missing` nonlinear handling. Previously this asserted grids were identical.

### New tests (`src/tests/orca-jedi/test_regridder.cc`, `test_source_extender.cc`)

Exercises the Regridder class with:

* Structured-to-structured interpolation
* Multi-field FieldSet regridding
* Nonlinear missing value handling
* ORCA1_T to ORCA2_T regridding using real test data

Exercises the SourceExtender class with:

* Cell-based flood-fill reduces missing values near coastlines
* Edge-based flood-fill as alternative adjacency
* No-op when all values are valid
* Graceful skip when missing_value metadata is absent
* FieldSet extension applies to multiple fields

### State resolution change test (src/tests/orca-jedi/test_state.cc)

Exercises the newly-implemented `State(targetGeom, sourceState)` constructor for ORCA1_T → ORCA2_T.

## Design notes:

The Regridder class is deliberately decoupled from OOPS/orca-jedi specifics to allow future extraction to a standalone atlas-based tool if desired.
For ORCA-to-ORCA regridding, the target geometry config path enables full use of existing NEMO-format NetCDF IO.
For structured grid targets (regular lon-lat, rotated pole), the target grid config path builds generic Atlas function spaces (output writing for this path is flagged for future implementation).


## Issue(s) addressed

Fixes #194

## Dependencies

None.

## Impact

* Existing tests are unaffected (the State resolution-change constructor preserves identical-grid behaviour).
* New executable orcamodel_regrid.x is available for regridding.
* The State(const Geometry&, const State&) constructor now supports cross-resolution use, which may enable multi-resolution DA workflows in OOPS that previously hit the ASSERT.

## Testing

<img width="1657" height="1612" alt="votemper_progression" src="https://github.com/user-attachments/assets/92fcea51-832b-45e4-b138-bd97517a5621" />

- [x] I have updated the unit tests to cover the change
- [x] New functions are documented briefly via Doxygen comments in the code
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [x] I have run [mo-bundle](https://cylchub/services/cylc-review/taskjobs/toby.searle/?suite=mobbs-oj193)
