### PR TITLE
 Add optional parallel netCDF I/O for NEMO fields

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set( CMAKE_DIRECTORY_LABELS "orca-jedi" )
 ## Dependencies
 find_package( jedicmake QUIET )  # Prefer find modules from jedi-cmake
 
-find_package( NetCDF COMPONENTS C CXX)
+find_package( NetCDF COMPONENTS C)
 ecbuild_debug( "   NetCDF_FEATURES: [${NetCDF_FEATURES}]" )
 
 find_package( MPI REQUIRED COMPONENTS CXX )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,11 @@ set( CMAKE_DIRECTORY_LABELS "orca-jedi" )
 ## Dependencies
 find_package( jedicmake QUIET )  # Prefer find modules from jedi-cmake
 
-find_package( NetCDF COMPONENTS CXX)
+find_package( NetCDF COMPONENTS C CXX)
 ecbuild_debug( "   NetCDF_FEATURES: [${NetCDF_FEATURES}]" )
+
+find_package( MPI REQUIRED COMPONENTS CXX )
+ecbuild_debug( "   MPI_CXX_FOUND: [${MPI_CXX_FOUND}]" )
 
 find_package( eckit 1.18 COMPONENTS LZ4 REQUIRED )
 ecbuild_debug( "   eckit_FEATURES : [${eckit_FEATURES}]" )

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _orca-jedi_ includes executables to calculate model values at observation locati
 ### Dependencies
 
   * [cmake](https://cmake.org/)
-  * [Unidata/netcdf-cxx4](https://github.com/Unidata/netcdf-cxx4)
+  * [Unidata/netcdf-c](https://github.com/Unidata/netcdf-c)
   * [ecmwf/ecbuild](https://github.com/ecmwf/ecbuild)
   * [ecmwf/eckit](https://github.com/ecmwf/eckit)
   * [JCSDA/oops](https://github.com/JCSDA/oops)

--- a/src/orca-jedi/CMakeLists.txt
+++ b/src/orca-jedi/CMakeLists.txt
@@ -67,6 +67,6 @@ ecbuild_add_library( TARGET   orcamodel
                      LINKER_LANGUAGE ${OOPS_LINKER_LANGUAGE}
                     )
                   #target_link_libraries( orcamodel PUBLIC MPI::MPI_Fortran MPI::MPI_CXX )
-target_link_libraries( orcamodel PUBLIC NetCDF::NetCDF_CXX NetCDF::NetCDF_C MPI::MPI_CXX)
+target_link_libraries( orcamodel PUBLIC NetCDF::NetCDF_C MPI::MPI_CXX)
 target_include_directories(orcamodel PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
                                             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)

--- a/src/orca-jedi/CMakeLists.txt
+++ b/src/orca-jedi/CMakeLists.txt
@@ -27,6 +27,14 @@ nemo_io/NemoFieldReader.cc
 nemo_io/NemoFieldWriter.h
 nemo_io/NemoFieldWriter.cc
 nemo_io/AtlasIndex.h
+nemo_io/SlabDecomposition.h
+nemo_io/IoBackend.h
+nemo_io/IoPool.h
+nemo_io/IoPool.cc
+nemo_io/Redistributor.h
+nemo_io/Redistributor.cc
+nemo_io/ParallelNetCDFBackend.h
+nemo_io/ParallelNetCDFBackend.cc
 nemo_io/ReadServer.h
 nemo_io/ReadServer.cc
 nemo_io/WriteServer.h
@@ -59,6 +67,6 @@ ecbuild_add_library( TARGET   orcamodel
                      LINKER_LANGUAGE ${OOPS_LINKER_LANGUAGE}
                     )
                   #target_link_libraries( orcamodel PUBLIC MPI::MPI_Fortran MPI::MPI_CXX )
-target_link_libraries( orcamodel PUBLIC NetCDF::NetCDF_CXX)
+target_link_libraries( orcamodel PUBLIC NetCDF::NetCDF_CXX NetCDF::NetCDF_C MPI::MPI_CXX)
 target_include_directories(orcamodel PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
                                             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)

--- a/src/orca-jedi/geometry/Geometry.h
+++ b/src/orca-jedi/geometry/Geometry.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <algorithm>
 
 #include "atlas/field/Field.h"
 #include "atlas/field/FieldSet.h"
@@ -71,6 +72,12 @@ class Geometry : public util::Printable,
   bool levelsAreTopDown() const {return true;}
   std::string distributionType() const {
       return params_.partitioner.value();}
+  bool parallelOutput() const {return params_.parallelOutput.value();}
+  size_t outputIoRanks() const {
+      return static_cast<size_t>(std::max(0, params_.outputIoRanks.value()));}
+  bool parallelInput() const {return params_.parallelInput.value();}
+  size_t inputIoRanks() const {
+      return static_cast<size_t>(std::max(0, params_.inputIoRanks.value()));}
   FieldDType fieldPrecision(std::string variable_name) const;
   std::shared_ptr<eckit::Timer> timer() const {return eckit_timer_;}
   void log_status() const;

--- a/src/orca-jedi/geometry/GeometryParameters.h
+++ b/src/orca-jedi/geometry/GeometryParameters.h
@@ -73,6 +73,32 @@ class OrcaGeometryParameters : public oops::Parameters {
       "initialise extra fields", this};
   oops::OptionalParameter<LandSeaMaskParameters> landSeaMask{
       "land sea mask", this};
+  oops::OptionalParameter<bool> extraFieldsInit{"initialise extra fields", this};
+
+  oops::Parameter<bool> parallelOutput{"parallel output",
+    "Write NEMO output files using the parallel (MPI + parallel-netCDF) I/O path"
+      " instead of gathering every field onto the root rank. Requires an MPI run."
+      " The default is false (gather-on-root).",
+    false,
+    this};
+  oops::Parameter<int> outputIoRanks{"output io ranks",
+    "Number of ranks to use for parallel output when 'parallel output' is true."
+      " A value of 0 (the default) uses every rank in the communicator. This"
+      " should typically be tuned towards the number of filesystem stripes.",
+    0,
+    this};
+  oops::Parameter<bool> parallelInput{"parallel input",
+    "Read NEMO input files using the parallel (MPI + parallel-netCDF) I/O path"
+      " instead of reading on the root rank and broadcasting. Requires an MPI"
+      " run and a netCDF-4 (HDF5) input file. The default is false"
+      " (read-on-root).",
+    false,
+    this};
+  oops::Parameter<int> inputIoRanks{"input io ranks",
+    "Number of ranks to use for parallel input when 'parallel input' is true."
+      " A value of 0 (the default) uses every rank in the communicator.",
+    0,
+    this};
 };
 
 }  //  namespace orcamodel

--- a/src/orca-jedi/geometry/GeometryParameters.h
+++ b/src/orca-jedi/geometry/GeometryParameters.h
@@ -73,7 +73,6 @@ class OrcaGeometryParameters : public oops::Parameters {
       "initialise extra fields", this};
   oops::OptionalParameter<LandSeaMaskParameters> landSeaMask{
       "land sea mask", this};
-  oops::OptionalParameter<bool> extraFieldsInit{"initialise extra fields", this};
 
   oops::Parameter<bool> parallelOutput{"parallel output",
     "Write NEMO output files using the parallel (MPI + parallel-netCDF) I/O path"

--- a/src/orca-jedi/nemo_io/AtlasIndex.h
+++ b/src/orca-jedi/nemo_io/AtlasIndex.h
@@ -27,6 +27,12 @@ class AtlasIndexToBufferIndex {
   virtual std::pair<int, int> ij(const size_t inode) const  = 0;
   virtual size_t nx() const = 0;
   virtual size_t ny() const = 0;
+  /// \brief Whether a mesh node maps onto a cell of the global i/j buffer.
+  ///        Nodes that fall outside the buffer (e.g. ORCA north-fold pivot
+  ///        ghost nodes) have no corresponding file cell and must be excluded
+  ///        from the parallel i/o scatter/gather; they are filled by the halo
+  ///        exchange instead.
+  virtual bool maps_to_buffer(const size_t inode) const = 0;
 };
 
 /// \brief Indexer from the orca netcdf i, j field to an index of a 1D buffer
@@ -85,6 +91,18 @@ class OrcaIndexToBufferIndex : public AtlasIndexToBufferIndex {
   int64_t operator()(const size_t inode) const {
       auto ij = atlas::array::make_view<int32_t, 2>(mesh_.nodes().field("ij"));
       return (*this)(ij(inode, 0), ij(inode, 1));
+  }
+
+  /// \brief Whether a mesh node maps onto a cell of the global i/j buffer.
+  ///        ORCA north-fold pivot ghost nodes have a j index one beyond the
+  ///        buffer and have no corresponding file cell; they are filled by the
+  ///        halo exchange rather than the parallel scatter.
+  bool maps_to_buffer(const size_t inode) const {
+      auto ij = atlas::array::make_view<int32_t, 2>(mesh_.nodes().field("ij"));
+      const int i = ij(inode, 0);
+      const int j = ij(inode, 1);
+      return i >= ix_glb_min && i <= ix_glb_max
+          && j >= iy_glb_min && j <= iy_glb_max;
   }
 
   /// \brief i, j pair corresponding to a node number. Only use this for diagnostic purposes as
@@ -156,6 +174,12 @@ class RegLonLatIndexToBufferIndex : public AtlasIndexToBufferIndex {
   /// \return std::pair of the 2D indices corresponding to the node.
   std::pair<int, int> ij(const size_t inode) const {
     return inode2ij[inode];
+  }
+
+  /// \brief Whether a mesh node maps onto a cell of the global i/j buffer.
+  bool maps_to_buffer(const size_t inode) const {
+    const auto[i, j] = inode2ij[inode];
+    return i >= 0 && i <= ix_glb_max && j >= 0 && j <= iy_glb_max;
   }
 
  private:

--- a/src/orca-jedi/nemo_io/IoBackend.h
+++ b/src/orca-jedi/nemo_io/IoBackend.h
@@ -1,0 +1,93 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "orca-jedi/nemo_io/SlabDecomposition.h"
+
+namespace orcamodel {
+
+/// \brief Abstract backend that turns per-I/O-rank slabs of data into bytes in
+///        a file.
+///
+/// This is the seam that decouples orca-jedi's I/O orchestration (communicator
+/// pool + redistribution, see IoPool and Redistributor) from the mechanism used
+/// to actually write the data. The default implementation is a parallel-netCDF
+/// (parallel HDF5) backend in which every I/O rank writes its own contiguous
+/// hyperslab collectively. Because the interface only exchanges already
+/// redistributed slabs plus their Hyperslab geometry, an alternative backend
+/// (for example one delegating to XIOS) can be dropped in without touching the
+/// redistribution logic or the callers in WriteServer.
+///
+/// Only double and float are supported, matching the field element types used
+/// throughout orca-jedi; virtual overloads are provided rather than templates
+/// so the interface remains polymorphic.
+class FieldWriteBackend {
+ public:
+  virtual ~FieldWriteBackend() = default;
+
+  /// \brief Declare dimensions and write the coordinate (lat/lon) variables.
+  /// \param slab      This I/O rank's row-band of the global grid.
+  /// \param lat_band  Latitudes for this rank's slab (size == slab.size()).
+  /// \param lon_band  Longitudes for this rank's slab (size == slab.size()).
+  virtual void write_dimensions(const Hyperslab& slab,
+                                const std::vector<double>& lat_band,
+                                const std::vector<double>& lon_band) = 0;
+
+  /// \brief Write a 2D surface variable slab at a time index.
+  virtual void write_surf_slab(const std::string& var_name, size_t t_index,
+                               const Hyperslab& slab,
+                               const std::vector<double>& data) = 0;
+  virtual void write_surf_slab(const std::string& var_name, size_t t_index,
+                               const Hyperslab& slab,
+                               const std::vector<float>& data) = 0;
+
+  /// \brief Write a contiguous range of levels of a 3D volume variable slab.
+  /// \param z_begin First level in this write.
+  /// \param z_count Number of levels in this write (data is laid out level-major:
+  ///                data[(k - z_begin) * slab.size() + p]).
+  virtual void write_vol_slab(const std::string& var_name, size_t t_index,
+                              size_t z_begin, size_t z_count,
+                              const Hyperslab& slab,
+                              const std::vector<double>& data) = 0;
+  virtual void write_vol_slab(const std::string& var_name, size_t t_index,
+                              size_t z_begin, size_t z_count,
+                              const Hyperslab& slab,
+                              const std::vector<float>& data) = 0;
+};
+
+/// \brief Abstract backend for reading per-I/O-rank slabs of data from a file.
+///
+/// The mirror image of FieldWriteBackend: each I/O rank reads its own
+/// contiguous hyperslab, which the Redistributor then scatters onto the compute
+/// decomposition.
+///
+/// Reads are expressed as a single horizontal (y, x) slice at a given time and
+/// level index, matching the access pattern of ReadServer::read_var (and
+/// NemoFieldReader::read_var_slice). The backend inspects the variable's
+/// dimensionality: for a 2D surface variable {t, y, x} the level index must be
+/// zero and is ignored; for a 3D volume variable {t, z, y, x} it selects the
+/// level.
+class FieldReadBackend {
+ public:
+  virtual ~FieldReadBackend() = default;
+
+  /// \brief Read a single horizontal slice of a variable into this rank's slab.
+  /// \param var_name Name of the variable in the file.
+  /// \param t_index  Time index to read.
+  /// \param z_index  Level index (ignored for surface variables).
+  /// \param slab     This I/O rank's row-band of the global grid.
+  /// \param data     Output slab (resized to slab.size()).
+  virtual void read_slab(const std::string& var_name, size_t t_index,
+                         size_t z_index, const Hyperslab& slab,
+                         std::vector<double>& data) = 0;
+  virtual void read_slab(const std::string& var_name, size_t t_index,
+                         size_t z_index, const Hyperslab& slab,
+                         std::vector<float>& data) = 0;
+};
+
+}  // namespace orcamodel

--- a/src/orca-jedi/nemo_io/IoPool.cc
+++ b/src/orca-jedi/nemo_io/IoPool.cc
@@ -1,0 +1,89 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#include "orca-jedi/nemo_io/IoPool.h"
+
+#include <algorithm>
+#include <string>
+#include <utility>
+
+#include "atlas/runtime/Exception.h"  // IWYU pragma: keep
+#include "oops/util/Logger.h"
+
+namespace orcamodel {
+
+namespace {
+/// \brief Decide whether a given parent rank should be an I/O rank, choosing
+///        ranks spread as evenly as possible across the parent communicator.
+///
+/// Rank r is selected if it is one of the n_io evenly spaced picks
+/// floor(k * size / n_io) for k in [0, n_io). This keeps I/O ranks on distinct
+/// nodes when ranks are packed node-by-node, improving aggregate filesystem
+/// bandwidth. Returns the pool index [0, n_io) if selected, or -1 otherwise.
+int pool_index(size_t rank, size_t size, size_t n_io) {
+  for (size_t k = 0; k < n_io; ++k) {
+    if ((k * size) / n_io == rank) {
+      return static_cast<int>(k);
+    }
+  }
+  return -1;
+}
+}  // namespace
+
+IoPool::IoPool(const eckit::mpi::Comm& parent, size_t n_io_ranks,
+               size_t nx, size_t ny, const std::string& name) {
+  const size_t size = parent.size();
+  const size_t rank = parent.rank();
+  parent_size_ = size;
+
+  n_io_ranks_ = std::max<size_t>(1, std::min({n_io_ranks, size, ny == 0 ? size : ny}));
+
+  const int idx = pool_index(rank, size, n_io_ranks_);
+  const int color = (idx >= 0) ? 0 : 1;
+
+  // split() is collective over the parent communicator; every rank must call it.
+  // It registers the resulting sub-communicator (for this rank's colour) under
+  // \p name in eckit's global registry, so both the I/O group and the non-I/O
+  // group hold a communicator under this name and both must free it later.
+  eckit::mpi::Comm& split_comm = parent.split(color, name);
+  comm_name_ = name;
+
+  if (idx >= 0) {
+    io_rank_ = idx;
+    io_comm_ = &split_comm;
+    // split() orders new-communicator ranks by parent rank, so the rank within
+    // the I/O communicator matches the evenly spaced pool index.
+    ATLAS_ASSERT(static_cast<size_t>(io_comm_->rank()) == static_cast<size_t>(idx),
+        "IoPool: unexpected I/O sub-communicator rank ordering");
+  }
+
+  decomposition_ = std::make_unique<YBandDecomposition>(nx, ny, n_io_ranks_);
+
+  oops::Log::trace() << "orcamodel::IoPool::IoPool selected " << n_io_ranks_
+                     << " I/O ranks from " << size << " (this rank io_rank="
+                     << io_rank_ << ")" << std::endl;
+}
+
+IoPool::IoPool(IoPool&& other) noexcept
+    : n_io_ranks_(other.n_io_ranks_),
+      parent_size_(other.parent_size_),
+      io_rank_(other.io_rank_),
+      io_comm_(other.io_comm_),
+      comm_name_(std::move(other.comm_name_)),
+      decomposition_(std::move(other.decomposition_)) {
+  // The moved-from pool must not free the communicator in its destructor.
+  other.comm_name_.clear();
+  other.io_comm_ = nullptr;
+}
+
+IoPool::~IoPool() {
+  // Free the split communicator so the name can be reused on a later pool. Only
+  // ranks that registered the name (all parent ranks, unless moved-from) delete
+  // it, and each does so collectively within its own colour group.
+  if (!comm_name_.empty() && eckit::mpi::hasComm(comm_name_)) {
+    eckit::mpi::deleteComm(comm_name_);
+  }
+}
+
+}  // namespace orcamodel

--- a/src/orca-jedi/nemo_io/IoPool.h
+++ b/src/orca-jedi/nemo_io/IoPool.h
@@ -1,0 +1,78 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "eckit/mpi/Comm.h"
+
+#include "orca-jedi/nemo_io/SlabDecomposition.h"
+
+namespace orcamodel {
+
+/// \brief A subset of MPI ranks dedicated to file I/O, together with the
+///        decomposition of the global grid across those ranks.
+///
+/// The pool selects a configurable number of I/O ranks spread evenly across the
+/// parent communicator (to avoid clustering them on a single compute node) and
+/// splits off a sub-communicator containing only those ranks. The file is later
+/// opened collectively on that sub-communicator, so non-I/O ranks never touch
+/// the filesystem. The number of I/O ranks is a runtime knob: it should
+/// typically be tuned towards the number of Lustre stripes / OSTs on the target
+/// filesystem rather than the total rank count.
+class IoPool {
+ public:
+  /// \param parent        Communicator to draw I/O ranks from (usually the model
+  ///                      communicator).
+  /// \param n_io_ranks    Desired number of I/O ranks (clamped to [1, parent
+  ///                      size] and to the number of grid rows).
+  /// \param nx            Global x extent of the grid.
+  /// \param ny            Global y extent of the grid.
+  /// \param name          Unique name used to register the split communicator.
+  IoPool(const eckit::mpi::Comm& parent, size_t n_io_ranks,
+         size_t nx, size_t ny, const std::string& name = "orca_io_pool");
+
+  /// \brief Frees the split communicator from the global eckit MPI registry so
+  ///        the pool name can be reused (e.g. across successive writes).
+  ~IoPool();
+
+  IoPool(IoPool&& other) noexcept;
+  IoPool(const IoPool&) = delete;
+  IoPool& operator=(IoPool&&) = delete;
+  IoPool& operator=(const IoPool&) = delete;
+
+  /// \brief Whether this rank participates in I/O.
+  bool is_io_rank() const { return io_rank_ >= 0; }
+
+  /// \brief This rank's index within the I/O pool, or -1 if not an I/O rank.
+  int io_rank() const { return io_rank_; }
+
+  /// \brief Number of ranks in the pool.
+  size_t n_io_ranks() const { return n_io_ranks_; }
+
+  /// \brief The parent-communicator rank of a given pool member. Mirrors the
+  ///        even-spacing selection used in the constructor.
+  size_t parent_rank_of(size_t pool_rank) const {
+    return (pool_rank * parent_size_) / n_io_ranks_;
+  }
+
+  /// \brief The I/O sub-communicator (only valid to use collectively on I/O
+  ///        ranks).
+  const eckit::mpi::Comm& io_comm() const { return *io_comm_; }
+
+  /// \brief The grid decomposition across the pool.
+  const SlabDecomposition& decomposition() const { return *decomposition_; }
+
+ private:
+  size_t n_io_ranks_;
+  size_t parent_size_ = 1;
+  int io_rank_ = -1;
+  const eckit::mpi::Comm* io_comm_ = nullptr;
+  std::string comm_name_;
+  std::unique_ptr<SlabDecomposition> decomposition_;
+};
+
+}  // namespace orcamodel

--- a/src/orca-jedi/nemo_io/NemoFieldReader.cc
+++ b/src/orca-jedi/nemo_io/NemoFieldReader.cc
@@ -4,14 +4,14 @@
 
 #include "orca-jedi/nemo_io/NemoFieldReader.h"
 
-#include <netcdf>
-// Using Lynton Appel's netcdf-cxx4 from
-// https://github.com/Unidata/netcdf-cxx4
-//
+#include <netcdf.h>
+
 #include <algorithm>
 #include <sstream>
 #include <limits>
-#include <map>
+#include <utility>
+#include <vector>
+#include <string>
 
 #include "eckit/exception/Exceptions.h"
 
@@ -22,195 +22,246 @@ namespace orcamodel {
 
 namespace {
 
-/// \brief Search the netCDF file for a dimension matching a name from a list of possible names.
-/// \param ncFile The netCDF file.
+/// \brief Throw an eckit::ReadError if a netcdf-c call returned an error.
+void nc_check(int status, const std::string& where) {
+  if (status != NC_NOERR) {
+    throw eckit::ReadError(std::string("orcamodel::NemoFieldReader ") + where
+        + ": " + nc_strerror(status), Here());
+  }
+}
+
+/// \brief Return true (and set varid) if a variable of the given name exists.
+bool nc_var_exists(int ncid, const std::string& name, int& varid) {
+  const int status = nc_inq_varid(ncid, name.c_str(), &varid);
+  if (status == NC_ENOTVAR) return false;
+  nc_check(status, "nc_inq_varid " + name);
+  return true;
+}
+
+/// \brief Return true (and set dimid) if a dimension of the given name exists.
+bool nc_dim_exists(int ncid, const std::string& name, int& dimid) {
+  const int status = nc_inq_dimid(ncid, name.c_str(), &dimid);
+  if (status == NC_EBADDIM) return false;
+  nc_check(status, "nc_inq_dimid " + name);
+  return true;
+}
+
+/// \brief Look up a variable id, throwing eckit::BadValue if it is absent.
+int get_varid_or_throw(int ncid, const std::string& name,
+    const std::string& where) {
+  int varid = -1;
+  if (!nc_var_exists(ncid, name, varid)) {
+    std::ostringstream err_stream;
+    err_stream << "orcamodel::NemoFieldReader::" << where << " ncVar '"
+               << name << "' is not present in NetCDF file";
+    throw eckit::BadValue(err_stream.str(), Here());
+  }
+  return varid;
+}
+
+/// \brief Search the netCDF file for a dimension matching a name from a list of
+///        possible names.
+/// \param ncid The netCDF file id.
 /// \param check_dim_for_dimvar Set to true to ensure the dimension has
 ///        a corresponding dimension variable.
 /// \param possible_names A vector of all possible names for the variable.
 /// \return The dimension name.
-std::string find_nc_var_name(const netCDF::NcFile& ncFile,
-    const bool check_dim_for_dimvar,
+std::string find_nc_var_name(int ncid, const bool check_dim_for_dimvar,
     const std::vector<std::string>& possible_names) {
-  std::string dimvar_name("");
-  netCDF::NcDim nc_dim;
-  netCDF::NcVar nc_var;
-  for (const auto & c_candidate : possible_names) {
-    // Copy because ncFile methods only have non-const interface
-    std::string candidate(c_candidate);
-    nc_var = ncFile.getVar(candidate);
-    nc_dim = ncFile.getDim(candidate);
-    // check for coordinate dimension and optionally corresponding dimension
-    // variable
-    if (!nc_dim.isNull() && (!check_dim_for_dimvar || !nc_var.isNull())) {
-      dimvar_name = candidate;
-      return dimvar_name;
+  for (const auto& candidate : possible_names) {
+    int dimid = -1;
+    int varid = -1;
+    const bool has_dim = nc_dim_exists(ncid, candidate, dimid);
+    const bool has_var = nc_var_exists(ncid, candidate, varid);
+    if (has_dim && (!check_dim_for_dimvar || has_var)) {
+      return candidate;
     }
   }
 
-  if (dimvar_name == "") {
-    std::ostringstream err_stream;
-    err_stream << "orcamodel::find_nc_var_name coordinate matching {";
-    for (const auto & n : possible_names) err_stream << "'" << n << "' ";
-    err_stream << "} is not present in NetCDF file" << std::endl;
-    throw eckit::BadValue(err_stream.str(), Here());
-  }
-
-  return dimvar_name;
+  std::ostringstream err_stream;
+  err_stream << "orcamodel::find_nc_var_name coordinate matching {";
+  for (const auto& n : possible_names) err_stream << "'" << n << "' ";
+  err_stream << "} is not present in NetCDF file" << std::endl;
+  throw eckit::BadValue(err_stream.str(), Here());
 }
-template<typename InType, typename OutType> void fill_from_ncvar_as_type(
-    const netCDF::NcVar nc_var,
-    const std::vector<size_t>& sizes, const std::vector<size_t>& counts,
+
+// Overload set dispatching a hyperslab read to the correct typed netcdf-c call.
+inline int nc_get_vara_dispatch(int ncid, int varid, const size_t* start,
+    const size_t* count, double* buf) {
+  return nc_get_vara_double(ncid, varid, start, count, buf);
+}
+inline int nc_get_vara_dispatch(int ncid, int varid, const size_t* start,
+    const size_t* count, float* buf) {
+  return nc_get_vara_float(ncid, varid, start, count, buf);
+}
+inline int nc_get_vara_dispatch(int ncid, int varid, const size_t* start,
+    const size_t* count, int* buf) {
+  return nc_get_vara_int(ncid, varid, start, count, buf);
+}
+inline int nc_get_vara_dispatch(int ncid, int varid, const size_t* start,
+    const size_t* count, long long* buf) {  // NOLINT(runtime/int)
+  return nc_get_vara_longlong(ncid, varid, start, count, buf);
+}
+
+/// \brief Read a hyperslab of a variable stored as InType, casting to OutType.
+template<typename InType, typename OutType>
+void fill_from_ncvar_as_type(int ncid, int varid,
+    const std::vector<size_t>& starts, const std::vector<size_t>& counts,
     std::vector<OutType>& result) {
   std::vector<InType> buffer(result.size());
-  nc_var.getVar(sizes, counts, buffer.data());
+  nc_check(nc_get_vara_dispatch(ncid, varid, starts.data(), counts.data(),
+      buffer.data()), "fill_from_ncvar_as_type nc_get_vara");
   std::transform(buffer.begin(), buffer.end(), result.begin(),
      [](const InType in) -> OutType { return static_cast<OutType>(in); });
 }
-template void fill_from_ncvar_as_type<float, double>(
-    const netCDF::NcVar nc_var,
-    const std::vector<size_t>& sizes, const std::vector<size_t>& counts,
-    std::vector<double>& result);
-template void fill_from_ncvar_as_type<double, float>(
-    const netCDF::NcVar nc_var,
-    const std::vector<size_t>& sizes, const std::vector<size_t>& counts,
-    std::vector<float>& result);
-template void fill_from_ncvar_as_type<int, double>(
-    const netCDF::NcVar nc_var,
-    const std::vector<size_t>& sizes, const std::vector<size_t>& counts,
-    std::vector<double>& result);
-template void fill_from_ncvar_as_type<int, float>(
-    const netCDF::NcVar nc_var,
-    const std::vector<size_t>& sizes, const std::vector<size_t>& counts,
-    std::vector<float>& result);
-template void fill_from_ncvar_as_type<int64_t, double>(
-    const netCDF::NcVar nc_var,
-    const std::vector<size_t>& sizes, const std::vector<size_t>& counts,
-    std::vector<double>& result);
-template void fill_from_ncvar_as_type<int64_t, float>(
-    const netCDF::NcVar nc_var,
-    const std::vector<size_t>& sizes, const std::vector<size_t>& counts,
-    std::vector<float>& result);
 
-template<> void fill_from_ncvar_as_type<double, double>(
-    const netCDF::NcVar nc_var,
-    const std::vector<size_t>& sizes, const std::vector<size_t>& counts,
+template<>
+void fill_from_ncvar_as_type<double, double>(int ncid, int varid,
+    const std::vector<size_t>& starts, const std::vector<size_t>& counts,
     std::vector<double>& result) {
-  nc_var.getVar(sizes, counts, result.data());
+  nc_check(nc_get_vara_double(ncid, varid, starts.data(), counts.data(),
+      result.data()), "fill_from_ncvar_as_type nc_get_vara_double");
 }
-template<> void fill_from_ncvar_as_type<float, float>(
-    const netCDF::NcVar nc_var,
-    const std::vector<size_t>& sizes, const std::vector<size_t>& counts,
+template<>
+void fill_from_ncvar_as_type<float, float>(int ncid, int varid,
+    const std::vector<size_t>& starts, const std::vector<size_t>& counts,
     std::vector<float>& result) {
-  nc_var.getVar(sizes, counts, result.data());
+  nc_check(nc_get_vara_float(ncid, varid, starts.data(), counts.data(),
+      result.data()), "fill_from_ncvar_as_type nc_get_vara_float");
+}
+
+// Overload set dispatching a scalar attribute read to the correct typed call.
+inline int nc_get_att_dispatch(int ncid, int varid, const char* name,
+    double* v) {
+  return nc_get_att_double(ncid, varid, name, v);
+}
+inline int nc_get_att_dispatch(int ncid, int varid, const char* name,
+    float* v) {
+  return nc_get_att_float(ncid, varid, name, v);
+}
+inline int nc_get_att_dispatch(int ncid, int varid, const char* name,
+    int* v) {
+  return nc_get_att_int(ncid, varid, name, v);
 }
 }  // namespace
 
 NemoFieldReader::NemoFieldReader(const eckit::PathName& filename)
-  : ncFile(nullptr), datetimes_() {
+  : ncid_(-1), datetimes_() {
   oops::Log::debug() << "orcamodel::NemoFieldReader::NemoFieldReader filename: "
                      << filename.fullName().asString() << std::endl;
-  std::ostringstream err_stream;
   if (!filename.exists()) {
+     std::ostringstream err_stream;
      err_stream << "orcamodel::NemoFieldReader::NemoFieldReader filename: "
                 << filename.fullName().asString() << " doesn't exist "
                 << std::endl;
      throw eckit::BadValue(err_stream.str(), Here());
   }
-  try {
-    ncFile = std::make_unique<netCDF::NcFile>(filename.fullName().asString(),
-        netCDF::NcFile::read);
-  } catch(netCDF::exceptions::NcException& e) {
+  // netcdf-c's nc_open reads netCDF-3 (classic) and netCDF-4 (HDF5)
+  // transparently, so the serial read path supports any on-disk format.
+  const int status = nc_open(filename.fullName().asString().c_str(),
+                             NC_NOWRITE, &ncid_);
+  if (status != NC_NOERR) {
+    std::ostringstream err_stream;
     err_stream << "orcamodel::NemoFieldReader::NemoFieldReader cannot open "
-               << filename << std::endl;
-    err_stream << "NetCDF Exception: " << e.what() << std::endl;
+               << filename << ": " << nc_strerror(status) << std::endl;
     throw eckit::BadValue(err_stream.str(), Here());
   }
 
-  time_dimvar_name_ = find_nc_var_name(*ncFile, true,
+  time_dimvar_name_ = find_nc_var_name(ncid_, true,
                                        {"t", "time", "time_counter"});
-  z_dimvar_name_ = find_nc_var_name(*ncFile, false, {"z", "deptht"});
+  z_dimvar_name_ = find_nc_var_name(ncid_, false, {"z", "deptht"});
 
   read_datetimes();
+}
+
+NemoFieldReader::~NemoFieldReader() {
+  if (ncid_ >= 0) {
+    nc_close(ncid_);
+  }
+}
+
+NemoFieldReader::NemoFieldReader(NemoFieldReader&& other) noexcept
+  : ncid_(other.ncid_),
+    datetimes_(std::move(other.datetimes_)),
+    time_dimvar_name_(std::move(other.time_dimvar_name_)),
+    z_dimvar_name_(std::move(other.z_dimvar_name_)) {
+  other.ncid_ = -1;
+}
+
+NemoFieldReader& NemoFieldReader::operator=(NemoFieldReader&& other) noexcept {
+  if (this != &other) {
+    if (ncid_ >= 0) nc_close(ncid_);
+    ncid_ = other.ncid_;
+    datetimes_ = std::move(other.datetimes_);
+    time_dimvar_name_ = std::move(other.time_dimvar_name_);
+    z_dimvar_name_ = std::move(other.z_dimvar_name_);
+    other.ncid_ = -1;
+  }
+  return *this;
 }
 
 /// \brief Read the dimension size for a given netCDF dimension specified by name
 /// \param name The name of the netCDF dimension
 /// \return size The size
 size_t NemoFieldReader::read_dim_size(const std::string& name) const {
-  auto dim = ncFile->getDim(name);
-  if (dim.isNull()) {
+  int dimid = -1;
+  if (!nc_dim_exists(ncid_, name, dimid)) {
     std::ostringstream err_stream;
     err_stream << "orcamodel::NemoFieldReader::read_dim_size Dimension '"
                << name << "' is not present in NetCDF file" << std::endl;
     throw eckit::BadValue(err_stream.str(), Here());
   }
-  return dim.getSize();
+  size_t len = 0;
+  nc_check(nc_inq_dimlen(ncid_, dimid, &len), "read_dim_size " + name);
+  return len;
 }
 
 /// \brief Update the datetimes_ in the object to contain times for each time index in file.
 void NemoFieldReader::read_datetimes() {
   // read time indices from file
   size_t n_times = read_dim_size(time_dimvar_name_);
+  const int varid = get_varid_or_throw(ncid_, time_dimvar_name_,
+                                       "read_datetimes");
 
-  try {
-    netCDF::NcVar nc_var_time = ncFile->getVar(time_dimvar_name_);
-    if (nc_var_time.isNull()) {
-      std::ostringstream err_stream;
-      err_stream << "orcamodel::NemoFieldReader::read_datetimes ncVar "
-                 << time_dimvar_name_
-                 << " is not present in NetCDF file" << std::endl;
-      throw eckit::BadValue(err_stream.str(), Here());
-    }
-
-    if (n_times < 1) {
-      std::ostringstream err_stream;
-      err_stream << "orcamodel::NemoFieldReader::read_datetimes n_times < 1 "
-                 << n_times << std::endl;
-      throw eckit::BadValue(err_stream.str(), Here());
-    }
-
-    std::vector<int64_t> timestamps(n_times);
-    nc_var_time.getVar({0}, {n_times}, timestamps.data());
-
-    // read time units attribute from file
-    netCDF::NcVarAtt nc_att_units;
-    std::string units_string;
-    nc_att_units = nc_var_time.getAtt("units");
-    if (nc_att_units.isNull()) {
-      std::ostringstream err_stream;
-      err_stream << "orcamodel::NemoFieldReader::read_datetimes ncVar units is "
-                 << "not present in NetCDF file";
-      throw eckit::BadValue(err_stream.str(), Here());
-    }
-    nc_att_units.getValues(units_string);
-
-    const std::string seconds_since = "seconds since ";
-    std::for_each(units_string.begin(),
-        units_string.begin()+seconds_since.size(),
-        [](char & c){ c = tolower(c); });
-    if (units_string.substr(0, seconds_since.size()) != seconds_since) {
-      std::ostringstream err_stream;
-      err_stream << "orcamodel::NemoFieldReader::read_datetimes units attribute"
-                 << " badly formatted: " << units_string << std::endl;
-      throw eckit::BadValue(err_stream.str(), Here());
-    }
-    units_string.replace(seconds_since.size() + 10, 1, 1, 'T');
-    units_string.append("Z");
-
-    auto epoch = util::DateTime(units_string.substr(seconds_since.size()));
-
-    // construct date times
-    datetimes_.resize(n_times);
-    for (size_t i=0; i < n_times; ++i) {
-      datetimes_[i] = epoch + util::Duration(timestamps[i]);
-    }
-  } catch(netCDF::exceptions::NcException& e)
-  {
+  if (n_times < 1) {
     std::ostringstream err_stream;
-    err_stream << "orcamodel::NemoFieldReader::read_datetimes NetCDF exception "
-               << time_dimvar_name_ << ": " << std::endl;
-    err_stream << e.what();
-    throw eckit::ReadError(err_stream.str(), Here());
+    err_stream << "orcamodel::NemoFieldReader::read_datetimes n_times < 1 "
+               << n_times << std::endl;
+    throw eckit::BadValue(err_stream.str(), Here());
+  }
+
+  std::vector<long long> timestamps(n_times);  // NOLINT(runtime/int)
+  const size_t start = 0;
+  nc_check(nc_get_vara_longlong(ncid_, varid, &start, &n_times,
+      timestamps.data()), "read_datetimes get time values");
+
+  // read time units attribute from file
+  size_t units_len = 0;
+  nc_check(nc_inq_attlen(ncid_, varid, "units", &units_len),
+      "read_datetimes units attribute length");
+  std::string units_string(units_len, '\0');
+  nc_check(nc_get_att_text(ncid_, varid, "units", &units_string[0]),
+      "read_datetimes get units attribute");
+
+  const std::string seconds_since = "seconds since ";
+  std::for_each(units_string.begin(),
+      units_string.begin()+seconds_since.size(),
+      [](char & c){ c = tolower(c); });
+  if (units_string.substr(0, seconds_since.size()) != seconds_since) {
+    std::ostringstream err_stream;
+    err_stream << "orcamodel::NemoFieldReader::read_datetimes units attribute"
+               << " badly formatted: " << units_string << std::endl;
+    throw eckit::BadValue(err_stream.str(), Here());
+  }
+  units_string.replace(seconds_since.size() + 10, 1, 1, 'T');
+  units_string.append("Z");
+
+  auto epoch = util::DateTime(units_string.substr(seconds_since.size()));
+
+  // construct date times
+  datetimes_.resize(n_times);
+  for (size_t i=0; i < n_times; ++i) {
+    datetimes_[i] = epoch + util::Duration(timestamps[i]);
   }
 }
 
@@ -219,27 +270,20 @@ void NemoFieldReader::read_datetimes() {
 /// \param name Name of the netCDF variable containing the _FillValue attribute to retrieve.
 /// \return The fill value for this netCDF variable
 template<typename T> T NemoFieldReader::read_fillvalue(const std::string& name) const {
-  netCDF::NcVar nc_var = ncFile->getVar(name);
-  if (nc_var.isNull()) {
-    std::ostringstream err_stream;
-    err_stream << "orcamodel::NemoFieldReader::read_fillvalue ncVar "
-               << time_dimvar_name_ << " is not present in NetCDF file"
-               << std::endl;
-    eckit::BadValue(err_stream.str(), Here());
-  }
+  const int varid = get_varid_or_throw(ncid_, name, "read_fillvalue");
 
   T fillvalue = std::numeric_limits<T>::lowest();
 
-  std::map<std::string, netCDF::NcVarAtt> attributeList = nc_var.getAtts();
-  auto myIter = attributeList.find("_FillValue");
-  if (myIter == attributeList.end()) {
+  const int status = nc_inq_att(ncid_, varid, "_FillValue", nullptr, nullptr);
+  if (status == NC_ENOTATT) {
     oops::Log::trace() << "orcamodel::NemoFieldReader::read_fillvalue fillvalue"
                        << " not found " << std::endl;
   } else {
+    nc_check(status, "read_fillvalue inq _FillValue " + name);
     oops::Log::trace() << "orcamodel::NemoFieldReader::read_fillvalue found: "
-                       << myIter->first << std::endl;
-    netCDF::NcVarAtt nc_att_fill = myIter->second;
-    nc_att_fill.getValues(&fillvalue);
+                       << "_FillValue" << std::endl;
+    nc_check(nc_get_att_dispatch(ncid_, varid, "_FillValue", &fillvalue),
+        "read_fillvalue get _FillValue " + name);
   }
 
   oops::Log::trace() << "orcamodel::NemoFieldReader::read_fillvalue fillvalue: "
@@ -276,71 +320,46 @@ size_t NemoFieldReader::get_nearest_datetime_index(
 /// \brief Read the latitude longitude locations of all points in a NEMO field file
 /// \return A vector of XY points of all nodes in the field.
 std::vector<atlas::PointXY> NemoFieldReader::read_locs() const {
-  try {
-    size_t nx = read_dim_size("x");
-    size_t ny = read_dim_size("y");
+  size_t nx = read_dim_size("x");
+  size_t ny = read_dim_size("y");
 
-    std::string varname = "nav_lat";
-    netCDF::NcVar nc_var_lat = ncFile->getVar(varname);
-    if (nc_var_lat.isNull()) {
-      std::ostringstream err_stream;
-      err_stream << "orcamodel::NemoFieldReader::read_locs ncVar " << varname
-                 << " is not present in NetCDF file" << std::endl;
-      throw eckit::BadValue(err_stream.str(), Here());
-    }
-
-    std::vector<double> lats(nx*ny);
-    std::string lat_type_name = nc_var_lat.getType().getName();
-    if (lat_type_name == "double") {
-      fill_from_ncvar_as_type<double, double>(nc_var_lat, {0, 0}, {ny, nx}, lats);
-    } else if (lat_type_name == "float") {
-      fill_from_ncvar_as_type<float, double>(nc_var_lat, {0, 0}, {ny, nx}, lats);
-    } else {
-      std::ostringstream err_stream;
-      err_stream << "orcamodel::NemoFieldReader::read_locs ncVar '"
-                 << varname << "' reading type "
-                 << lat_type_name << " not supported.";
-      throw eckit::BadValue(err_stream.str(), Here());
-    }
-
-    varname = "nav_lon";
-    netCDF::NcVar nc_var_lon = ncFile->getVar(varname);
-    if (nc_var_lon.isNull()) {
-      std::ostringstream err_stream;
-      err_stream << "orcamodel::NemoFieldReader::read_locs ncVar '" << varname
-                 <<"' is not present in NetCDF file.";
-      throw eckit::BadValue(err_stream.str(), Here());
-    }
-
-    std::vector<double> lons(nx*ny);
-    std::string lon_type_name = nc_var_lat.getType().getName();
-    if (lon_type_name == "double") {
-      fill_from_ncvar_as_type<double, double>(nc_var_lon, {0, 0}, {ny, nx}, lons);
-    } else if (lon_type_name == "float") {
-      fill_from_ncvar_as_type<float, double>(nc_var_lon, {0, 0}, {ny, nx}, lons);
-    } else {
-      std::ostringstream err_stream;
-      err_stream << "orcamodel::NemoFieldReader::read_locs ncVar '"
-                 << varname << "' reading type "
-                 << nc_var_lon.getType().getName() << " not supported.";
-      throw eckit::BadValue(err_stream.str(), Here());
-    }
-
-    std::vector<atlas::PointXY> locations(nx*ny);
-
-    for (size_t i=0; i < nx*ny; i++) {
-      locations[i] = atlas::PointXY(lons[i], lats[i]);
-    }
-
-    return locations;
-  } catch(netCDF::exceptions::NcException& e)
-  {
+  const int lat_id = get_varid_or_throw(ncid_, "nav_lat", "read_locs");
+  nc_type lat_type;
+  nc_check(nc_inq_vartype(ncid_, lat_id, &lat_type), "read_locs nav_lat type");
+  std::vector<double> lats(nx*ny);
+  if (lat_type == NC_DOUBLE) {
+    fill_from_ncvar_as_type<double, double>(ncid_, lat_id, {0, 0}, {ny, nx}, lats);
+  } else if (lat_type == NC_FLOAT) {
+    fill_from_ncvar_as_type<float, double>(ncid_, lat_id, {0, 0}, {ny, nx}, lats);
+  } else {
     std::ostringstream err_stream;
-    err_stream << "orcamodel::NemoFieldReader::read_locs NetCDF exception: "
-               << std::endl;
-    err_stream << e.what();
-    throw eckit::ReadError(err_stream.str(), Here());
+    err_stream << "orcamodel::NemoFieldReader::read_locs ncVar 'nav_lat'"
+               << " reading type " << lat_type << " not supported.";
+    throw eckit::BadValue(err_stream.str(), Here());
   }
+
+  const int lon_id = get_varid_or_throw(ncid_, "nav_lon", "read_locs");
+  nc_type lon_type;
+  nc_check(nc_inq_vartype(ncid_, lon_id, &lon_type), "read_locs nav_lon type");
+  std::vector<double> lons(nx*ny);
+  if (lon_type == NC_DOUBLE) {
+    fill_from_ncvar_as_type<double, double>(ncid_, lon_id, {0, 0}, {ny, nx}, lons);
+  } else if (lon_type == NC_FLOAT) {
+    fill_from_ncvar_as_type<float, double>(ncid_, lon_id, {0, 0}, {ny, nx}, lons);
+  } else {
+    std::ostringstream err_stream;
+    err_stream << "orcamodel::NemoFieldReader::read_locs ncVar 'nav_lon'"
+               << " reading type " << lon_type << " not supported.";
+    throw eckit::BadValue(err_stream.str(), Here());
+  }
+
+  std::vector<atlas::PointXY> locations(nx*ny);
+
+  for (size_t i=0; i < nx*ny; i++) {
+    locations[i] = atlas::PointXY(lons[i], lats[i]);
+  }
+
+  return locations;
 }
 
 /// \brief Read all data for a given variable at a level and time.
@@ -353,64 +372,53 @@ template<typename T> std::vector<T> NemoFieldReader::read_var_slice(const std::s
   oops::Log::trace() << "orcamodel::NemoFieldReader::read_var_slice("
                      << varname << ", " << t_indx << ", " << z_indx
                      << ")" << std::endl;
-  try {
-    size_t nx = read_dim_size("x");
-    size_t ny = read_dim_size("y");
+  size_t nx = read_dim_size("x");
+  size_t ny = read_dim_size("y");
 
-    netCDF::NcVar nc_var = ncFile->getVar(varname);
-    if (nc_var.isNull()) {
-      std::ostringstream err_stream;
-      err_stream << "orcamodel::NemoFieldReader::read_var_slice ncVar '"
-                 << varname << "' is not present in NetCDF file";
-      throw eckit::BadValue(err_stream.str(), Here());
-    }
+  const int varid = get_varid_or_throw(ncid_, varname, "read_var_slice");
 
-    size_t n_dims = nc_var.getDimCount();
-    std::vector<size_t> starts;
-    std::vector<size_t> counts;
-    if (n_dims == 4) {
-      starts = {t_indx, z_indx, 0, 0};
-      counts = {1, 1, ny, nx};
-    } else if (n_dims == 3) {
-      starts = {t_indx, 0, 0};
-      counts = {1, ny, nx};
-    } else if (n_dims == 2) {
-      starts = {0, 0};
-      counts = {ny, nx};
-    } else {
-      std::ostringstream err_stream;
-      err_stream << "orcamodel::NemoFieldReader::read_var_slice ncVar '"
-                 << varname << "' has " << n_dims << " dimensions.";
-      throw eckit::BadValue(err_stream.str(), Here());
-    }
-
-    std::vector<T> var_data(nx*ny);
-
-    std::string nc_type_name = nc_var.getType().getName();
-    if (nc_type_name == "double") {
-        fill_from_ncvar_as_type<double, T>(nc_var, starts, counts, var_data);
-    } else if (nc_type_name == "float") {
-        fill_from_ncvar_as_type<float, T>(nc_var, starts, counts, var_data);
-    } else if (nc_type_name == "int") {
-        fill_from_ncvar_as_type<int, T>(nc_var, starts, counts, var_data);
-    } else if (nc_type_name == "int64") {
-        fill_from_ncvar_as_type<int64_t, T>(nc_var, starts, counts, var_data);
-    } else {
-        std::ostringstream err_stream;
-        err_stream << "orcamodel::NemoFieldReader::read_var_slice ncVar '"
-                   << varname << "' reading type "
-                   << nc_type_name << " not supported.";
-        throw eckit::BadValue(err_stream.str(), Here());
-    }
-
-    return var_data;
-  } catch(netCDF::exceptions::NcException& e)
-  {
+  int n_dims = 0;
+  nc_check(nc_inq_varndims(ncid_, varid, &n_dims), "read_var_slice ndims " + varname);
+  std::vector<size_t> starts;
+  std::vector<size_t> counts;
+  if (n_dims == 4) {
+    starts = {t_indx, z_indx, 0, 0};
+    counts = {1, 1, ny, nx};
+  } else if (n_dims == 3) {
+    starts = {t_indx, 0, 0};
+    counts = {1, ny, nx};
+  } else if (n_dims == 2) {
+    starts = {0, 0};
+    counts = {ny, nx};
+  } else {
     std::ostringstream err_stream;
-    err_stream << "orcamodel::NemoFieldReader::read_var_slice varname: "
-               << varname << " NetCDF exception: " << std::endl << e.what();
-    throw eckit::ReadError(err_stream.str(), Here());
+    err_stream << "orcamodel::NemoFieldReader::read_var_slice ncVar '"
+               << varname << "' has " << n_dims << " dimensions.";
+    throw eckit::BadValue(err_stream.str(), Here());
   }
+
+  std::vector<T> var_data(nx*ny);
+
+  nc_type xtype;
+  nc_check(nc_inq_vartype(ncid_, varid, &xtype), "read_var_slice type " + varname);
+  if (xtype == NC_DOUBLE) {
+      fill_from_ncvar_as_type<double, T>(ncid_, varid, starts, counts, var_data);
+  } else if (xtype == NC_FLOAT) {
+      fill_from_ncvar_as_type<float, T>(ncid_, varid, starts, counts, var_data);
+  } else if (xtype == NC_INT) {
+      fill_from_ncvar_as_type<int, T>(ncid_, varid, starts, counts, var_data);
+  } else if (xtype == NC_INT64) {
+      // NOLINTNEXTLINE(runtime/int)
+      fill_from_ncvar_as_type<long long, T>(ncid_, varid, starts, counts, var_data);
+  } else {
+      std::ostringstream err_stream;
+      err_stream << "orcamodel::NemoFieldReader::read_var_slice ncVar '"
+                 << varname << "' reading type "
+                 << xtype << " not supported.";
+      throw eckit::BadValue(err_stream.str(), Here());
+  }
+
+  return var_data;
 }
 template std::vector<double> NemoFieldReader::read_var_slice(const std::string& varname,
       const size_t t_indx, const size_t z_indx) const;
@@ -426,61 +434,61 @@ template<typename T> std::vector<T> NemoFieldReader::read_vertical_var(
     const size_t nlevels) const {
   oops::Log::trace() << "orcamodel::NemoFieldReader::read_vertical_var"
                      << std::endl;
-  try {
-    size_t nz = read_dim_size(z_dimvar_name_);
+  size_t nz = read_dim_size(z_dimvar_name_);
 
-    if (nlevels > nz) {
-      std::ostringstream err_stream;
-      err_stream << "orcamodel::NemoFieldReader::read_vertical_var num levels "
-                 << "is larger than NetCDF file z dimension ";
-      throw eckit::BadValue(err_stream.str(), Here());
-    }
-
-    netCDF::NcVar nc_var = ncFile->getVar(varname);
-    if (nc_var.isNull()) {
-      std::ostringstream err_stream;
-      err_stream << "orcamodel::NemoFieldReader::read_vertical_var ncVar '"
-                 << varname << "' is not present in NetCDF file";
-      throw eckit::BadValue(err_stream.str(), Here());
-    }
-
-    size_t n_dims = nc_var.getDimCount();
-    std::string first_dim_name = nc_var.getDim(0).getName();
-    if (n_dims != 1 || first_dim_name != z_dimvar_name_) {
-      std::ostringstream err_stream;
-      err_stream << "orcamodel::NemoFieldReader::read_vertical_var ncVar '"
-                 << varname << "' has " << n_dims << " dimensions.";
-      throw eckit::BadValue(err_stream.str(), Here());
-    }
-
-    std::vector<T> buffer(nlevels);
-    std::vector<size_t> starts = {0, };
-    std::vector<size_t> counts = {nlevels, };
-    std::string nc_type_name = nc_var.getType().getName();
-    if (nc_type_name == "double") {
-        fill_from_ncvar_as_type<double, T>(nc_var, starts, counts, buffer);
-    } else if (nc_type_name == "float") {
-        fill_from_ncvar_as_type<float, T>(nc_var, starts, counts, buffer);
-    } else if (nc_type_name == "int") {
-        fill_from_ncvar_as_type<int, T>(nc_var, starts, counts, buffer);
-    } else if (nc_type_name == "int64") {
-        fill_from_ncvar_as_type<int64_t, T>(nc_var, starts, counts, buffer);
-    } else {
-        std::ostringstream err_stream;
-        err_stream << "orcamodel::NemoFieldReader::read_vertical_var ncVar '"
-                   << varname << "' reading type "
-                   << nc_var.getType().getName() << " not supported.";
-        throw eckit::BadValue(err_stream.str(), Here());
-    }
-
-    return buffer;
-  } catch(netCDF::exceptions::NcException& e)
-  {
+  if (nlevels > nz) {
     std::ostringstream err_stream;
-    err_stream << "orcamodel::NemoFieldReader::read_vertical_var varname: "
-               << varname << " NetCDF exception: " << std::endl << e.what();
-    throw eckit::ReadError(err_stream.str(), Here());
+    err_stream << "orcamodel::NemoFieldReader::read_vertical_var num levels "
+               << "is larger than NetCDF file z dimension ";
+    throw eckit::BadValue(err_stream.str(), Here());
   }
+
+  const int varid = get_varid_or_throw(ncid_, varname, "read_vertical_var");
+
+  int n_dims = 0;
+  nc_check(nc_inq_varndims(ncid_, varid, &n_dims),
+      "read_vertical_var ndims " + varname);
+  std::string first_dim_name;
+  if (n_dims == 1) {
+    int dimids[1] = {-1};
+    nc_check(nc_inq_vardimid(ncid_, varid, dimids),
+        "read_vertical_var vardimid " + varname);
+    char dim_name[NC_MAX_NAME + 1] = {0};
+    nc_check(nc_inq_dimname(ncid_, dimids[0], dim_name),
+        "read_vertical_var dimname " + varname);
+    first_dim_name = dim_name;
+  }
+  if (n_dims != 1 || first_dim_name != z_dimvar_name_) {
+    std::ostringstream err_stream;
+    err_stream << "orcamodel::NemoFieldReader::read_vertical_var ncVar '"
+               << varname << "' has " << n_dims << " dimensions.";
+    throw eckit::BadValue(err_stream.str(), Here());
+  }
+
+  std::vector<T> buffer(nlevels);
+  std::vector<size_t> starts = {0, };
+  std::vector<size_t> counts = {nlevels, };
+  nc_type xtype;
+  nc_check(nc_inq_vartype(ncid_, varid, &xtype),
+      "read_vertical_var type " + varname);
+  if (xtype == NC_DOUBLE) {
+      fill_from_ncvar_as_type<double, T>(ncid_, varid, starts, counts, buffer);
+  } else if (xtype == NC_FLOAT) {
+      fill_from_ncvar_as_type<float, T>(ncid_, varid, starts, counts, buffer);
+  } else if (xtype == NC_INT) {
+      fill_from_ncvar_as_type<int, T>(ncid_, varid, starts, counts, buffer);
+  } else if (xtype == NC_INT64) {
+      // NOLINTNEXTLINE(runtime/int)
+      fill_from_ncvar_as_type<long long, T>(ncid_, varid, starts, counts, buffer);
+  } else {
+      std::ostringstream err_stream;
+      err_stream << "orcamodel::NemoFieldReader::read_vertical_var ncVar '"
+                 << varname << "' reading type "
+                 << xtype << " not supported.";
+      throw eckit::BadValue(err_stream.str(), Here());
+  }
+
+  return buffer;
 }
 template std::vector<double> NemoFieldReader::read_vertical_var(
     const std::string& varname,

--- a/src/orca-jedi/nemo_io/NemoFieldReader.h
+++ b/src/orca-jedi/nemo_io/NemoFieldReader.h
@@ -5,10 +5,9 @@
 
 #pragma once
 
-#include <netcdf>
+#include <netcdf.h>
 
 #include <string>
-#include <memory>
 #include <vector>
 
 #include "eckit/filesystem/PathName.h"
@@ -25,6 +24,11 @@ class NemoFieldReader : private util::ObjectCounter<NemoFieldReader> {
   static const std::string classname() {return "orcamodel::NemoFieldReader";}
 
   explicit NemoFieldReader(const eckit::PathName& filename);
+  ~NemoFieldReader();
+  NemoFieldReader(NemoFieldReader&& other) noexcept;
+  NemoFieldReader& operator=(NemoFieldReader&& other) noexcept;
+  NemoFieldReader(const NemoFieldReader&) = delete;
+  NemoFieldReader& operator=(const NemoFieldReader&) = delete;
 
   void read_datetimes();
   std::vector<atlas::PointXY> read_locs() const;
@@ -37,8 +41,8 @@ class NemoFieldReader : private util::ObjectCounter<NemoFieldReader> {
       const size_t nlevels) const;
 
  private:
-  NemoFieldReader() : ncFile() {}
-  std::unique_ptr<netCDF::NcFile> ncFile;
+  NemoFieldReader() = default;
+  int ncid_ = -1;
   std::vector<util::DateTime> datetimes_;
   std::string time_dimvar_name_;
   std::string z_dimvar_name_;

--- a/src/orca-jedi/nemo_io/NemoFieldWriter.cc
+++ b/src/orca-jedi/nemo_io/NemoFieldWriter.cc
@@ -4,8 +4,7 @@
 
 #include "orca-jedi/nemo_io/NemoFieldWriter.h"
 
-// https://github.com/Unidata/netcdf-cxx4
-#include <netcdf>
+#include <netcdf.h>
 
 #include "orca-jedi/utilities/Types.h"
 
@@ -21,6 +20,43 @@
 
 namespace orcamodel {
 
+namespace {
+
+/// \brief Throw an eckit::FailedLibraryCall if a netcdf-c call failed.
+void nc_check(int status, const std::string& where) {
+  if (status != NC_NOERR) {
+    throw eckit::FailedLibraryCall("NetCDF",
+        "orcamodel::NemoFieldWriter", where + ": " + nc_strerror(status),
+        Here());
+  }
+}
+
+/// \brief Return true (and set varid) if a variable of the given name exists.
+bool nc_var_exists(int ncid, const std::string& name, int& varid) {
+  const int status = nc_inq_varid(ncid, name.c_str(), &varid);
+  if (status == NC_ENOTVAR) return false;
+  nc_check(status, "nc_inq_varid " + name);
+  return true;
+}
+
+/// \brief Look up a dimension id by name.
+int get_dimid(int ncid, const std::string& name) {
+  int dimid = -1;
+  nc_check(nc_inq_dimid(ncid, name.c_str(), &dimid), "nc_inq_dimid " + name);
+  return dimid;
+}
+
+// Overload set dispatching a hyperslab write to the correct typed netcdf-c call.
+inline int nc_put_vara_dispatch(int ncid, int varid, const size_t* start,
+    const size_t* count, const double* buf) {
+  return nc_put_vara_double(ncid, varid, start, count, buf);
+}
+inline int nc_put_vara_dispatch(int ncid, int varid, const size_t* start,
+    const size_t* count, const float* buf) {
+  return nc_put_vara_float(ncid, varid, start, count, buf);
+}
+}  // namespace
+
 NemoFieldWriter::NemoFieldWriter(const eckit::PathName& filename,
     const std::vector<util::DateTime>& datetimes,
     size_t nx, size_t ny,
@@ -34,128 +70,142 @@ NemoFieldWriter::NemoFieldWriter(const eckit::PathName& filename,
     , dimension_variables_present_(false) {
     bool new_file;
     if (!filename.exists()) {
-      ncFile = std::make_unique<netCDF::NcFile>(filename.fullName().asString(),
-          netCDF::NcFile::replace);
+      nc_check(nc_create(filename.fullName().asString().c_str(),
+          NC_NETCDF4 | NC_CLOBBER, &ncid_),
+          "NemoFieldWriter nc_create " + filename);
       new_file = true;
     } else {
-      ncFile = std::make_unique<netCDF::NcFile>(filename.fullName().asString(),
-          netCDF::NcFile::write);
+      nc_check(nc_open(filename.fullName().asString().c_str(),
+          NC_WRITE, &ncid_),
+          "NemoFieldWriter nc_open " + filename);
       new_file = false;
-    }
-    if (ncFile->isNull()) {
-        throw eckit::BadValue("orcamodel::NemoFieldWriter::NemoFieldWriter "
-            + filename + " not found or created");
     }
 
     if (new_file) {
       setup_dimensions();
     }
 
-    try {
-      auto navLatVar = ncFile->getVar("nav_lat");
-      auto navLonVar = ncFile->getVar("nav_lon");
-      auto tVar = ncFile->getVar("t");
-      auto zVar = ncFile->getVar("z");
-      if (navLatVar.isNull() || navLonVar.isNull() || tVar.isNull() || zVar.isNull()) {
-        dimension_variables_present_ = false;
-      } else {
-        dimension_variables_present_ = true;
-      }
-    }
-    catch (netCDF::exceptions::NcException& e) {
-        throw eckit::FailedLibraryCall("NetCDF",
-            "orcamodel::NemoFieldWriter::NemoFieldWriter", e.what(), Here());
-    }
+    int varid = -1;
+    dimension_variables_present_ =
+        nc_var_exists(ncid_, "nav_lat", varid) &&
+        nc_var_exists(ncid_, "nav_lon", varid) &&
+        nc_var_exists(ncid_, "t", varid) &&
+        nc_var_exists(ncid_, "z", varid);
 }
 
+NemoFieldWriter::~NemoFieldWriter() {
+  if (ncid_ >= 0) {
+    nc_close(ncid_);
+    ncid_ = -1;
+  }
+}
 
 void NemoFieldWriter::setup_dimensions() {
     oops::Log::trace() << "orcamodel::NemoFieldWriter::setup_dimensions" << std::endl;
-    auto nxDim = ncFile->addDim("x", nx_);
-    auto nyDim = ncFile->addDim("y", ny_);
-    auto nzDim = ncFile->addDim("z", nLevels_);
-    auto ntDim = ncFile->addDim("t", nTimes_);
+    int dimid = -1;
+    nc_check(nc_def_dim(ncid_, "x", nx_, &dimid), "setup_dimensions def x");
+    nc_check(nc_def_dim(ncid_, "y", ny_, &dimid), "setup_dimensions def y");
+    nc_check(nc_def_dim(ncid_, "z", nLevels_, &dimid), "setup_dimensions def z");
+    nc_check(nc_def_dim(ncid_, "t", nTimes_, &dimid), "setup_dimensions def t");
 }
 
 void NemoFieldWriter::write_dimensions(const std::vector<double>& lats,
                                        const std::vector<double>& lons) {
     oops::Log::trace() << "orcamodel::NemoFieldWriter::write_dimensions" << std::endl;
-    try {
-      auto nxDim = ncFile->getDim("x");
-      auto nyDim = ncFile->getDim("y");
-      auto nzDim = ncFile->getDim("z");
-      auto ntDim = ncFile->getDim("t");
 
-      if ((lons.size() != nx_*ny_) || (lats.size() != nx_*ny_)) {
-        throw eckit::BadValue(
-            std::string("orcamodel::NemoFieldWriter::write_dimensions")
-            + " dimensions sizes do not match lat/lon buffer sizes",
-          Here());
-      }
-      if (dimension_variables_present_) {
-         oops::Log::trace() << "orcamodel::NemoFieldWriter::write_dimensions "
-                            << "dimensions already present" << std::endl;
-         return;
-      }
-      auto navLatVar = ncFile->addVar("nav_lat", netCDF::ncDouble, {nyDim, nxDim});
-      auto navLonVar = ncFile->addVar("nav_lon", netCDF::ncDouble, {nyDim, nxDim});
-      navLonVar.putVar({0, 0}, {ny_, nx_}, lons.data());
-      navLatVar.putVar({0, 0}, {ny_, nx_}, lats.data());
-
-      auto timeVar = ncFile->addVar("t", netCDF::ncInt, {ntDim});
-      const std::string seconds_since = "seconds since ";
-      std::string units_string = "seconds since 1970-01-01 00:00:00";
-      timeVar.putAtt("units", units_string);
-
-      units_string.replace(seconds_since.size() + 10, 1, 1, 'T');
-      units_string.append("Z");
-      util::DateTime epoch = util::DateTime(
-          units_string.substr(seconds_since.size()));
-      for (size_t iTime = 0; iTime < nTimes_; ++iTime) {
-        int seconds_since_epoch = (datetimes_[iTime] - epoch).toSeconds();
-        timeVar.putVar({iTime}, seconds_since_epoch);
-      }
-
-      {
-        auto levVar = ncFile->addVar("z", netCDF::ncDouble, {nzDim});
-        std::vector<size_t> starts = {0};
-        std::vector<size_t> counts = {nLevels_};
-        levVar.putVar(starts, counts, depths_.data());
-      }
-
-      dimension_variables_present_ = true;
+    if ((lons.size() != nx_*ny_) || (lats.size() != nx_*ny_)) {
+      throw eckit::BadValue(
+          std::string("orcamodel::NemoFieldWriter::write_dimensions")
+          + " dimensions sizes do not match lat/lon buffer sizes",
+        Here());
     }
-    catch (netCDF::exceptions::NcException& e) {
-        throw eckit::FailedLibraryCall("NetCDF",
-            "orcamodel::NemoFieldWriter::write_dimensions", e.what(), Here());
+    if (dimension_variables_present_) {
+       oops::Log::trace() << "orcamodel::NemoFieldWriter::write_dimensions "
+                          << "dimensions already present" << std::endl;
+       return;
     }
+
+    const int nxDim = get_dimid(ncid_, "x");
+    const int nyDim = get_dimid(ncid_, "y");
+    const int nzDim = get_dimid(ncid_, "z");
+    const int ntDim = get_dimid(ncid_, "t");
+
+    const int latlon_dims[2] = {nyDim, nxDim};
+    int navLatVar = -1;
+    nc_check(nc_def_var(ncid_, "nav_lat", NC_DOUBLE, 2, latlon_dims, &navLatVar),
+        "write_dimensions def nav_lat");
+    int navLonVar = -1;
+    nc_check(nc_def_var(ncid_, "nav_lon", NC_DOUBLE, 2, latlon_dims, &navLonVar),
+        "write_dimensions def nav_lon");
+    {
+      const size_t starts[2] = {0, 0};
+      const size_t counts[2] = {ny_, nx_};
+      nc_check(nc_put_vara_double(ncid_, navLonVar, starts, counts, lons.data()),
+          "write_dimensions put nav_lon");
+      nc_check(nc_put_vara_double(ncid_, navLatVar, starts, counts, lats.data()),
+          "write_dimensions put nav_lat");
+    }
+
+    const int t_dims[1] = {ntDim};
+    int timeVar = -1;
+    nc_check(nc_def_var(ncid_, "t", NC_INT, 1, t_dims, &timeVar),
+        "write_dimensions def t");
+    const std::string seconds_since = "seconds since ";
+    std::string units_string = "seconds since 1970-01-01 00:00:00";
+    nc_check(nc_put_att_text(ncid_, timeVar, "units",
+        units_string.size(), units_string.c_str()),
+        "write_dimensions put t units");
+
+    units_string.replace(seconds_since.size() + 10, 1, 1, 'T');
+    units_string.append("Z");
+    util::DateTime epoch = util::DateTime(
+        units_string.substr(seconds_since.size()));
+    for (size_t iTime = 0; iTime < nTimes_; ++iTime) {
+      int seconds_since_epoch = (datetimes_[iTime] - epoch).toSeconds();
+      const size_t index[1] = {iTime};
+      nc_check(nc_put_var1_int(ncid_, timeVar, index, &seconds_since_epoch),
+          "write_dimensions put t");
+    }
+
+    {
+      const int z_dims[1] = {nzDim};
+      int levVar = -1;
+      nc_check(nc_def_var(ncid_, "z", NC_DOUBLE, 1, z_dims, &levVar),
+          "write_dimensions def z");
+      const size_t starts[1] = {0};
+      const size_t counts[1] = {nLevels_};
+      nc_check(nc_put_vara_double(ncid_, levVar, starts, counts, depths_.data()),
+          "write_dimensions put z");
+    }
+
+    dimension_variables_present_ = true;
 }
+
 template <typename T> void NemoFieldWriter::write_surf_var(std::string varname,
     const std::vector<T>& var_data, size_t iTime) {
     oops::Log::trace() << "orcamodel::NemoFieldWriter::write_surf_var" << std::endl;
-    try {
-        if (!dimension_variables_present_) {
-          throw eckit::BadValue(
-              std::string("orcamodel::NemoFieldWriter::write_surf_var")
-              + " can't write '" + varname + "' as the dimensions have not yet been constructed",
-            Here());
-        }
-
-        auto ncVar = ncFile->getVar(varname);
-        if (ncVar.isNull()) {
-          auto nxDim = ncFile->getDim("x");
-          auto nyDim = ncFile->getDim("y");
-          auto ntDim = ncFile->getDim("t");
-          ncVar = ncFile->addVar(varname, NetCDFTypeMap<T>::ncType, {ntDim, nyDim, nxDim});
-          ncVar.setFill(true, static_cast<T>(NemoFieldWriter::fillValue));
-        }
-
-        ncVar.putVar({iTime, 0, 0}, {1, ny_, nx_}, var_data.data());
+    if (!dimension_variables_present_) {
+      throw eckit::BadValue(
+          std::string("orcamodel::NemoFieldWriter::write_surf_var")
+          + " can't write '" + varname + "' as the dimensions have not yet been constructed",
+        Here());
     }
-    catch (netCDF::exceptions::NcException& e) {
-        throw eckit::FailedLibraryCall("NetCDF",
-            "orcamodel::NemoFieldWriter::write_surf_var", e.what(), Here());
+
+    int varid = -1;
+    if (!nc_var_exists(ncid_, varname, varid)) {
+      const int dims[3] = {get_dimid(ncid_, "t"), get_dimid(ncid_, "y"),
+                           get_dimid(ncid_, "x")};
+      nc_check(nc_def_var(ncid_, varname.c_str(), NetCDFTypeMap<T>::ncType,
+          3, dims, &varid), "write_surf_var def " + varname);
+      const T fill = static_cast<T>(NemoFieldWriter::fillValue);
+      nc_check(nc_def_var_fill(ncid_, varid, 0, &fill),
+          "write_surf_var fill " + varname);
     }
+
+    const size_t starts[3] = {iTime, 0, 0};
+    const size_t counts[3] = {1, ny_, nx_};
+    nc_check(nc_put_vara_dispatch(ncid_, varid, starts, counts, var_data.data()),
+        "write_surf_var put " + varname);
 }
 
 template void NemoFieldWriter::write_surf_var<double>(std::string varname,
@@ -166,31 +216,28 @@ template void NemoFieldWriter::write_surf_var<float>(std::string varname,
 template <typename T> void NemoFieldWriter::write_vol_var(std::string varname,
     const std::vector<T>& var_data, size_t iTime) {
     oops::Log::trace() << "orcamodel::NemoFieldWriter::write_vol_var" << std::endl;
-    try {
-        if (!dimension_variables_present_) {
-          throw eckit::BadValue(
-              std::string("orcamodel::NemoFieldWriter::write_vol_var")
-              + " can't write '" + varname + "' as the dimensions have not yet been constructed",
-            Here());
-        }
-
-        auto ncVar = ncFile->getVar(varname);
-        if (ncVar.isNull()) {
-          auto nxDim = ncFile->getDim("x");
-          auto nyDim = ncFile->getDim("y");
-          auto nzDim = ncFile->getDim("z");
-          auto ntDim = ncFile->getDim("t");
-          ncVar = ncFile->addVar(varname, NetCDFTypeMap<T>::ncType,
-              {ntDim, nzDim, nyDim, nxDim});
-          ncVar.setFill(true, static_cast<T>(NemoFieldWriter::fillValue));
-        }
-
-        ncVar.putVar({iTime, 0, 0, 0}, {1, nLevels_, ny_, nx_}, var_data.data());
+    if (!dimension_variables_present_) {
+      throw eckit::BadValue(
+          std::string("orcamodel::NemoFieldWriter::write_vol_var")
+          + " can't write '" + varname + "' as the dimensions have not yet been constructed",
+        Here());
     }
-    catch (netCDF::exceptions::NcException& e) {
-        throw eckit::FailedLibraryCall("NetCDF",
-            "orcamodel::NemoFieldWriter::write_vol_var", e.what(), Here());
+
+    int varid = -1;
+    if (!nc_var_exists(ncid_, varname, varid)) {
+      const int dims[4] = {get_dimid(ncid_, "t"), get_dimid(ncid_, "z"),
+                           get_dimid(ncid_, "y"), get_dimid(ncid_, "x")};
+      nc_check(nc_def_var(ncid_, varname.c_str(), NetCDFTypeMap<T>::ncType,
+          4, dims, &varid), "write_vol_var def " + varname);
+      const T fill = static_cast<T>(NemoFieldWriter::fillValue);
+      nc_check(nc_def_var_fill(ncid_, varid, 0, &fill),
+          "write_vol_var fill " + varname);
     }
+
+    const size_t starts[4] = {iTime, 0, 0, 0};
+    const size_t counts[4] = {1, nLevels_, ny_, nx_};
+    nc_check(nc_put_vara_dispatch(ncid_, varid, starts, counts, var_data.data()),
+        "write_vol_var put " + varname);
 }
 
 template void NemoFieldWriter::write_vol_var<double>(std::string varname,

--- a/src/orca-jedi/nemo_io/NemoFieldWriter.cc
+++ b/src/orca-jedi/nemo_io/NemoFieldWriter.cc
@@ -181,7 +181,7 @@ void NemoFieldWriter::write_dimensions(const std::vector<double>& lats,
     dimension_variables_present_ = true;
 }
 
-template <typename T> void NemoFieldWriter::write_surf_var(std::string varname,
+template <typename T> void NemoFieldWriter::write_surf_var(const std::string& varname,
     const std::vector<T>& var_data, size_t iTime) {
     oops::Log::trace() << "orcamodel::NemoFieldWriter::write_surf_var" << std::endl;
     if (!dimension_variables_present_) {
@@ -208,12 +208,12 @@ template <typename T> void NemoFieldWriter::write_surf_var(std::string varname,
         "write_surf_var put " + varname);
 }
 
-template void NemoFieldWriter::write_surf_var<double>(std::string varname,
+template void NemoFieldWriter::write_surf_var<double>(const std::string& varname,
     const std::vector<double>& var_data, size_t iTime);
-template void NemoFieldWriter::write_surf_var<float>(std::string varname,
+template void NemoFieldWriter::write_surf_var<float>(const std::string& varname,
     const std::vector<float>& var_data, size_t iTime);
 
-template <typename T> void NemoFieldWriter::write_vol_var(std::string varname,
+template <typename T> void NemoFieldWriter::write_vol_var(const std::string& varname,
     const std::vector<T>& var_data, size_t iTime) {
     oops::Log::trace() << "orcamodel::NemoFieldWriter::write_vol_var" << std::endl;
     if (!dimension_variables_present_) {
@@ -240,8 +240,8 @@ template <typename T> void NemoFieldWriter::write_vol_var(std::string varname,
         "write_vol_var put " + varname);
 }
 
-template void NemoFieldWriter::write_vol_var<double>(std::string varname,
+template void NemoFieldWriter::write_vol_var<double>(const std::string& varname,
     const std::vector<double>& var_data, size_t iTime);
-template void NemoFieldWriter::write_vol_var<float>(std::string varname,
+template void NemoFieldWriter::write_vol_var<float>(const std::string& varname,
     const std::vector<float>& var_data, size_t iTime);
 }  // namespace orcamodel

--- a/src/orca-jedi/nemo_io/NemoFieldWriter.h
+++ b/src/orca-jedi/nemo_io/NemoFieldWriter.h
@@ -5,9 +5,8 @@
 
 #pragma once
 
-#include <netcdf>
+#include <netcdf.h>
 
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -26,6 +25,9 @@ class NemoFieldWriter {
                     const std::vector<util::DateTime>& datetimes,
                     size_t nx, size_t ny,
                     const std::vector<double>& depths);
+    ~NemoFieldWriter();
+    NemoFieldWriter(const NemoFieldWriter&) = delete;
+    NemoFieldWriter& operator=(const NemoFieldWriter&) = delete;
     void write_dimensions(const std::vector<double>& lats,
                           const std::vector<double>& lons);
     template <typename T> void write_surf_var(std::string varname,
@@ -35,8 +37,8 @@ class NemoFieldWriter {
 
  private:
     void setup_dimensions();
-    NemoFieldWriter(): ncFile() {}
-    std::unique_ptr<netCDF::NcFile> ncFile = nullptr;
+    NemoFieldWriter() = default;
+    int ncid_ = -1;
     std::vector<util::DateTime> datetimes_;
     std::vector<double> depths_;
     size_t nLevels_{1};

--- a/src/orca-jedi/nemo_io/NemoFieldWriter.h
+++ b/src/orca-jedi/nemo_io/NemoFieldWriter.h
@@ -30,9 +30,9 @@ class NemoFieldWriter {
     NemoFieldWriter& operator=(const NemoFieldWriter&) = delete;
     void write_dimensions(const std::vector<double>& lats,
                           const std::vector<double>& lons);
-    template <typename T> void write_surf_var(std::string varname,
+    template <typename T> void write_surf_var(const std::string& varname,
         const std::vector<T>& var_data, size_t iTime);
-    template <typename T> void write_vol_var(std::string varname,
+    template <typename T> void write_vol_var(const std::string& varname,
         const std::vector<T>& var_data, size_t iTime);
 
  private:

--- a/src/orca-jedi/nemo_io/ParallelNetCDFBackend.cc
+++ b/src/orca-jedi/nemo_io/ParallelNetCDFBackend.cc
@@ -1,0 +1,289 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#include "orca-jedi/nemo_io/ParallelNetCDFBackend.h"
+
+#include <mpi.h>
+#include <netcdf.h>
+#include <netcdf_par.h>
+
+#include <string>
+#include <vector>
+
+#include "eckit/exception/Exceptions.h"
+
+#include "oops/util/DateTime.h"
+#include "oops/util/Duration.h"
+#include "oops/util/Logger.h"
+
+#include "orca-jedi/nemo_io/NemoFieldWriter.h"
+
+namespace orcamodel {
+
+namespace {
+
+/// \brief Throw an eckit exception if a netCDF C call did not succeed.
+void nc_check(int status, const std::string& where) {
+  if (status != NC_NOERR) {
+    throw eckit::FailedLibraryCall("NetCDF", where, nc_strerror(status), Here());
+  }
+}
+
+/// \brief Enable filling with NemoFieldWriter::fillValue for a just-defined
+///        variable (must be called in define mode).
+void set_fill(int ncid, int varid, int nc_type) {
+  if (nc_type == NC_DOUBLE) {
+    double fv = static_cast<double>(NemoFieldWriter::fillValue);
+    nc_check(nc_def_var_fill(ncid, varid, 0, &fv),
+             "ParallelNetCDFWriteBackend::set_fill(double)");
+  } else {
+    float fv = static_cast<float>(NemoFieldWriter::fillValue);
+    nc_check(nc_def_var_fill(ncid, varid, 0, &fv),
+             "ParallelNetCDFWriteBackend::set_fill(float)");
+  }
+}
+
+}  // namespace
+
+ParallelNetCDFWriteBackend::ParallelNetCDFWriteBackend(
+    const eckit::mpi::Comm& io_comm, const eckit::PathName& path,
+    size_t nx, size_t ny,
+    const std::vector<util::DateTime>& datetimes,
+    const std::vector<double>& depths)
+    : nx_(nx), ny_(ny), n_levels_(depths.size()), n_times_(datetimes.size()) {
+  oops::Log::trace() << "orcamodel::ParallelNetCDFWriteBackend::ctor "
+                     << path.fullName().asString() << std::endl;
+
+  // eckit hands out the communicator as a Fortran handle; translate to the C
+  // MPI_Comm required by nc_create_par.
+  MPI_Comm comm = MPI_Comm_f2c(io_comm.communicator());
+
+  // MPI_Info could carry filesystem striping / collective-buffering hints; the
+  // collective HDF5 layer already aggregates writes, so start unhinted.
+  nc_check(nc_create_par(path.fullName().asString().c_str(),
+                         NC_NETCDF4 | NC_CLOBBER, comm, MPI_INFO_NULL, &ncid_),
+           "ParallelNetCDFWriteBackend::nc_create_par");
+
+  // Dimensions, matching NemoFieldWriter::setup_dimensions.
+  nc_check(nc_def_dim(ncid_, "x", nx_, &dim_x_), "nc_def_dim x");
+  nc_check(nc_def_dim(ncid_, "y", ny_, &dim_y_), "nc_def_dim y");
+  nc_check(nc_def_dim(ncid_, "z", n_levels_, &dim_z_), "nc_def_dim z");
+  nc_check(nc_def_dim(ncid_, "t", n_times_, &dim_t_), "nc_def_dim t");
+
+  // Coordinate variables (defined now, values written later / below).
+  int lat_dims[2] = {dim_y_, dim_x_};
+  int lon_dims[2] = {dim_y_, dim_x_};
+  int nav_lat_id, nav_lon_id, t_id, z_id;
+  nc_check(nc_def_var(ncid_, "nav_lat", NC_DOUBLE, 2, lat_dims, &nav_lat_id),
+           "nc_def_var nav_lat");
+  nc_check(nc_def_var(ncid_, "nav_lon", NC_DOUBLE, 2, lon_dims, &nav_lon_id),
+           "nc_def_var nav_lon");
+  nc_check(nc_def_var(ncid_, "t", NC_INT, 1, &dim_t_, &t_id), "nc_def_var t");
+  nc_check(nc_def_var(ncid_, "z", NC_DOUBLE, 1, &dim_z_, &z_id), "nc_def_var z");
+
+  // Time units attribute (identical string/format to NemoFieldWriter).
+  const std::string seconds_since = "seconds since ";
+  std::string units_string = "seconds since 1970-01-01 00:00:00";
+  nc_check(nc_put_att_text(ncid_, t_id, "units", units_string.size(),
+                           units_string.c_str()),
+           "nc_put_att_text t units");
+
+  nc_check(nc_enddef(ncid_), "ParallelNetCDFWriteBackend::nc_enddef");
+
+  // Small 1-D coordinate variables carry the same data on every rank, so write
+  // them independently from the pool root only.
+  nc_check(nc_var_par_access(ncid_, t_id, NC_INDEPENDENT), "par_access t");
+  nc_check(nc_var_par_access(ncid_, z_id, NC_INDEPENDENT), "par_access z");
+  nc_check(nc_var_par_access(ncid_, nav_lat_id, NC_COLLECTIVE), "par_access nav_lat");
+  nc_check(nc_var_par_access(ncid_, nav_lon_id, NC_COLLECTIVE), "par_access nav_lon");
+
+  if (io_comm.rank() == 0) {
+    units_string.replace(seconds_since.size() + 10, 1, 1, 'T');
+    units_string.append("Z");
+    util::DateTime epoch(units_string.substr(seconds_since.size()));
+    std::vector<int> t_values(n_times_);
+    for (size_t iTime = 0; iTime < n_times_; ++iTime) {
+      t_values[iTime] = (datetimes[iTime] - epoch).toSeconds();
+    }
+    nc_check(nc_put_var_int(ncid_, t_id, t_values.data()), "nc_put_var t");
+    nc_check(nc_put_var_double(ncid_, z_id, depths.data()), "nc_put_var z");
+  }
+}
+
+ParallelNetCDFWriteBackend::~ParallelNetCDFWriteBackend() {
+  if (ncid_ >= 0) {
+    // Close is collective; ignore the status in the destructor.
+    nc_close(ncid_);
+  }
+}
+
+int ParallelNetCDFWriteBackend::ensure_surf_var(const std::string& var_name,
+                                                int nc_type) {
+  int varid = -1;
+  int status = nc_inq_varid(ncid_, var_name.c_str(), &varid);
+  if (status == NC_NOERR) return varid;
+  if (status != NC_ENOTVAR) {
+    nc_check(status, "ensure_surf_var inq " + var_name);
+  }
+  int dims[3] = {dim_t_, dim_y_, dim_x_};
+  nc_check(nc_redef(ncid_), "ensure_surf_var redef " + var_name);
+  nc_check(nc_def_var(ncid_, var_name.c_str(), nc_type, 3, dims, &varid),
+           "ensure_surf_var def " + var_name);
+  set_fill(ncid_, varid, nc_type);
+  nc_check(nc_enddef(ncid_), "ensure_surf_var enddef " + var_name);
+  nc_check(nc_var_par_access(ncid_, varid, NC_COLLECTIVE),
+           "ensure_surf_var par_access " + var_name);
+  return varid;
+}
+
+int ParallelNetCDFWriteBackend::ensure_vol_var(const std::string& var_name,
+                                               int nc_type) {
+  int varid = -1;
+  int status = nc_inq_varid(ncid_, var_name.c_str(), &varid);
+  if (status == NC_NOERR) return varid;
+  if (status != NC_ENOTVAR) {
+    nc_check(status, "ensure_vol_var inq " + var_name);
+  }
+  int dims[4] = {dim_t_, dim_z_, dim_y_, dim_x_};
+  nc_check(nc_redef(ncid_), "ensure_vol_var redef " + var_name);
+  nc_check(nc_def_var(ncid_, var_name.c_str(), nc_type, 4, dims, &varid),
+           "ensure_vol_var def " + var_name);
+  set_fill(ncid_, varid, nc_type);
+  nc_check(nc_enddef(ncid_), "ensure_vol_var enddef " + var_name);
+  nc_check(nc_var_par_access(ncid_, varid, NC_COLLECTIVE),
+           "ensure_vol_var par_access " + var_name);
+  return varid;
+}
+
+void ParallelNetCDFWriteBackend::write_dimensions(
+    const Hyperslab& slab, const std::vector<double>& lat_band,
+    const std::vector<double>& lon_band) {
+  oops::Log::trace() << "orcamodel::ParallelNetCDFWriteBackend::write_dimensions"
+                     << std::endl;
+  int nav_lat_id, nav_lon_id;
+  nc_check(nc_inq_varid(ncid_, "nav_lat", &nav_lat_id), "inq nav_lat");
+  nc_check(nc_inq_varid(ncid_, "nav_lon", &nav_lon_id), "inq nav_lon");
+
+  size_t start[2] = {slab.j_begin, 0};
+  size_t count[2] = {slab.j_count, nx_};
+  nc_check(nc_put_vara_double(ncid_, nav_lat_id, start, count, lat_band.data()),
+           "nc_put_vara nav_lat");
+  nc_check(nc_put_vara_double(ncid_, nav_lon_id, start, count, lon_band.data()),
+           "nc_put_vara nav_lon");
+}
+
+void ParallelNetCDFWriteBackend::write_surf_slab(const std::string& var_name,
+    size_t t_index, const Hyperslab& slab, const std::vector<double>& data) {
+  const int varid = ensure_surf_var(var_name, NC_DOUBLE);
+  size_t start[3] = {t_index, slab.j_begin, 0};
+  size_t count[3] = {1, slab.j_count, nx_};
+  nc_check(nc_put_vara_double(ncid_, varid, start, count, data.data()),
+           "write_surf_slab(double) " + var_name);
+}
+
+void ParallelNetCDFWriteBackend::write_surf_slab(const std::string& var_name,
+    size_t t_index, const Hyperslab& slab, const std::vector<float>& data) {
+  const int varid = ensure_surf_var(var_name, NC_FLOAT);
+  size_t start[3] = {t_index, slab.j_begin, 0};
+  size_t count[3] = {1, slab.j_count, nx_};
+  nc_check(nc_put_vara_float(ncid_, varid, start, count, data.data()),
+           "write_surf_slab(float) " + var_name);
+}
+
+void ParallelNetCDFWriteBackend::write_vol_slab(const std::string& var_name,
+    size_t t_index, size_t z_begin, size_t z_count, const Hyperslab& slab,
+    const std::vector<double>& data) {
+  const int varid = ensure_vol_var(var_name, NC_DOUBLE);
+  size_t start[4] = {t_index, z_begin, slab.j_begin, 0};
+  size_t count[4] = {1, z_count, slab.j_count, nx_};
+  nc_check(nc_put_vara_double(ncid_, varid, start, count, data.data()),
+           "write_vol_slab(double) " + var_name);
+}
+
+void ParallelNetCDFWriteBackend::write_vol_slab(const std::string& var_name,
+    size_t t_index, size_t z_begin, size_t z_count, const Hyperslab& slab,
+    const std::vector<float>& data) {
+  const int varid = ensure_vol_var(var_name, NC_FLOAT);
+  size_t start[4] = {t_index, z_begin, slab.j_begin, 0};
+  size_t count[4] = {1, z_count, slab.j_count, nx_};
+  nc_check(nc_put_vara_float(ncid_, varid, start, count, data.data()),
+           "write_vol_slab(float) " + var_name);
+}
+
+// -----------------------------------------------------------------------------
+// Read backend.
+// -----------------------------------------------------------------------------
+
+ParallelNetCDFReadBackend::ParallelNetCDFReadBackend(
+    const eckit::mpi::Comm& io_comm, const eckit::PathName& path) {
+  oops::Log::trace() << "orcamodel::ParallelNetCDFReadBackend::ctor "
+                     << path.fullName().asString() << std::endl;
+  MPI_Comm comm = MPI_Comm_f2c(io_comm.communicator());
+  nc_check(nc_open_par(path.fullName().asString().c_str(), NC_NOWRITE,
+                       comm, MPI_INFO_NULL, &ncid_),
+           "ParallelNetCDFReadBackend::nc_open_par");
+}
+
+ParallelNetCDFReadBackend::~ParallelNetCDFReadBackend() {
+  if (ncid_ >= 0) {
+    nc_close(ncid_);
+  }
+}
+
+namespace {
+
+/// \brief Resolve the varid, set collective access and compute the netCDF
+///        start/count for a single (t, z) horizontal slice of \p slab. Handles
+///        both surface {t, y, x} and volume {t, z, y, x} variables.
+int read_slab_setup(int ncid, const std::string& var_name, size_t t_index,
+                    size_t z_index, const Hyperslab& slab,
+                    size_t start[4], size_t count[4], int& ndims) {
+  int varid = -1;
+  nc_check(nc_inq_varid(ncid, var_name.c_str(), &varid),
+           "ParallelNetCDFReadBackend inq_varid " + var_name);
+  nc_check(nc_inq_varndims(ncid, varid, &ndims),
+           "ParallelNetCDFReadBackend inq_varndims " + var_name);
+  nc_check(nc_var_par_access(ncid, varid, NC_COLLECTIVE),
+           "ParallelNetCDFReadBackend par_access " + var_name);
+  if (ndims == 3) {
+    start[0] = t_index; start[1] = slab.j_begin; start[2] = 0;
+    count[0] = 1;       count[1] = slab.j_count; count[2] = slab.nx;
+  } else if (ndims == 4) {
+    start[0] = t_index; start[1] = z_index; start[2] = slab.j_begin; start[3] = 0;
+    count[0] = 1;       count[1] = 1;       count[2] = slab.j_count; count[3] = slab.nx;
+  } else {
+    throw eckit::FailedLibraryCall("NetCDF",
+        "ParallelNetCDFReadBackend::read_slab",
+        "variable '" + var_name + "' has unsupported rank", Here());
+  }
+  return varid;
+}
+
+}  // namespace
+
+void ParallelNetCDFReadBackend::read_slab(const std::string& var_name,
+    size_t t_index, size_t z_index, const Hyperslab& slab,
+    std::vector<double>& data) {
+  data.resize(slab.size());
+  size_t start[4], count[4];
+  int ndims = 0;
+  const int varid = read_slab_setup(ncid_, var_name, t_index, z_index, slab,
+                                    start, count, ndims);
+  nc_check(nc_get_vara_double(ncid_, varid, start, count, data.data()),
+           "read_slab(double) " + var_name);
+}
+
+void ParallelNetCDFReadBackend::read_slab(const std::string& var_name,
+    size_t t_index, size_t z_index, const Hyperslab& slab,
+    std::vector<float>& data) {
+  data.resize(slab.size());
+  size_t start[4], count[4];
+  int ndims = 0;
+  const int varid = read_slab_setup(ncid_, var_name, t_index, z_index, slab,
+                                    start, count, ndims);
+  nc_check(nc_get_vara_float(ncid_, varid, start, count, data.data()),
+           "read_slab(float) " + var_name);
+}
+
+}  // namespace orcamodel

--- a/src/orca-jedi/nemo_io/ParallelNetCDFBackend.cc
+++ b/src/orca-jedi/nemo_io/ParallelNetCDFBackend.cc
@@ -8,6 +8,7 @@
 #include <netcdf.h>
 #include <netcdf_par.h>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -51,9 +52,20 @@ ParallelNetCDFWriteBackend::ParallelNetCDFWriteBackend(
     size_t nx, size_t ny,
     const std::vector<util::DateTime>& datetimes,
     const std::vector<double>& depths)
-    : nx_(nx), ny_(ny), n_levels_(depths.size()), n_times_(datetimes.size()) {
+    : nx_(nx), ny_(ny), n_levels_(depths.size()), n_times_(datetimes.size()),
+      n_io_ranks_(io_comm.size()) {
   oops::Log::trace() << "orcamodel::ParallelNetCDFWriteBackend::ctor "
                      << path.fullName().asString() << std::endl;
+
+  // Pick the chunk y-extent to match the y-band decomposition: the number of
+  // I/O ranks is clamped to at most ny (a rank cannot own less than one row),
+  // and the tallest band is ceil(ny / ranks). Choosing that as the chunk height
+  // means each "fat" rank writes exactly one whole chunk row per (t, z) slice,
+  // giving contiguous, non-overlapping collective writes that map cleanly onto
+  // Lustre stripes. Rows never split, so chunks always span the full x extent.
+  const size_t p_eff = std::max<size_t>(1,
+      std::min(n_io_ranks_, ny_ == 0 ? size_t{1} : ny_));
+  chunk_y_ = std::max<size_t>(1, (ny_ + p_eff - 1) / p_eff);
 
   // eckit hands out the communicator as a Fortran handle; translate to the C
   // MPI_Comm required by nc_create_par.
@@ -82,6 +94,13 @@ ParallelNetCDFWriteBackend::ParallelNetCDFWriteBackend(
   nc_check(nc_def_var(ncid_, "t", NC_INT, 1, &dim_t_, &t_id), "nc_def_var t");
   nc_check(nc_def_var(ncid_, "z", NC_DOUBLE, 1, &dim_z_, &z_id), "nc_def_var z");
 
+  // Chunk the 2-D coordinate fields on the same y-band as the data variables.
+  size_t coord_chunk[2] = {chunk_y_, nx_};
+  nc_check(nc_def_var_chunking(ncid_, nav_lat_id, NC_CHUNKED, coord_chunk),
+           "nc_def_var_chunking nav_lat");
+  nc_check(nc_def_var_chunking(ncid_, nav_lon_id, NC_CHUNKED, coord_chunk),
+           "nc_def_var_chunking nav_lon");
+
   // Time units attribute (identical string/format to NemoFieldWriter).
   const std::string seconds_since = "seconds since ";
   std::string units_string = "seconds since 1970-01-01 00:00:00";
@@ -108,6 +127,28 @@ ParallelNetCDFWriteBackend::ParallelNetCDFWriteBackend(
     }
     nc_check(nc_put_var_int(ncid_, t_id, t_values.data()), "nc_put_var t");
     nc_check(nc_put_var_double(ncid_, z_id, depths.data()), "nc_put_var z");
+
+    // Report the chunk geometry so it can be matched to Lustre striping. The
+    // horizontal footprint (chunk_y * nx) is identical for surface and volume
+    // variables because volume levels are written one at a time (z chunk = 1).
+    const size_t chunk_elems = chunk_y_ * nx_;
+    const size_t f64_bytes = chunk_elems * sizeof(double);
+    const size_t f32_bytes = chunk_elems * sizeof(float);
+    // Lustre stripe size must be a multiple of 64 KiB; round the f64 chunk up
+    // to the next whole MiB for a safe, ready-to-use suggestion.
+    const size_t stripe_mib = (f64_bytes + (size_t{1} << 20) - 1) >> 20;
+    oops::Log::info()
+        << "orcamodel::ParallelNetCDFWriteBackend: parallel output chunking\n"
+        << "  output file        : " << path.fullName().asString() << "\n"
+        << "  I/O ranks          : " << n_io_ranks_ << "\n"
+        << "  global grid (ny,nx): (" << ny_ << ", " << nx_ << ")\n"
+        << "  surface chunk shape: {t=1, y=" << chunk_y_ << ", x=" << nx_ << "}\n"
+        << "  volume chunk shape : {t=1, z=1, y=" << chunk_y_ << ", x=" << nx_
+        << "}\n"
+        << "  chunk footprint    : " << chunk_elems << " elements = "
+        << f64_bytes << " B (f64) / " << f32_bytes << " B (f32)\n"
+        << "  suggested striping : lfs setstripe -c " << n_io_ranks_
+        << " -S " << stripe_mib << "M <output-dir>" << std::endl;
   }
 }
 
@@ -130,6 +171,9 @@ int ParallelNetCDFWriteBackend::ensure_surf_var(const std::string& var_name,
   nc_check(nc_redef(ncid_), "ensure_surf_var redef " + var_name);
   nc_check(nc_def_var(ncid_, var_name.c_str(), nc_type, 3, dims, &varid),
            "ensure_surf_var def " + var_name);
+  size_t chunk[3] = {1, chunk_y_, nx_};
+  nc_check(nc_def_var_chunking(ncid_, varid, NC_CHUNKED, chunk),
+           "ensure_surf_var chunking " + var_name);
   set_fill(ncid_, varid, nc_type);
   nc_check(nc_enddef(ncid_), "ensure_surf_var enddef " + var_name);
   nc_check(nc_var_par_access(ncid_, varid, NC_COLLECTIVE),
@@ -149,6 +193,9 @@ int ParallelNetCDFWriteBackend::ensure_vol_var(const std::string& var_name,
   nc_check(nc_redef(ncid_), "ensure_vol_var redef " + var_name);
   nc_check(nc_def_var(ncid_, var_name.c_str(), nc_type, 4, dims, &varid),
            "ensure_vol_var def " + var_name);
+  size_t chunk[4] = {1, 1, chunk_y_, nx_};
+  nc_check(nc_def_var_chunking(ncid_, varid, NC_CHUNKED, chunk),
+           "ensure_vol_var chunking " + var_name);
   set_fill(ncid_, varid, nc_type);
   nc_check(nc_enddef(ncid_), "ensure_vol_var enddef " + var_name);
   nc_check(nc_var_par_access(ncid_, varid, NC_COLLECTIVE),

--- a/src/orca-jedi/nemo_io/ParallelNetCDFBackend.cc
+++ b/src/orca-jedi/nemo_io/ParallelNetCDFBackend.cc
@@ -9,6 +9,8 @@
 #include <netcdf_par.h>
 
 #include <algorithm>
+#include <cstdlib>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -53,7 +55,7 @@ ParallelNetCDFWriteBackend::ParallelNetCDFWriteBackend(
     const std::vector<util::DateTime>& datetimes,
     const std::vector<double>& depths)
     : nx_(nx), ny_(ny), n_levels_(depths.size()), n_times_(datetimes.size()),
-      n_io_ranks_(io_comm.size()) {
+      n_io_ranks_(io_comm.size()), io_comm_(&io_comm), path_(path) {
   oops::Log::trace() << "orcamodel::ParallelNetCDFWriteBackend::ctor "
                      << path.fullName().asString() << std::endl;
 
@@ -71,11 +73,48 @@ ParallelNetCDFWriteBackend::ParallelNetCDFWriteBackend(
   // MPI_Comm required by nc_create_par.
   MPI_Comm comm = MPI_Comm_f2c(io_comm.communicator());
 
-  // MPI_Info could carry filesystem striping / collective-buffering hints; the
-  // collective HDF5 layer already aggregates writes, so start unhinted.
-  nc_check(nc_create_par(path.fullName().asString().c_str(),
-                         NC_NETCDF4 | NC_CLOBBER, comm, MPI_INFO_NULL, &ncid_),
-           "ParallelNetCDFWriteBackend::nc_create_par");
+  // Horizontal footprint of one collective write (one whole y-band row for a
+  // single (t, z) slice). Shared by the Lustre hints below and the striping
+  // suggestion logged from rank 0. Volume levels are written one at a time
+  // (z chunk = 1) so surface and volume writes have the same footprint.
+  const size_t chunk_elems = chunk_y_ * nx_;
+  const size_t f64_bytes = chunk_elems * sizeof(double);
+  const size_t f32_bytes = chunk_elems * sizeof(float);
+  // Lustre stripe unit must be a multiple of 64 KiB; round the f64 chunk
+  // footprint up to the next whole MiB so each rank's slab lands on one stripe.
+  const size_t stripe_bytes =
+      ((f64_bytes + (size_t{1} << 20) - 1) >> 20) << 20;
+  const size_t stripe_mib = stripe_bytes >> 20;
+  requested_stripe_bytes_ = stripe_bytes;
+
+  // Give the collective-I/O layer explicit Lustre and collective-buffering
+  // hints. Without these the aggregator layer does not align its writes to the
+  // OST stripe geometry, so an `lfs setstripe` on the output directory has
+  // little or no effect. The keys below are chosen to work under BOTH MPI-IO
+  // backends we may build against:
+  //   * striping_factor / striping_unit / cb_nodes / cb_buffer_size are honoured
+  //     by both OpenMPI's OMPIO (fs/lustre component) and MPICH/ROMIO's Lustre
+  //     ADIO driver - they set the file's stripe layout and the two-phase
+  //     aggregation geometry.
+  //   * romio_cb_write / romio_ds_write are ROMIO-specific (force collective
+  //     buffering on, data sieving off); OMPIO simply ignores them.
+  // Any key an implementation does not recognise is silently dropped, so the
+  // combined set is always safe. cb_nodes = number of I/O ranks and
+  // cb_buffer_size = one stripe make each I/O rank aggregate exactly one stripe.
+  MPI_Info info = MPI_INFO_NULL;
+  MPI_Info_create(&info);
+  MPI_Info_set(info, "striping_factor", std::to_string(n_io_ranks_).c_str());
+  MPI_Info_set(info, "striping_unit", std::to_string(stripe_bytes).c_str());
+  MPI_Info_set(info, "cb_nodes", std::to_string(n_io_ranks_).c_str());
+  MPI_Info_set(info, "cb_buffer_size", std::to_string(stripe_bytes).c_str());
+  MPI_Info_set(info, "romio_cb_write", "enable");
+  MPI_Info_set(info, "romio_ds_write", "disable");
+
+  const int create_status = nc_create_par(path.fullName().asString().c_str(),
+                                          NC_NETCDF4 | NC_CLOBBER, comm, info,
+                                          &ncid_);
+  MPI_Info_free(&info);
+  nc_check(create_status, "ParallelNetCDFWriteBackend::nc_create_par");
 
   // Dimensions, matching NemoFieldWriter::setup_dimensions.
   nc_check(nc_def_dim(ncid_, "x", nx_, &dim_x_), "nc_def_dim x");
@@ -128,15 +167,11 @@ ParallelNetCDFWriteBackend::ParallelNetCDFWriteBackend(
     nc_check(nc_put_var_int(ncid_, t_id, t_values.data()), "nc_put_var t");
     nc_check(nc_put_var_double(ncid_, z_id, depths.data()), "nc_put_var z");
 
-    // Report the chunk geometry so it can be matched to Lustre striping. The
-    // horizontal footprint (chunk_y * nx) is identical for surface and volume
-    // variables because volume levels are written one at a time (z chunk = 1).
-    const size_t chunk_elems = chunk_y_ * nx_;
-    const size_t f64_bytes = chunk_elems * sizeof(double);
-    const size_t f32_bytes = chunk_elems * sizeof(float);
-    // Lustre stripe size must be a multiple of 64 KiB; round the f64 chunk up
-    // to the next whole MiB for a safe, ready-to-use suggestion.
-    const size_t stripe_mib = (f64_bytes + (size_t{1} << 20) - 1) >> 20;
+    // Report the chunk geometry (computed above) so it can be matched to
+    // Lustre striping, plus the MPI-IO hints actually requested at file
+    // creation. The horizontal footprint (chunk_y * nx) is identical for
+    // surface and volume variables because volume levels are written one at a
+    // time (z chunk = 1).
     oops::Log::info()
         << "orcamodel::ParallelNetCDFWriteBackend: parallel output chunking\n"
         << "  output file        : " << path.fullName().asString() << "\n"
@@ -145,6 +180,10 @@ ParallelNetCDFWriteBackend::ParallelNetCDFWriteBackend(
         << "  surface chunk shape: {t=1, y=" << chunk_y_ << ", x=" << nx_ << "}\n"
         << "  volume chunk shape : {t=1, z=1, y=" << chunk_y_ << ", x=" << nx_
         << "}\n"
+        << "  MPI-IO hints set   : striping_factor=" << n_io_ranks_
+        << ", striping_unit=" << stripe_bytes << " B (" << stripe_mib
+        << "M), cb_nodes=" << n_io_ranks_ << ", cb_buffer_size=" << stripe_bytes
+        << " B, romio_cb_write=enable, romio_ds_write=disable\n"
         << "  chunk footprint    : " << chunk_elems << " elements = "
         << f64_bytes << " B (f64) / " << f32_bytes << " B (f32)\n"
         << "  suggested striping : lfs setstripe -c " << n_io_ranks_
@@ -157,6 +196,64 @@ ParallelNetCDFWriteBackend::~ParallelNetCDFWriteBackend() {
     // Close is collective; ignore the status in the destructor.
     nc_close(ncid_);
   }
+  // The file is now flushed and closed, so its final on-disk layout is fixed:
+  // reopen it read-only and report the hints the MPI-IO layer actually used.
+  report_effective_hints();
+}
+
+void ParallelNetCDFWriteBackend::report_effective_hints() {
+  if (io_comm_ == nullptr || ncid_ < 0) return;
+
+  // Reopening the file is a (small) collective cost, so only pay it when
+  // tracing/debugging is requested - mirroring the other opt-in diagnostics.
+  // OOPS_TRACE / OOPS_DEBUG are process-wide environment variables with the
+  // same value on every rank, so this gate keeps the collective MPI_File_open
+  // below perfectly balanced. "0" / empty count as off.
+  const auto env_on = [](const char* name) {
+    const char* v = ::getenv(name);
+    return v != nullptr && v[0] != '\0' && std::string(v) != "0";
+  };
+  if (!env_on("OOPS_TRACE") && !env_on("OOPS_DEBUG")) return;
+
+  // MPI_File_open is collective on the I/O communicator; every I/O rank reaches
+  // this destructor in lockstep (same as the collective nc_close above). Open
+  // read-only purely to interrogate the hints - no data is read.
+  MPI_Comm comm = MPI_Comm_f2c(io_comm_->communicator());
+  MPI_File fh = MPI_FILE_NULL;
+  const int open_status =
+      MPI_File_open(comm, path_.fullName().asString().c_str(),
+                    MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
+  if (open_status != MPI_SUCCESS) return;  // never throw from a destructor
+
+  MPI_Info used = MPI_INFO_NULL;
+  MPI_File_get_info(fh, &used);
+
+  if (io_comm_->rank() == 0 && used != MPI_INFO_NULL) {
+    int nkeys = 0;
+    MPI_Info_get_nkeys(used, &nkeys);
+    std::ostringstream oss;
+    oss << "orcamodel::ParallelNetCDFWriteBackend: effective MPI-IO hints for "
+        << path_.fullName().asString() << "\n"
+        << "  requested          : striping_factor=" << n_io_ranks_
+        << ", striping_unit=" << requested_stripe_bytes_ << " B\n"
+        << "  effective (" << nkeys << " keys reported by MPI_File_get_info):\n";
+    for (int i = 0; i < nkeys; ++i) {
+      char key[MPI_MAX_INFO_KEY];
+      MPI_Info_get_nthkey(used, i, key);
+      int vlen = 0;
+      int flag = 0;
+      MPI_Info_get_valuelen(used, key, &vlen, &flag);
+      std::vector<char> buf(static_cast<size_t>(vlen) + 1, '\0');
+      if (flag) MPI_Info_get(used, key, vlen, buf.data(), &flag);
+      oss << "    " << key << " = " << buf.data() << "\n";
+    }
+    oss << "  (striping_factor / striping_unit here reflect the file's actual "
+           "Lustre layout; if they match the request the hints were applied)";
+    oops::Log::info() << oss.str() << std::endl;
+  }
+
+  if (used != MPI_INFO_NULL) MPI_Info_free(&used);
+  MPI_File_close(&fh);
 }
 
 int ParallelNetCDFWriteBackend::ensure_surf_var(const std::string& var_name,

--- a/src/orca-jedi/nemo_io/ParallelNetCDFBackend.h
+++ b/src/orca-jedi/nemo_io/ParallelNetCDFBackend.h
@@ -37,7 +37,7 @@ class ParallelNetCDFWriteBackend : public FieldWriteBackend {
   /// \param nx, ny     Global grid extents.
   /// \param datetimes  Time coordinate values (defines the t dimension).
   /// \param depths     Depth/level coordinate values (defines the z dimension).
-  ParallelNetCDFWriteBackend(const eckit::mpi::Comm& io_comm,
+  explicit ParallelNetCDFWriteBackend(const eckit::mpi::Comm& io_comm,
                              const eckit::PathName& path,
                              size_t nx, size_t ny,
                              const std::vector<util::DateTime>& datetimes,
@@ -109,7 +109,7 @@ class ParallelNetCDFReadBackend : public FieldReadBackend {
  public:
   /// \param io_comm I/O sub-communicator (from IoPool::io_comm()).
   /// \param path    Input file path (must be a netCDF-4 / HDF5 file).
-  ParallelNetCDFReadBackend(const eckit::mpi::Comm& io_comm,
+  explicit ParallelNetCDFReadBackend(const eckit::mpi::Comm& io_comm,
                             const eckit::PathName& path);
 
   ~ParallelNetCDFReadBackend() override;

--- a/src/orca-jedi/nemo_io/ParallelNetCDFBackend.h
+++ b/src/orca-jedi/nemo_io/ParallelNetCDFBackend.h
@@ -83,6 +83,8 @@ class ParallelNetCDFWriteBackend : public FieldWriteBackend {
   size_t ny_ = 0;
   size_t n_levels_ = 1;
   size_t n_times_ = 1;
+  size_t n_io_ranks_ = 1;  ///< Number of I/O ranks (size of the I/O comm).
+  size_t chunk_y_ = 1;     ///< Chunk extent along y (= ceil(ny / n_io_ranks)).
 };
 
 /// \brief FieldReadBackend that reads NEMO-layout netCDF files in parallel.

--- a/src/orca-jedi/nemo_io/ParallelNetCDFBackend.h
+++ b/src/orca-jedi/nemo_io/ParallelNetCDFBackend.h
@@ -1,0 +1,119 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "eckit/filesystem/PathName.h"
+#include "eckit/mpi/Comm.h"
+
+#include "oops/util/DateTime.h"
+
+#include "orca-jedi/nemo_io/IoBackend.h"
+#include "orca-jedi/nemo_io/SlabDecomposition.h"
+
+namespace orcamodel {
+
+/// \brief FieldWriteBackend that writes NEMO-layout netCDF files in parallel.
+///
+/// The file is created collectively on the I/O sub-communicator with
+/// nc_create_par (parallel HDF5), and every I/O rank writes its own contiguous
+/// y-band hyperslab of each variable using collective netCDF calls. The
+/// on-disk layout (dimensions x, y, z, t; coordinate variables nav_lat, nav_lon,
+/// t, z; surface variables {t, y, x}; volume variables {t, z, y, x}; fill value
+/// NemoFieldWriter::fillValue) is identical to the serial NemoFieldWriter so the
+/// two paths are interchangeable.
+///
+/// All I/O ranks must call every method collectively and in the same order:
+/// data variables are defined lazily on first write, which requires a collective
+/// define-mode transition across the sub-communicator.
+class ParallelNetCDFWriteBackend : public FieldWriteBackend {
+ public:
+  /// \param io_comm    I/O sub-communicator (from IoPool::io_comm()).
+  /// \param path       Output file path.
+  /// \param nx, ny     Global grid extents.
+  /// \param datetimes  Time coordinate values (defines the t dimension).
+  /// \param depths     Depth/level coordinate values (defines the z dimension).
+  ParallelNetCDFWriteBackend(const eckit::mpi::Comm& io_comm,
+                             const eckit::PathName& path,
+                             size_t nx, size_t ny,
+                             const std::vector<util::DateTime>& datetimes,
+                             const std::vector<double>& depths);
+
+  ~ParallelNetCDFWriteBackend() override;
+
+  ParallelNetCDFWriteBackend(ParallelNetCDFWriteBackend&&) = delete;
+  ParallelNetCDFWriteBackend(const ParallelNetCDFWriteBackend&) = delete;
+  ParallelNetCDFWriteBackend& operator=(ParallelNetCDFWriteBackend&&) = delete;
+  ParallelNetCDFWriteBackend& operator=(const ParallelNetCDFWriteBackend&) = delete;
+
+  void write_dimensions(const Hyperslab& slab,
+                        const std::vector<double>& lat_band,
+                        const std::vector<double>& lon_band) override;
+
+  void write_surf_slab(const std::string& var_name, size_t t_index,
+                       const Hyperslab& slab,
+                       const std::vector<double>& data) override;
+  void write_surf_slab(const std::string& var_name, size_t t_index,
+                       const Hyperslab& slab,
+                       const std::vector<float>& data) override;
+
+  void write_vol_slab(const std::string& var_name, size_t t_index,
+                      size_t z_begin, size_t z_count, const Hyperslab& slab,
+                      const std::vector<double>& data) override;
+  void write_vol_slab(const std::string& var_name, size_t t_index,
+                      size_t z_begin, size_t z_count, const Hyperslab& slab,
+                      const std::vector<float>& data) override;
+
+ private:
+  /// \brief Return the varid of \p var_name, defining it collectively (with the
+  ///        given netCDF type and dimensionality) on first use.
+  int ensure_surf_var(const std::string& var_name, int nc_type);
+  int ensure_vol_var(const std::string& var_name, int nc_type);
+
+  int ncid_ = -1;
+  int dim_x_ = -1;
+  int dim_y_ = -1;
+  int dim_z_ = -1;
+  int dim_t_ = -1;
+  size_t nx_ = 0;
+  size_t ny_ = 0;
+  size_t n_levels_ = 1;
+  size_t n_times_ = 1;
+};
+
+/// \brief FieldReadBackend that reads NEMO-layout netCDF files in parallel.
+///
+/// The mirror image of ParallelNetCDFWriteBackend: the file is opened
+/// collectively on the I/O sub-communicator with nc_open_par, and every I/O
+/// rank reads its own contiguous y-band hyperslab of a variable using
+/// collective netCDF calls. Both 2D surface {t, y, x} and 3D volume
+/// {t, z, y, x} variables are supported; the variable's dimensionality is
+/// discovered on read.
+class ParallelNetCDFReadBackend : public FieldReadBackend {
+ public:
+  /// \param io_comm I/O sub-communicator (from IoPool::io_comm()).
+  /// \param path    Input file path (must be a netCDF-4 / HDF5 file).
+  ParallelNetCDFReadBackend(const eckit::mpi::Comm& io_comm,
+                            const eckit::PathName& path);
+
+  ~ParallelNetCDFReadBackend() override;
+
+  ParallelNetCDFReadBackend(ParallelNetCDFReadBackend&&) = delete;
+  ParallelNetCDFReadBackend(const ParallelNetCDFReadBackend&) = delete;
+  ParallelNetCDFReadBackend& operator=(ParallelNetCDFReadBackend&&) = delete;
+  ParallelNetCDFReadBackend& operator=(const ParallelNetCDFReadBackend&) = delete;
+
+  void read_slab(const std::string& var_name, size_t t_index, size_t z_index,
+                 const Hyperslab& slab, std::vector<double>& data) override;
+  void read_slab(const std::string& var_name, size_t t_index, size_t z_index,
+                 const Hyperslab& slab, std::vector<float>& data) override;
+
+ private:
+  int ncid_ = -1;
+};
+
+}  // namespace orcamodel

--- a/src/orca-jedi/nemo_io/ParallelNetCDFBackend.h
+++ b/src/orca-jedi/nemo_io/ParallelNetCDFBackend.h
@@ -74,6 +74,13 @@ class ParallelNetCDFWriteBackend : public FieldWriteBackend {
   int ensure_surf_var(const std::string& var_name, int nc_type);
   int ensure_vol_var(const std::string& var_name, int nc_type);
 
+  /// \brief After the file has been closed, reopen it read-only on the I/O
+  ///        communicator and log the MPI-IO hints the library actually applied
+  ///        (notably the real Lustre stripe layout). Lets the requested
+  ///        striping be compared against what the file ended up with. Never
+  ///        throws (called from the destructor); silently skips on any error.
+  void report_effective_hints();
+
   int ncid_ = -1;
   int dim_x_ = -1;
   int dim_y_ = -1;
@@ -85,6 +92,9 @@ class ParallelNetCDFWriteBackend : public FieldWriteBackend {
   size_t n_times_ = 1;
   size_t n_io_ranks_ = 1;  ///< Number of I/O ranks (size of the I/O comm).
   size_t chunk_y_ = 1;     ///< Chunk extent along y (= ceil(ny / n_io_ranks)).
+  size_t requested_stripe_bytes_ = 0;  ///< striping_unit hint requested (bytes).
+  const eckit::mpi::Comm* io_comm_ = nullptr;  ///< I/O comm (for hint readback).
+  eckit::PathName path_;   ///< Output path (for post-write hint readback).
 };
 
 /// \brief FieldReadBackend that reads NEMO-layout netCDF files in parallel.

--- a/src/orca-jedi/nemo_io/ReadServer.cc
+++ b/src/orca-jedi/nemo_io/ReadServer.cc
@@ -14,17 +14,28 @@
 #include "atlas/parallel/omp/omp.h"
 #include "eckit/exception/Exceptions.h"
 
+#include "orca-jedi/nemo_io/ParallelNetCDFBackend.h"
+
 namespace orcamodel {
 
 ReadServer::ReadServer(std::shared_ptr<eckit::Timer> eckit_timer,
-  const eckit::PathName& file_path, const atlas::Mesh& mesh) :
+  const eckit::PathName& file_path, const atlas::Mesh& mesh,
+  bool parallel_io, size_t n_io_ranks) :
   mesh_(mesh),
-  eckit_timer_(eckit_timer) {
+  eckit_timer_(eckit_timer),
+  parallel_(parallel_io) {
   buffer_indices_ = AtlasIndexToBufferIndexCreator::create_unique(
           mesh.grid().type(), mesh);
 
+  // The root rank always keeps a serial reader for cheap metadata reads
+  // (datetime index, fill value) and small 1-D vertical variables. Only the
+  // large gridded field reads are routed through the parallel pool.
   if (myrank == mpiroot) {
     reader_ = std::make_unique<NemoFieldReader>(file_path);
+  }
+
+  if (parallel_) {
+    this->setup_parallel(file_path, n_io_ranks);
   }
 }
 
@@ -146,6 +157,11 @@ template<class T> void ReadServer::read_var(const std::string& var_name,
   oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::read_var "
     << var_name << std::endl;
 
+  if (parallel_) {
+    this->read_var_parallel<T>(var_name, t_index, field_view);
+    return;
+  }
+
   size_t n_levels = field_view.shape(1);
   size_t size = buffer_indices_->nx() * buffer_indices_->ny();
 
@@ -173,6 +189,69 @@ template void ReadServer::read_var<float>(
     const std::string& var_name,
     const size_t t_index,
     atlas::array::ArrayView<float, 2>& field_view);
+
+// -----------------------------------------------------------------------------
+// Parallel (I/O pool + redistributor + parallel-netCDF backend) read path.
+// -----------------------------------------------------------------------------
+
+void ReadServer::setup_parallel(const eckit::PathName& file_path,
+    size_t n_io_ranks) {
+  oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::setup_parallel" << std::endl;
+  const size_t nx = buffer_indices_->nx();
+  const size_t ny = buffer_indices_->ny();
+
+  // Every local node (including ghost nodes) participates so the scatter fills
+  // the ORCA halo cells that are only reachable through ghost nodes.
+  std::vector<size_t> node_index;
+  std::vector<size_t> global_index;
+  node_index.reserve(mesh_.nodes().size());
+  global_index.reserve(mesh_.nodes().size());
+  for (atlas::idx_t i_node = 0; i_node < mesh_.nodes().size(); ++i_node) {
+    node_index.emplace_back(static_cast<size_t>(i_node));
+    global_index.emplace_back((*buffer_indices_)(i_node));
+  }
+
+  const eckit::mpi::Comm& comm = atlas::mpi::comm();
+  const size_t requested = n_io_ranks == 0 ? comm.size() : n_io_ranks;
+  pool_ = std::make_unique<IoPool>(comm, requested, nx, ny, "orca_read_pool");
+  redist_ = std::make_unique<Redistributor>(comm, *pool_, node_index, global_index);
+
+  if (pool_->is_io_rank()) {
+    backend_ = std::make_unique<ParallelNetCDFReadBackend>(pool_->io_comm(), file_path);
+  }
+}
+
+/// \brief Read a variable one level at a time through the I/O pool and scatter
+///        each level onto the field view. Unlike the root-broadcast path this
+///        also fills ghost nodes (a superset of what the caller needs; the
+///        subsequent halo exchange is a no-op on those points).
+template<class T> void ReadServer::read_var_parallel(const std::string& var_name,
+    const size_t t_index, atlas::array::ArrayView<T, 2>& field_view) {
+  oops::Log::trace() << "State(ORCA)::nemo_io::ReadServer::read_var_parallel "
+    << var_name << std::endl;
+  const bool is_io = pool_->is_io_rank();
+  const Hyperslab slab = is_io ? pool_->decomposition().slab(pool_->io_rank())
+                               : Hyperslab{};
+  const size_t n_levels = field_view.shape(1);
+  const size_t num_nodes = field_view.shape(0);
+
+  std::vector<T> local(num_nodes);
+  for (size_t iLev = 0; iLev < n_levels; ++iLev) {
+    std::vector<T> slab_data;
+    if (is_io) {
+      backend_->read_slab(var_name, t_index, iLev, slab, slab_data);
+    }
+    redist_->from_io<T>(slab_data, local);
+    for (size_t inode = 0; inode < num_nodes; ++inode) {
+      field_view(inode, iLev) = local[inode];
+    }
+    log_status();
+  }
+}
+template void ReadServer::read_var_parallel<double>(const std::string& var_name,
+    const size_t t_index, atlas::array::ArrayView<double, 2>& field_view);
+template void ReadServer::read_var_parallel<float>(const std::string& var_name,
+    const size_t t_index, atlas::array::ArrayView<float, 2>& field_view);
 
 /// \brief Read a vertical variable into an atlas field.
 /// \param var_name The netCDF name of the variable to read.

--- a/src/orca-jedi/nemo_io/ReadServer.cc
+++ b/src/orca-jedi/nemo_io/ReadServer.cc
@@ -200,15 +200,19 @@ void ReadServer::setup_parallel(const eckit::PathName& file_path,
   const size_t nx = buffer_indices_->nx();
   const size_t ny = buffer_indices_->ny();
 
-  // Every local node (including ghost nodes) participates so the scatter fills
-  // the ORCA halo cells that are only reachable through ghost nodes.
+  // Every local node that maps onto the buffer (including in-buffer ghost
+  // nodes) participates so the scatter fills the ORCA halo cells that are only
+  // reachable through ghost nodes. Out-of-buffer nodes (the north-fold pivot
+  // ghost row) have no file cell and are filled by the later halo exchange.
   std::vector<size_t> node_index;
   std::vector<size_t> global_index;
   node_index.reserve(mesh_.nodes().size());
   global_index.reserve(mesh_.nodes().size());
   for (atlas::idx_t i_node = 0; i_node < mesh_.nodes().size(); ++i_node) {
-    node_index.emplace_back(static_cast<size_t>(i_node));
-    global_index.emplace_back((*buffer_indices_)(i_node));
+    const size_t inode = static_cast<size_t>(i_node);
+    if (!buffer_indices_->maps_to_buffer(inode)) continue;
+    node_index.emplace_back(inode);
+    global_index.emplace_back((*buffer_indices_)(inode));
   }
 
   const eckit::mpi::Comm& comm = atlas::mpi::comm();

--- a/src/orca-jedi/nemo_io/ReadServer.h
+++ b/src/orca-jedi/nemo_io/ReadServer.h
@@ -18,6 +18,9 @@
 
 #include "orca-jedi/nemo_io/AtlasIndex.h"
 #include "orca-jedi/nemo_io/NemoFieldReader.h"
+#include "orca-jedi/nemo_io/IoPool.h"
+#include "orca-jedi/nemo_io/Redistributor.h"
+#include "orca-jedi/nemo_io/IoBackend.h"
 
 #include "eckit/log/Timer.h"
 #include "eckit/system/ResourceUsage.h"
@@ -27,7 +30,8 @@ class ReadServer {
  public:
   explicit ReadServer(std::shared_ptr<eckit::Timer> eckit_timer,
       const eckit::PathName& file_path,
-      const atlas::Mesh& mesh);
+      const atlas::Mesh& mesh,
+      bool parallel_io = false, size_t n_io_ranks = 0);
   ReadServer(ReadServer &&) = default;
   ReadServer(const ReadServer &) = delete;
   ReadServer &operator=(ReadServer &&) = delete;
@@ -58,11 +62,25 @@ void log_status() const {
       atlas::array::ArrayView<T, 2>& field_view) const;
   template<class T> void fill_vertical_field(const std::vector<T>& buffer,
       atlas::array::ArrayView<T, 2>& field_view) const;
+
+  /// \brief Build the parallel I/O pool, redistributor and (on I/O ranks) the
+  ///        parallel-netCDF read backend. Only used when parallel_ is true.
+  void setup_parallel(const eckit::PathName& file_path, size_t n_io_ranks);
+  /// \brief Read one horizontal slice on the pool and scatter it onto the
+  ///        per-node field view (fills all nodes, including ghost nodes).
+  template<class T> void read_var_parallel(const std::string& var_name,
+      const size_t t_index, atlas::array::ArrayView<T, 2>& field_view);
+
   const size_t mpiroot = 0;
   const size_t myrank = atlas::mpi::rank();
   const atlas::Mesh& mesh_;
   std::unique_ptr<AtlasIndexToBufferIndex> buffer_indices_;
   std::unique_ptr<NemoFieldReader> reader_;
   std::shared_ptr<eckit::Timer> eckit_timer_;
+
+  bool parallel_ = false;
+  std::unique_ptr<IoPool> pool_;
+  std::unique_ptr<Redistributor> redist_;
+  std::unique_ptr<FieldReadBackend> backend_;
 };
 }  // namespace orcamodel

--- a/src/orca-jedi/nemo_io/Redistributor.cc
+++ b/src/orca-jedi/nemo_io/Redistributor.cc
@@ -1,0 +1,153 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#include "orca-jedi/nemo_io/Redistributor.h"
+
+#include <numeric>
+#include <vector>
+
+#include "atlas/runtime/Exception.h"  // IWYU pragma: keep
+#include "oops/util/Logger.h"
+
+namespace orcamodel {
+
+Redistributor::Redistributor(const eckit::mpi::Comm& comm, const IoPool& pool,
+                             const std::vector<size_t>& node_index,
+                             const std::vector<size_t>& global_index)
+    : comm_(&comm) {
+  oops::Log::trace() << "orcamodel::Redistributor::Redistributor" << std::endl;
+  ATLAS_ASSERT(node_index.size() == global_index.size(),
+      "Redistributor: node_index and global_index must be the same length");
+
+  const size_t size = comm.size();
+  const size_t n_owned = global_index.size();
+  const SlabDecomposition& decomp = pool.decomposition();
+
+  // 1. Count how many owned points go to each destination parent rank.
+  send_counts_.assign(size, 0);
+  std::vector<size_t> dest(n_owned);
+  for (size_t p = 0; p < n_owned; ++p) {
+    const size_t owner_pool_rank = decomp.owner(global_index[p]);
+    const size_t dest_rank = pool.parent_rank_of(owner_pool_rank);
+    ATLAS_ASSERT(dest_rank < size);
+    dest[p] = dest_rank;
+    ++send_counts_[dest_rank];
+  }
+
+  // 2. Send displacements (prefix sum).
+  send_displs_.assign(size, 0);
+  for (size_t r = 1; r < size; ++r) {
+    send_displs_[r] = send_displs_[r - 1] + send_counts_[r - 1];
+  }
+
+  // 3. Bucket owned points by destination, recording the source node and the
+  //    global index (which travels alongside so receivers can locate each
+  //    value within their slab).
+  send_node_order_.resize(n_owned);
+  std::vector<size_t> send_global(n_owned);
+  {
+    std::vector<int> cursor = send_displs_;
+    for (size_t p = 0; p < n_owned; ++p) {
+      const int slot = cursor[dest[p]]++;
+      send_node_order_[slot] = node_index[p];
+      send_global[slot] = global_index[p];
+    }
+  }
+
+  // 4. Exchange counts, then build receive displacements.
+  recv_counts_.assign(size, 0);
+  comm.allToAll(send_counts_, recv_counts_);
+  recv_displs_.assign(size, 0);
+  for (size_t r = 1; r < size; ++r) {
+    recv_displs_[r] = recv_displs_[r - 1] + recv_counts_[r - 1];
+  }
+  const size_t n_recv = std::accumulate(recv_counts_.begin(), recv_counts_.end(), size_t{0});
+
+  // 5. Exchange the global indices to learn the received layout.
+  std::vector<size_t> recv_global(n_recv);
+  comm.allToAllv(send_global.data(), send_counts_.data(), send_displs_.data(),
+                 recv_global.data(), recv_counts_.data(), recv_displs_.data());
+
+  // 6. On I/O ranks, translate received global indices into slab offsets.
+  //
+  // The caller feeds *all* local nodes, including halo/ghost nodes, because on
+  // the ORCA grid the extra halo buffer cells (east/west wrap and the north
+  // fold) are only reachable through ghost nodes. A given global buffer index
+  // can therefore arrive from more than one compute rank (the owner plus every
+  // rank holding it as a ghost), so the received count is >= the slab size
+  // rather than equal to it. Duplicates are harmless: every copy of a halo
+  // point carries the same value, so writing a slab cell more than once is a
+  // last-wins no-op (this matches the behaviour of the original gather + sort
+  // on the root rank). The requirement we *do* enforce is full coverage: every
+  // cell of the slab must be written at least once.
+  recv_slab_offset_.resize(n_recv);
+  if (pool.is_io_rank()) {
+    const Hyperslab slab = decomp.slab(pool.io_rank());
+    slab_size_ = slab.size();
+    const size_t base = slab.global_index_begin();
+    std::vector<char> covered(slab_size_, 0);
+    for (size_t r = 0; r < n_recv; ++r) {
+      ATLAS_ASSERT(recv_global[r] >= base && recv_global[r] < base + slab_size_,
+          "Redistributor: received a global index outside this rank's slab");
+      const size_t offset = recv_global[r] - base;
+      recv_slab_offset_[r] = offset;
+      covered[offset] = 1;
+    }
+    const size_t n_covered =
+        std::accumulate(covered.begin(), covered.end(), size_t{0});
+    ATLAS_ASSERT(n_covered == slab_size_,
+        "Redistributor: slab not fully covered (covered " + std::to_string(n_covered)
+        + " of " + std::to_string(slab_size_) + " cells); ensure all nodes,"
+        " including ghost nodes, are passed to the Redistributor");
+  } else {
+    ATLAS_ASSERT(n_recv == 0, "Redistributor: non-I/O rank received data");
+  }
+}
+
+template <class T>
+void Redistributor::to_io(const std::vector<T>& local_values,
+                          std::vector<T>& slab_out) const {
+  std::vector<T> send_buf(send_node_order_.size());
+  for (size_t s = 0; s < send_node_order_.size(); ++s) {
+    send_buf[s] = local_values[send_node_order_[s]];
+  }
+
+  std::vector<T> recv_buf(recv_slab_offset_.size());
+  comm_->allToAllv(send_buf.data(), send_counts_.data(), send_displs_.data(),
+                   recv_buf.data(), recv_counts_.data(), recv_displs_.data());
+
+  slab_out.resize(slab_size_);
+  for (size_t r = 0; r < recv_slab_offset_.size(); ++r) {
+    slab_out[recv_slab_offset_[r]] = recv_buf[r];
+  }
+}
+template void Redistributor::to_io<double>(const std::vector<double>&,
+                                           std::vector<double>&) const;
+template void Redistributor::to_io<float>(const std::vector<float>&,
+                                          std::vector<float>&) const;
+
+template <class T>
+void Redistributor::from_io(const std::vector<T>& slab_in,
+                            std::vector<T>& local_values) const {
+  // Gather from the slab in the same order the values were received during
+  // setup, then run the exchange in reverse (send/recv roles swapped).
+  std::vector<T> recv_buf(recv_slab_offset_.size());
+  for (size_t r = 0; r < recv_slab_offset_.size(); ++r) {
+    recv_buf[r] = slab_in[recv_slab_offset_[r]];
+  }
+
+  std::vector<T> send_buf(send_node_order_.size());
+  comm_->allToAllv(recv_buf.data(), recv_counts_.data(), recv_displs_.data(),
+                   send_buf.data(), send_counts_.data(), send_displs_.data());
+
+  for (size_t s = 0; s < send_node_order_.size(); ++s) {
+    local_values[send_node_order_[s]] = send_buf[s];
+  }
+}
+template void Redistributor::from_io<double>(const std::vector<double>&,
+                                             std::vector<double>&) const;
+template void Redistributor::from_io<float>(const std::vector<float>&,
+                                            std::vector<float>&) const;
+
+}  // namespace orcamodel

--- a/src/orca-jedi/nemo_io/Redistributor.h
+++ b/src/orca-jedi/nemo_io/Redistributor.h
@@ -1,0 +1,72 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "eckit/mpi/Comm.h"
+
+#include "orca-jedi/nemo_io/IoPool.h"
+
+namespace orcamodel {
+
+/// \brief Bridges the compute (atlas) decomposition and the I/O-slab
+///        decomposition with a cached, partitioner-agnostic all-to-all plan.
+///
+/// The plan is computed once from the global buffer index of each local grid
+/// point and reused for every field, level and time step. Data volume moved
+/// equals (roughly) a single copy of the field, but the exchange is a balanced
+/// all-to-all onto the I/O pool rather than an all-to-one gather onto a single
+/// root, and it composes with concurrent collective writes.
+///
+/// The caller must pass *all* local nodes, including halo/ghost nodes: on the
+/// ORCA grid the extra halo buffer cells (east/west wrap and the north fold) are
+/// only reachable through ghost nodes, so omitting them would leave those cells
+/// unwritten. A global buffer index may consequently be contributed by more than
+/// one rank (its owner plus every rank holding it as a ghost). Duplicates are
+/// harmless - each copy carries the same value, so a slab cell written more than
+/// once is a last-wins no-op, matching the original gather-and-sort on root.
+class Redistributor {
+ public:
+  /// \param comm          Parent communicator spanning all compute ranks (the
+  ///                      I/O ranks are a subset of this communicator).
+  /// \param pool          The I/O pool defining slab ownership.
+  /// \param node_index    Atlas node index of each local point, including ghost
+  ///                      nodes (required for full halo-cell coverage).
+  /// \param global_index  Flattened global buffer index (g = j*nx + i) of each
+  ///                      local point; parallel to node_index.
+  Redistributor(const eckit::mpi::Comm& comm, const IoPool& pool,
+                const std::vector<size_t>& node_index,
+                const std::vector<size_t>& global_index);
+
+  /// \brief Number of horizontal points in this rank's slab (0 on non-I/O ranks).
+  size_t slab_size() const { return slab_size_; }
+
+  /// \brief Compute -> I/O. Gather one horizontal level from the per-node
+  ///        \p local_values (indexed by atlas node) into this I/O rank's
+  ///        contiguous \p slab_out (resized to slab_size()).
+  template <class T>
+  void to_io(const std::vector<T>& local_values, std::vector<T>& slab_out) const;
+
+  /// \brief I/O -> compute. Scatter this I/O rank's contiguous \p slab_in back
+  ///        onto the entries of the per-node \p local_values (which the caller
+  ///        must pre-size to the number of atlas nodes). All contributing nodes,
+  ///        including ghost nodes, are filled from the file.
+  template <class T>
+  void from_io(const std::vector<T>& slab_in, std::vector<T>& local_values) const;
+
+ private:
+  const eckit::mpi::Comm* comm_;
+  std::vector<int> send_counts_;
+  std::vector<int> send_displs_;
+  std::vector<int> recv_counts_;
+  std::vector<int> recv_displs_;
+  std::vector<size_t> send_node_order_;   ///< send slot -> local atlas node index
+  std::vector<size_t> recv_slab_offset_;  ///< recv slot -> offset within slab
+  size_t slab_size_ = 0;
+};
+
+}  // namespace orcamodel

--- a/src/orca-jedi/nemo_io/SlabDecomposition.h
+++ b/src/orca-jedi/nemo_io/SlabDecomposition.h
@@ -1,0 +1,110 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <string>
+
+#include "atlas/runtime/Exception.h"  // IWYU pragma: keep
+
+namespace orcamodel {
+
+/// \brief Description of the contiguous region of the global (ny, nx) horizontal
+///        grid owned by a single I/O rank.
+///
+/// The decomposition splits the grid into horizontal row-bands (whole rows of
+/// x), which map onto a single contiguous netCDF hyperslab and a single
+/// contiguous run of the flattened global buffer index g = j * nx + i. Levels
+/// are handled by the caller looping over level ranges, so this struct is
+/// purely two-dimensional and independent of the number of vertical levels.
+struct Hyperslab {
+  size_t j_begin = 0;   ///< First global row (y index) owned by the I/O rank.
+  size_t j_count = 0;   ///< Number of rows owned.
+  size_t nx = 0;        ///< Full x extent of the grid (rows are never split).
+
+  /// \brief First flattened global buffer index owned by this slab.
+  size_t global_index_begin() const { return j_begin * nx; }
+
+  /// \brief Number of horizontal points owned by this slab.
+  size_t size() const { return j_count * nx; }
+
+  /// \brief Whether a flattened global buffer index falls inside this slab.
+  bool contains(size_t global_index) const {
+    return global_index >= global_index_begin()
+        && global_index < global_index_begin() + size();
+  }
+};
+
+/// \brief Strategy describing how the global horizontal grid is partitioned
+///        across the I/O ranks.
+///
+/// This is deliberately independent of the compute (atlas) decomposition: it
+/// only ever reasons about the global flattened buffer index of a grid point.
+/// Any MPI partitioner can therefore be paired with any SlabDecomposition; the
+/// Redistributor bridges the two. Implementations must guarantee that the slabs
+/// tile the whole grid exactly once (no gaps, no overlaps).
+class SlabDecomposition {
+ public:
+  virtual ~SlabDecomposition() = default;
+
+  /// \brief Number of I/O ranks the grid is split across.
+  virtual size_t n_io_ranks() const = 0;
+
+  /// \brief The row-band owned by a given I/O rank.
+  virtual Hyperslab slab(size_t io_rank) const = 0;
+
+  /// \brief The I/O rank that owns a given flattened global buffer index.
+  virtual size_t owner(size_t global_index) const = 0;
+};
+
+/// \brief Row-band (split on y) decomposition of the global (ny, nx) grid.
+///
+/// Rows are distributed as evenly as possible: the first (ny % n_io_ranks)
+/// ranks receive one extra row. Each band is fully contiguous both in the file
+/// and in the flattened global buffer, which is the friendliest layout for
+/// parallel HDF5 collective writes and Lustre striping.
+class YBandDecomposition : public SlabDecomposition {
+ public:
+  YBandDecomposition(size_t nx, size_t ny, size_t n_io_ranks)
+      : nx_(nx), ny_(ny),
+        n_io_ranks_(std::min(n_io_ranks, ny == 0 ? size_t{1} : ny)),
+        base_(ny_ / n_io_ranks_), remainder_(ny_ % n_io_ranks_) {
+    ATLAS_ASSERT(n_io_ranks_ >= 1, "YBandDecomposition needs at least one I/O rank");
+    ATLAS_ASSERT(nx_ >= 1, "YBandDecomposition needs a non-zero x extent");
+  }
+
+  static std::string name() { return "y-band"; }
+
+  size_t n_io_ranks() const override { return n_io_ranks_; }
+
+  Hyperslab slab(size_t io_rank) const override {
+    ATLAS_ASSERT(io_rank < n_io_ranks_);
+    // Ranks below remainder_ carry one extra row.
+    const size_t extra = std::min(io_rank, remainder_);
+    const size_t j_begin = io_rank * base_ + extra;
+    const size_t j_count = base_ + (io_rank < remainder_ ? 1 : 0);
+    return Hyperslab{j_begin, j_count, nx_};
+  }
+
+  size_t owner(size_t global_index) const override {
+    const size_t j = global_index / nx_;
+    // Rows [0, remainder_*(base_+1)) belong to the "fat" ranks.
+    const size_t fat_rows = remainder_ * (base_ + 1);
+    if (j < fat_rows) {
+      return j / (base_ + 1);
+    }
+    return remainder_ + (j - fat_rows) / base_;
+  }
+
+ private:
+  size_t nx_;
+  size_t ny_;
+  size_t n_io_ranks_;
+  size_t base_;       ///< Rows per rank before distributing the remainder.
+  size_t remainder_;  ///< Number of ranks receiving one extra row.
+};
+
+}  // namespace orcamodel

--- a/src/orca-jedi/nemo_io/WriteServer.cc
+++ b/src/orca-jedi/nemo_io/WriteServer.cc
@@ -4,7 +4,7 @@
 
 #include "orca-jedi/nemo_io/WriteServer.h"
 
-#include<algorithm>
+#include <algorithm>
 
 #include "eckit/exception/Exceptions.h"
 #include "oops/util/Logger.h"

--- a/src/orca-jedi/nemo_io/WriteServer.cc
+++ b/src/orca-jedi/nemo_io/WriteServer.cc
@@ -10,6 +10,8 @@
 #include "oops/util/Logger.h"
 #include "atlas-orca/grid/OrcaGrid.h"
 
+#include "orca-jedi/nemo_io/ParallelNetCDFBackend.h"
+
 
 namespace orcamodel {
 
@@ -137,6 +139,10 @@ template<class T> void WriteServer::write_vol_var(const std::string& var_name,
     const atlas::array::ArrayView<T, 2>& field_view) {
   oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::write_vol_var "
                      << var_name << std::endl;
+  if (parallel_) {
+    this->write_vol_var_parallel<T>(var_name, t_index, missingValue, field_view);
+    return;
+  }
   std::vector<T> buffer;
   size_t size = buffer_indices_->nx() * buffer_indices_->ny();
   if (myrank == mpiroot) {
@@ -179,6 +185,10 @@ template<class T> void WriteServer::write_surf_var(const std::string& var_name,
     const atlas::array::ArrayView<T, 2>& field_view) {
   oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::write_surf_var "
                      << var_name << std::endl;
+  if (parallel_) {
+    this->write_surf_var_parallel<T>(var_name, t_index, missingValue, field_view);
+    return;
+  }
   // gather data for this level onto the root processor.
   const std::vector<T> buffer = this->gather_field_on_root<T>(field_view, 0, missingValue);
   log_status();
@@ -196,6 +206,10 @@ template void WriteServer::write_surf_var<float>(const std::string& var_name,
 /// \brief  Write latitude and longitude dimensions.
 void WriteServer::write_dimensions() {
   oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::write_dimensions" << std::endl;
+  if (parallel_) {
+    this->write_dimensions_parallel();
+    return;
+  }
   atlas::array::ArrayView<double, 2> lonlat{atlas::array::make_view<double, 2>(
                                               mesh_.nodes().lonlat())};
   atlas::field::MissingValue missingValue(mesh_.nodes().lonlat());
@@ -211,16 +225,143 @@ void WriteServer::write_dimensions() {
   }
 }
 
+// -----------------------------------------------------------------------------
+// Parallel (I/O pool + redistributor + parallel-netCDF backend) path.
+// -----------------------------------------------------------------------------
+
+/// \brief Build the I/O pool, the cached redistribution plan and, on I/O ranks,
+///        the parallel-netCDF backend (which creates the file collectively).
+void WriteServer::setup_parallel(const eckit::PathName& file_path,
+    const std::vector<util::DateTime>& datetimes,
+    const std::vector<double>& depths, size_t n_io_ranks) {
+  oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::setup_parallel" << std::endl;
+  const size_t nx = buffer_indices_->nx();
+  const size_t ny = buffer_indices_->ny();
+
+  // Every local node (including ghost nodes) contributes its global buffer index
+  // so that the ORCA halo cells reachable only through ghosts are covered.
+  std::vector<size_t> node_index;
+  std::vector<size_t> global_index;
+  node_index.reserve(mesh_.nodes().size());
+  global_index.reserve(mesh_.nodes().size());
+  for (atlas::idx_t i_node = 0; i_node < mesh_.nodes().size(); ++i_node) {
+    node_index.emplace_back(static_cast<size_t>(i_node));
+    global_index.emplace_back((*buffer_indices_)(i_node));
+  }
+
+  const eckit::mpi::Comm& comm = atlas::mpi::comm();
+  const size_t requested = n_io_ranks == 0 ? comm.size() : n_io_ranks;
+  pool_ = std::make_unique<IoPool>(comm, requested, nx, ny, "orca_write_pool");
+  redist_ = std::make_unique<Redistributor>(comm, *pool_, node_index, global_index);
+
+  if (pool_->is_io_rank()) {
+    backend_ = std::make_unique<ParallelNetCDFWriteBackend>(pool_->io_comm(),
+        file_path, nx, ny, datetimes, depths);
+  }
+}
+
+/// \brief Redistribute one horizontal level of a field onto this rank's I/O slab,
+///        substituting the fill value for masked points (mirrors
+///        gather_field_on_root). Returns an empty vector on non-I/O ranks.
+template<class T> std::vector<T> WriteServer::field_to_slab(
+    const atlas::array::ArrayView<T, 2>& field_view, const size_t i_level,
+    const atlas::field::MissingValue& missingValue) const {
+  const bool has_mv = static_cast<bool>(missingValue);
+  std::vector<T> local(mesh_.nodes().size());
+  for (atlas::idx_t i_node = 0; i_node < mesh_.nodes().size(); ++i_node) {
+    if (has_mv && missingValue(field_view(i_node, i_level))) {
+      local[i_node] = NemoFieldWriter::fillValue;
+    } else {
+      local[i_node] = field_view(i_node, i_level);
+    }
+  }
+  std::vector<T> slab;
+  redist_->to_io<T>(local, slab);
+  return slab;
+}
+
+/// \brief  Write latitude and longitude dimensions on the I/O pool.
+void WriteServer::write_dimensions_parallel() {
+  oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::write_dimensions_parallel"
+                     << std::endl;
+  atlas::array::ArrayView<double, 2> lonlat{atlas::array::make_view<double, 2>(
+                                              mesh_.nodes().lonlat())};
+  atlas::field::MissingValue missingValue(mesh_.nodes().lonlat());
+
+  // NEMO layout: nav_lon is component 0, nav_lat is component 1.
+  const std::vector<double> lon_band = this->field_to_slab<double>(lonlat, 0, missingValue);
+  const std::vector<double> lat_band = this->field_to_slab<double>(lonlat, 1, missingValue);
+
+  if (pool_->is_io_rank()) {
+    const Hyperslab slab = pool_->decomposition().slab(pool_->io_rank());
+    backend_->write_dimensions(slab, lat_band, lon_band);
+  }
+}
+
+/// \brief  Write a 3D field at a given time index through the I/O pool.
+template<class T> void WriteServer::write_vol_var_parallel(const std::string& var_name,
+    const size_t t_index, const atlas::field::MissingValue& missingValue,
+    const atlas::array::ArrayView<T, 2>& field_view) {
+  oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::write_vol_var_parallel "
+                     << var_name << std::endl;
+  const bool is_io = pool_->is_io_rank();
+  const Hyperslab slab = is_io ? pool_->decomposition().slab(pool_->io_rank())
+                               : Hyperslab{};
+  // One level at a time keeps the slab buffer small; every I/O rank loops
+  // identically so the collective backend writes stay in step.
+  for (size_t iLev = 0; iLev < n_levels_; ++iLev) {
+    const std::vector<T> slab_data = this->field_to_slab<T>(field_view, iLev, missingValue);
+    if (is_io) {
+      backend_->write_vol_slab(var_name, t_index, iLev, 1, slab, slab_data);
+    }
+    log_status();
+  }
+}
+template void WriteServer::write_vol_var_parallel<double>(const std::string& var_name,
+    const size_t t_index, const atlas::field::MissingValue& missingValue,
+    const atlas::array::ArrayView<double, 2>& field_view);
+template void WriteServer::write_vol_var_parallel<float>(const std::string& var_name,
+    const size_t t_index, const atlas::field::MissingValue& missingValue,
+    const atlas::array::ArrayView<float, 2>& field_view);
+
+/// \brief  Write a 2D field at a given time index through the I/O pool.
+template<class T> void WriteServer::write_surf_var_parallel(const std::string& var_name,
+    const size_t t_index, const atlas::field::MissingValue& missingValue,
+    const atlas::array::ArrayView<T, 2>& field_view) {
+  oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::write_surf_var_parallel "
+                     << var_name << std::endl;
+  const std::vector<T> slab_data = this->field_to_slab<T>(field_view, 0, missingValue);
+  if (pool_->is_io_rank()) {
+    const Hyperslab slab = pool_->decomposition().slab(pool_->io_rank());
+    backend_->write_surf_slab(var_name, t_index, slab, slab_data);
+  }
+  log_status();
+}
+template void WriteServer::write_surf_var_parallel<double>(const std::string& var_name,
+    const size_t t_index, const atlas::field::MissingValue& missingValue,
+    const atlas::array::ArrayView<double, 2>& field_view);
+template void WriteServer::write_surf_var_parallel<float>(const std::string& var_name,
+    const size_t t_index, const atlas::field::MissingValue& missingValue,
+    const atlas::array::ArrayView<float, 2>& field_view);
+
 WriteServer::WriteServer(std::shared_ptr<eckit::Timer> eckit_timer,
     const eckit::PathName& file_path,
     const atlas::Mesh& mesh,
     const std::vector<util::DateTime> datetimes,
     const std::vector<double> depths,
-    bool is_serial) : mesh_(mesh), eckit_timer_(eckit_timer), is_serial_(is_serial),
-  n_levels_(depths.size()) {
+    bool is_serial,
+    bool parallel_io,
+    size_t n_io_ranks) : mesh_(mesh), eckit_timer_(eckit_timer), is_serial_(is_serial),
+  n_levels_(depths.size()), parallel_(parallel_io) {
   oops::Log::trace() << "State(ORCA)::nemo_io::WriteServer::WriteServer" << std::endl;
   buffer_indices_ = AtlasIndexToBufferIndexCreator::create_unique(
           mesh.grid().type(), mesh);
+
+  if (parallel_) {
+    this->setup_parallel(file_path, datetimes, depths, n_io_ranks);
+    this->write_dimensions();
+    return;
+  }
 
   std::vector<size_t> local_buf_indices;
 

--- a/src/orca-jedi/nemo_io/WriteServer.cc
+++ b/src/orca-jedi/nemo_io/WriteServer.cc
@@ -238,15 +238,19 @@ void WriteServer::setup_parallel(const eckit::PathName& file_path,
   const size_t nx = buffer_indices_->nx();
   const size_t ny = buffer_indices_->ny();
 
-  // Every local node (including ghost nodes) contributes its global buffer index
-  // so that the ORCA halo cells reachable only through ghosts are covered.
+  // Every local node that maps onto the buffer (including in-buffer ghost
+  // nodes) contributes its global buffer index so that the ORCA halo cells
+  // reachable only through ghosts are covered. Out-of-buffer nodes (the
+  // north-fold pivot ghost row) have no file cell and must not write one.
   std::vector<size_t> node_index;
   std::vector<size_t> global_index;
   node_index.reserve(mesh_.nodes().size());
   global_index.reserve(mesh_.nodes().size());
   for (atlas::idx_t i_node = 0; i_node < mesh_.nodes().size(); ++i_node) {
-    node_index.emplace_back(static_cast<size_t>(i_node));
-    global_index.emplace_back((*buffer_indices_)(i_node));
+    const size_t inode = static_cast<size_t>(i_node);
+    if (!buffer_indices_->maps_to_buffer(inode)) continue;
+    node_index.emplace_back(inode);
+    global_index.emplace_back((*buffer_indices_)(inode));
   }
 
   const eckit::mpi::Comm& comm = atlas::mpi::comm();

--- a/src/orca-jedi/nemo_io/WriteServer.h
+++ b/src/orca-jedi/nemo_io/WriteServer.h
@@ -18,6 +18,9 @@
 
 #include "orca-jedi/nemo_io/AtlasIndex.h"
 #include "orca-jedi/nemo_io/NemoFieldWriter.h"
+#include "orca-jedi/nemo_io/IoPool.h"
+#include "orca-jedi/nemo_io/Redistributor.h"
+#include "orca-jedi/nemo_io/IoBackend.h"
 
 #include "eckit/log/Timer.h"
 #include "eckit/system/ResourceUsage.h"  // IWYU pragma: keep
@@ -29,7 +32,8 @@ class WriteServer {
       const eckit::PathName& file_path,
       const atlas::Mesh& mesh,
       const std::vector<util::DateTime> datetimes,
-      const std::vector<double> depths, bool is_serial);
+      const std::vector<double> depths, bool is_serial,
+      bool parallel_io = false, size_t n_io_ranks = 0);
   WriteServer(WriteServer &&) = default;
   WriteServer(const WriteServer &) = delete;
   WriteServer &operator=(WriteServer &&) = delete;
@@ -60,6 +64,24 @@ class WriteServer {
       const atlas::field::MissingValue& missingValue) const;
   template<class T> std::vector<T> sort_buffer(
     const std::vector<T> & buffer) const;
+
+  /// \brief Build the parallel I/O pool, redistributor and (on I/O ranks) the
+  ///        parallel-netCDF backend. Only used when parallel_ is true.
+  void setup_parallel(const eckit::PathName& file_path,
+      const std::vector<util::DateTime>& datetimes,
+      const std::vector<double>& depths, size_t n_io_ranks);
+  /// \brief Gather a per-node level into this rank's I/O slab (fill masked).
+  template<class T> std::vector<T> field_to_slab(
+      const atlas::array::ArrayView<T, 2>& field_view, const size_t i_level,
+      const atlas::field::MissingValue& missingValue) const;
+  void write_dimensions_parallel();
+  template<class T> void write_vol_var_parallel(const std::string& var_name,
+      const size_t t_index, const atlas::field::MissingValue& missingValue,
+      const atlas::array::ArrayView<T, 2>& field_view);
+  template<class T> void write_surf_var_parallel(const std::string& var_name,
+      const size_t t_index, const atlas::field::MissingValue& missingValue,
+      const atlas::array::ArrayView<T, 2>& field_view);
+
   const size_t mpiroot = 0;
   const size_t myrank = atlas::mpi::rank();
   const atlas::Mesh& mesh_;
@@ -72,5 +94,10 @@ class WriteServer {
   bool is_serial_;
   const size_t n_levels_;
   int recvcnt_;
+
+  bool parallel_ = false;
+  std::unique_ptr<IoPool> pool_;
+  std::unique_ptr<Redistributor> redist_;
+  std::unique_ptr<FieldWriteBackend> backend_;
 };
 }  // namespace orcamodel

--- a/src/orca-jedi/utilities/IOUtils.cc
+++ b/src/orca-jedi/utilities/IOUtils.cc
@@ -40,7 +40,8 @@ void readFieldsFromFile(
     auto nemo_field_path = eckit::PathName(nemo_file_name);
     oops::Log::debug() << "orcamodel::readFieldsFromFile:: nemo_field_path "
                        << nemo_field_path << std::endl;
-    ReadServer nemo_reader(geom.timer(), nemo_field_path, geom.mesh());
+    ReadServer nemo_reader(geom.timer(), nemo_field_path, geom.mesh(),
+        geom.parallelInput(), geom.inputIoRanks());
 
     // Read fields from Nemo field file
     // field names in the atlas fieldset are assumed to match their names in
@@ -160,7 +161,8 @@ void writeFieldsToFile(
     for (size_t iLev = 0; iLev < levels.size(); ++iLev) { levels[iLev] = iLev; }
 
     WriteServer writer(geom.timer(), nemo_field_path, geom.mesh(), datetimes, levels,
-                       geom.distributionType() == "serial");
+                       geom.distributionType() == "serial",
+                       geom.parallelOutput(), geom.outputIoRanks());
     for (atlas::Field field : fs) {
       std::string fieldName = field.name();
       std::string nemoName = geom.nemo_var_name(fieldName);

--- a/src/orca-jedi/utilities/Types.h
+++ b/src/orca-jedi/utilities/Types.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <netcdf>
+#include <netcdf.h>
 
 #include <string>
 
@@ -46,23 +46,23 @@ void ApplyForFieldType(const Functor& functor, atlas::DataType datatype,
   }
 }
 
-// create a mapping between C++ types and NetCDF type objects
+// create a mapping between C++ types and NetCDF (netcdf-c) type constants
 template <typename T>
 struct NetCDFTypeMap;
 
 template <>
 struct NetCDFTypeMap<float> {
-  inline static const netCDF::NcType ncType = netCDF::ncFloat;
+  inline static const nc_type ncType = NC_FLOAT;
 };
 
 template <>
 struct NetCDFTypeMap<double> {
-  inline static const netCDF::NcType ncType = netCDF::ncDouble;
+  inline static const nc_type ncType = NC_DOUBLE;
 };
 
 template <>
 struct NetCDFTypeMap<int> {
-  inline static const netCDF::NcType ncType = netCDF::ncInt;
+  inline static const nc_type ncType = NC_INT;
 };
 
 }  // namespace orcamodel

--- a/src/tests/orca-jedi/CMakeLists.txt
+++ b/src/tests/orca-jedi/CMakeLists.txt
@@ -4,6 +4,46 @@ ecbuild_add_test( TARGET  orcajedi_nemo_io_field_reader.x
                   SOURCES test_nemo_io_field_reader.cc
                   LIBS    orcamodel )
 
+ecbuild_add_test( TARGET  orcajedi_nemo_io_redistributor.x
+                  SOURCES test_nemo_io_redistributor.cc
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  LIBS    orcamodel )
+
+ecbuild_add_test( TARGET  orcajedi_nemo_io_redistributor_MPI2.x
+                  SOURCES test_nemo_io_redistributor.cc
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  MPI        2
+                  CONDITION  eckit_HAVE_MPI
+                  LIBS    orcamodel )
+
+ecbuild_add_test( TARGET  orcajedi_nemo_io_parallel_netcdf_MPI1.x
+                  SOURCES test_nemo_io_parallel_netcdf.cc
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  MPI        1
+                  CONDITION  eckit_HAVE_MPI
+                  LIBS    orcamodel )
+
+ecbuild_add_test( TARGET  orcajedi_nemo_io_parallel_netcdf_MPI2.x
+                  SOURCES test_nemo_io_parallel_netcdf.cc
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  MPI        2
+                  CONDITION  eckit_HAVE_MPI
+                  LIBS    orcamodel )
+
+ecbuild_add_test( TARGET  orcajedi_nemo_io_parallel_server_MPI1.x
+                  SOURCES test_nemo_io_parallel_server.cc
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  MPI        1
+                  CONDITION  eckit_HAVE_MPI
+                  LIBS    orcamodel )
+
+ecbuild_add_test( TARGET  orcajedi_nemo_io_parallel_server_MPI2.x
+                  SOURCES test_nemo_io_parallel_server.cc
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  MPI        2
+                  CONDITION  eckit_HAVE_MPI
+                  LIBS    orcamodel )
+
 ecbuild_add_test( TARGET  orcajedi_nemo_io_field_writer.x
                   SOURCES test_nemo_io_field_writer.cc
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}

--- a/src/tests/orca-jedi/test_nemo_io_parallel_netcdf.cc
+++ b/src/tests/orca-jedi/test_nemo_io_parallel_netcdf.cc
@@ -1,0 +1,209 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#include <netcdf.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "eckit/testing/Test.h"
+#include "eckit/filesystem/PathName.h"
+
+#include "atlas/parallel/mpi/mpi.h"
+
+#include "oops/util/DateTime.h"
+
+#include "orca-jedi/nemo_io/IoPool.h"
+#include "orca-jedi/nemo_io/ParallelNetCDFBackend.h"
+#include "orca-jedi/nemo_io/SlabDecomposition.h"
+
+#include "tests/orca-jedi/OrcaModelTestEnvironment.h"
+
+namespace orcamodel {
+namespace test {
+
+//-----------------------------------------------------------------------------
+
+CASE("ParallelNetCDFWriteBackend writes a NEMO-layout file in parallel") {
+  const size_t nx = 10;
+  const size_t ny = 7;
+  const size_t n_levels = 3;
+  const std::vector<double> depths{0.0, 1.0, 2.0};
+  const std::vector<util::DateTime> datetimes{util::DateTime("2021-06-30T00:00:00Z")};
+
+  const eckit::PathName path("test_parallel_netcdf.nc");
+
+  // Known-value generators keyed on the flattened global buffer index, so the
+  // reader can verify placement independently of the write-side decomposition.
+  const auto surf_val = [](size_t g) { return static_cast<double>(g) * 0.5 + 1.0; };
+  const auto vol_val = [](size_t k, size_t g) {
+    return static_cast<double>(k) * 100.0 + static_cast<double>(g) * 0.25 + 2.0;
+  };
+  const auto lat_val = [](size_t g) { return static_cast<double>(g) * 0.1; };
+  const auto lon_val = [](size_t g) { return static_cast<double>(g) * 0.2; };
+
+  const size_t n_io = std::min<size_t>(atlas::mpi::size(), ny);
+  IoPool pool(atlas::mpi::comm(), n_io, nx, ny, "test_pnetcdf_pool");
+
+  {
+    if (pool.is_io_rank()) {
+      const Hyperslab slab = pool.decomposition().slab(pool.io_rank());
+      const size_t g0 = slab.global_index_begin();
+      const size_t n = slab.size();
+
+      std::vector<double> lat_band(n), lon_band(n), surf(n);
+      for (size_t p = 0; p < n; ++p) {
+        lat_band[p] = lat_val(g0 + p);
+        lon_band[p] = lon_val(g0 + p);
+        surf[p] = surf_val(g0 + p);
+      }
+      std::vector<double> vol(n_levels * n);
+      for (size_t k = 0; k < n_levels; ++k) {
+        for (size_t p = 0; p < n; ++p) {
+          vol[k * n + p] = vol_val(k, g0 + p);
+        }
+      }
+
+      ParallelNetCDFWriteBackend backend(pool.io_comm(), path, nx, ny,
+                                         datetimes, depths);
+      backend.write_dimensions(slab, lat_band, lon_band);
+      backend.write_surf_slab("test_surf", 0, slab, surf);
+      backend.write_vol_slab("test_vol", 0, 0, n_levels, slab, vol);
+    }
+  }  // backend destructor closes the file collectively over the I/O comm
+
+  atlas::mpi::comm().barrier();
+
+  // Verify serially on the world root (which is always I/O rank 0).
+  if (atlas::mpi::rank() == 0) {
+    int ncid = -1;
+    EXPECT(nc_open(path.fullName().asString().c_str(), NC_NOWRITE, &ncid) == NC_NOERR);
+
+    int surf_id, vol_id, lat_id, lon_id, z_id;
+    EXPECT(nc_inq_varid(ncid, "test_surf", &surf_id) == NC_NOERR);
+    EXPECT(nc_inq_varid(ncid, "test_vol", &vol_id) == NC_NOERR);
+    EXPECT(nc_inq_varid(ncid, "nav_lat", &lat_id) == NC_NOERR);
+    EXPECT(nc_inq_varid(ncid, "nav_lon", &lon_id) == NC_NOERR);
+    EXPECT(nc_inq_varid(ncid, "z", &z_id) == NC_NOERR);
+
+    std::vector<double> surf(nx * ny);
+    std::vector<double> vol(n_levels * nx * ny);
+    std::vector<double> lat(nx * ny), lon(nx * ny), z(n_levels);
+    EXPECT(nc_get_var_double(ncid, surf_id, surf.data()) == NC_NOERR);
+    EXPECT(nc_get_var_double(ncid, vol_id, vol.data()) == NC_NOERR);
+    EXPECT(nc_get_var_double(ncid, lat_id, lat.data()) == NC_NOERR);
+    EXPECT(nc_get_var_double(ncid, lon_id, lon.data()) == NC_NOERR);
+    EXPECT(nc_get_var_double(ncid, z_id, z.data()) == NC_NOERR);
+
+    for (size_t g = 0; g < nx * ny; ++g) {
+      EXPECT(surf[g] == surf_val(g));
+      EXPECT(lat[g] == lat_val(g));
+      EXPECT(lon[g] == lon_val(g));
+    }
+    for (size_t k = 0; k < n_levels; ++k) {
+      EXPECT(z[k] == depths[k]);
+      for (size_t g = 0; g < nx * ny; ++g) {
+        EXPECT(vol[k * nx * ny + g] == vol_val(k, g));
+      }
+    }
+
+    EXPECT(nc_close(ncid) == NC_NOERR);
+    std::remove(path.fullName().asString().c_str());
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+CASE("ParallelNetCDFReadBackend reads NEMO-layout slabs in parallel") {
+  const size_t nx = 10;
+  const size_t ny = 7;
+  const size_t n_levels = 3;
+  const std::vector<double> depths{0.0, 1.0, 2.0};
+  const std::vector<util::DateTime> datetimes{util::DateTime("2021-06-30T00:00:00Z")};
+
+  const eckit::PathName path("test_parallel_netcdf_read.nc");
+
+  const auto surf_val = [](size_t g) { return static_cast<double>(g) * 0.5 + 1.0; };
+  const auto vol_val = [](size_t k, size_t g) {
+    return static_cast<double>(k) * 100.0 + static_cast<double>(g) * 0.25 + 2.0;
+  };
+  const auto lat_val = [](size_t g) { return static_cast<double>(g) * 0.1; };
+  const auto lon_val = [](size_t g) { return static_cast<double>(g) * 0.2; };
+
+  const size_t n_io = std::min<size_t>(atlas::mpi::size(), ny);
+  IoPool pool(atlas::mpi::comm(), n_io, nx, ny, "test_pnetcdf_read_pool");
+
+  // Write a self-contained netCDF-4 file so the read path never depends on the
+  // on-disk format of the pre-existing test data.
+  {
+    if (pool.is_io_rank()) {
+      const Hyperslab slab = pool.decomposition().slab(pool.io_rank());
+      const size_t g0 = slab.global_index_begin();
+      const size_t n = slab.size();
+
+      std::vector<double> lat_band(n), lon_band(n), surf(n);
+      for (size_t p = 0; p < n; ++p) {
+        lat_band[p] = lat_val(g0 + p);
+        lon_band[p] = lon_val(g0 + p);
+        surf[p] = surf_val(g0 + p);
+      }
+      std::vector<double> vol(n_levels * n);
+      for (size_t k = 0; k < n_levels; ++k) {
+        for (size_t p = 0; p < n; ++p) {
+          vol[k * n + p] = vol_val(k, g0 + p);
+        }
+      }
+
+      ParallelNetCDFWriteBackend backend(pool.io_comm(), path, nx, ny,
+                                         datetimes, depths);
+      backend.write_dimensions(slab, lat_band, lon_band);
+      backend.write_surf_slab("test_surf", 0, slab, surf);
+      backend.write_vol_slab("test_vol", 0, 0, n_levels, slab, vol);
+    }
+  }
+
+  atlas::mpi::comm().barrier();
+
+  // Read each rank's own slab back through the parallel read backend and check
+  // the values against the generators.
+  if (pool.is_io_rank()) {
+    const Hyperslab slab = pool.decomposition().slab(pool.io_rank());
+    const size_t g0 = slab.global_index_begin();
+    const size_t n = slab.size();
+
+    ParallelNetCDFReadBackend backend(pool.io_comm(), path);
+
+    std::vector<double> surf;
+    backend.read_slab("test_surf", 0, 0, slab, surf);
+    EXPECT(surf.size() == n);
+    for (size_t p = 0; p < n; ++p) {
+      EXPECT(surf[p] == surf_val(g0 + p));
+    }
+
+    for (size_t k = 0; k < n_levels; ++k) {
+      std::vector<double> lev;
+      backend.read_slab("test_vol", 0, k, slab, lev);
+      EXPECT(lev.size() == n);
+      for (size_t p = 0; p < n; ++p) {
+        EXPECT(lev[p] == vol_val(k, g0 + p));
+      }
+    }
+  }
+
+  atlas::mpi::comm().barrier();
+  if (atlas::mpi::rank() == 0) {
+    std::remove(path.fullName().asString().c_str());
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace orcamodel
+
+int main(int argc, char** argv) {
+  return orcamodel::test::run(argc, argv);
+}

--- a/src/tests/orca-jedi/test_nemo_io_parallel_server.cc
+++ b/src/tests/orca-jedi/test_nemo_io_parallel_server.cc
@@ -52,93 +52,110 @@ CASE("parallel WriteServer + ReadServer round-trip") {
                               + static_cast<double>(lev) * 1000.0 + 2.0);
   };
 
+  // halo == 0 exercises the original path; halo > 0 adds a source-mesh ghost
+  // ring that reaches beyond the i/j buffer (as used operationally, e.g.
+  // eORCA12 with "source mesh halo: 1"). Those out-of-buffer ghost nodes have
+  // no file cell and must be skipped by the parallel setup, otherwise the
+  // buffer indexer asserts (j > iy_glb_max). See maps_to_buffer in AtlasIndex.h.
+  const std::vector<int64_t> halos{0, 1};
+
   for (const std::string& partitioner_name : partitioner_names) {
-    atlas::OrcaGrid grid("ORCA2_T");
-    auto meshgen = atlas::MeshGenerator(grid.meshgenerator());
-    auto partitioner_config = grid.partitioner();
-    partitioner_config.set("type", partitioner_name);
-    auto partitioner = atlas::grid::Partitioner(partitioner_config);
-    auto mesh = meshgen.generate(grid, partitioner);
-    auto funcSpace = atlas::functionspace::NodeColumns(mesh);
+    for (const int64_t halo : halos) {
+      // atlas-orca rejects halo > 0 with the serial distribution
+      // (OrcaMeshGenerator throws), and Geometry.cc forces halo = 0 for the
+      // serial partitioner, so only exercise halo > 0 with a distributed one.
+      if (partitioner_name == "serial" && halo > 0) continue;
+      atlas::OrcaGrid grid("ORCA2_T");
+      auto meshgen_config = grid.meshgenerator() | atlas::option::halo(halo);
+      auto meshgen = atlas::MeshGenerator(meshgen_config);
+      auto partitioner_config = grid.partitioner();
+      partitioner_config.set("type", partitioner_name);
+      auto partitioner = atlas::grid::Partitioner(partitioner_config);
+      auto mesh = meshgen.generate(grid, partitioner);
+      auto funcSpace = atlas::functionspace::NodeColumns(
+          mesh, atlas::option::halo(halo));
 
-    std::unique_ptr<AtlasIndexToBufferIndex> atlas2buffer(
-        AtlasIndexToBufferIndexCreator::create_unique(grid.type(), mesh));
-    auto ghost = atlas::array::make_view<int32_t, 1>(mesh.nodes().ghost());
+      std::unique_ptr<AtlasIndexToBufferIndex> atlas2buffer(
+          AtlasIndexToBufferIndexCreator::create_unique(grid.type(), mesh));
+      auto ghost = atlas::array::make_view<int32_t, 1>(mesh.nodes().ghost());
 
-    // Fields without missing_value metadata so values pass through untouched.
-    auto field_ice = funcSpace.createField<double>(
-        atlas::option::name("iiceconc") | atlas::option::levels(1));
-    auto field_temp = funcSpace.createField<float>(
-        atlas::option::name("votemper") | atlas::option::levels(3));
-    atlas::field::MissingValue ice_mv(field_ice);
-    atlas::field::MissingValue temp_mv(field_temp);
+      // Fields without missing_value metadata so values pass through untouched.
+      auto field_ice = funcSpace.createField<double>(
+          atlas::option::name("iiceconc") | atlas::option::levels(1));
+      auto field_temp = funcSpace.createField<float>(
+          atlas::option::name("votemper") | atlas::option::levels(3));
+      atlas::field::MissingValue ice_mv(field_ice);
+      atlas::field::MissingValue temp_mv(field_temp);
 
-    auto view_ice = atlas::array::make_view<double, 2>(field_ice);
-    auto view_temp = atlas::array::make_view<float, 2>(field_temp);
+      auto view_ice = atlas::array::make_view<double, 2>(field_ice);
+      auto view_temp = atlas::array::make_view<float, 2>(field_temp);
 
-    const size_t num_nodes = mesh.nodes().size();
-    for (size_t inode = 0; inode < num_nodes; ++inode) {
-      if (ghost(inode)) continue;
-      const int64_t g = (*atlas2buffer)(inode);
-      view_ice(inode, 0) = surf_val(g);
-      for (size_t lev = 0; lev < 3; ++lev) {
-        view_temp(inode, lev) = vol_val(g, lev);
+      const size_t num_nodes = mesh.nodes().size();
+      for (size_t inode = 0; inode < num_nodes; ++inode) {
+        if (ghost(inode)) continue;
+        const int64_t g = (*atlas2buffer)(inode);
+        view_ice(inode, 0) = surf_val(g);
+        for (size_t lev = 0; lev < 3; ++lev) {
+          view_temp(inode, lev) = vol_val(g, lev);
+        }
       }
-    }
-    funcSpace.haloExchange(field_ice);
-    funcSpace.haloExchange(field_temp);
+      funcSpace.haloExchange(field_ice);
+      funcSpace.haloExchange(field_temp);
 
-    std::vector<size_t> io_rank_options{0};   // 0 => every rank is an I/O rank
-    if (nparts > 1) io_rank_options.push_back(1);
+      std::vector<size_t> io_rank_options{0};   // 0 => every rank is an I/O rank
+      if (nparts > 1) io_rank_options.push_back(1);
 
-    for (size_t n_io : io_rank_options) {
-      SECTION(partitioner_name + "_" + std::to_string(nparts)
-              + " n_io=" + std::to_string(n_io)) {
-        const eckit::PathName path(std::string("../testoutput/parallel_roundtrip_")
-            + partitioner_name + "_" + std::to_string(nparts)
-            + "_nio" + std::to_string(n_io) + ".nc");
-        const std::vector<util::DateTime> datetimes{
-            util::DateTime("1970-01-01T00:00:00Z")};
+      for (size_t n_io : io_rank_options) {
+        SECTION(partitioner_name + "_" + std::to_string(nparts)
+                + " halo=" + std::to_string(halo)
+                + " n_io=" + std::to_string(n_io)) {
+          const eckit::PathName path(std::string("../testoutput/parallel_roundtrip_")
+              + partitioner_name + "_" + std::to_string(nparts)
+              + "_halo" + std::to_string(halo)
+              + "_nio" + std::to_string(n_io) + ".nc");
+          const std::vector<util::DateTime> datetimes{
+              util::DateTime("1970-01-01T00:00:00Z")};
 
-        // --- parallel write (scoped so the backend closes the file) ---
-        {
-          std::shared_ptr<eckit::Timer> timer = std::make_shared<eckit::Timer>(
-              "parallel_server write: ", oops::Log::debug());
-          WriteServer writer(timer, path, mesh, datetimes, {1.0, 2.0, 3.0},
-                             /*is_serial=*/false, /*parallel_io=*/true, n_io);
-          writer.write_surf_var<double>("iiceconc", 0, ice_mv, view_ice);
-          writer.write_vol_var<float>("votemper", 0, temp_mv, view_temp);
-        }
-        atlas::mpi::comm().barrier();
-
-        // --- parallel read-back into fresh fields ---
-        auto rt_ice = funcSpace.createField<double>(
-            atlas::option::name("iiceconc") | atlas::option::levels(1));
-        auto rt_temp = funcSpace.createField<float>(
-            atlas::option::name("votemper") | atlas::option::levels(3));
-        auto rt_view_ice = atlas::array::make_view<double, 2>(rt_ice);
-        auto rt_view_temp = atlas::array::make_view<float, 2>(rt_temp);
-
-        {
-          std::shared_ptr<eckit::Timer> timer = std::make_shared<eckit::Timer>(
-              "parallel_server read: ", oops::Log::debug());
-          ReadServer reader(timer, path, mesh, /*parallel_io=*/true, n_io);
-          reader.read_var<double>("iiceconc", 0, rt_view_ice);
-          reader.read_var<float>("votemper", 0, rt_view_temp);
-        }
-
-        // Compare on owned (non-ghost) nodes: the round-trip must be exact.
-        for (size_t inode = 0; inode < num_nodes; ++inode) {
-          if (ghost(inode)) continue;
-          EXPECT(rt_view_ice(inode, 0) == view_ice(inode, 0));
-          for (size_t lev = 0; lev < 3; ++lev) {
-            EXPECT(rt_view_temp(inode, lev) == view_temp(inode, lev));
+          // --- parallel write (scoped so the backend closes the file) ---
+          {
+            std::shared_ptr<eckit::Timer> timer = std::make_shared<eckit::Timer>(
+                "parallel_server write: ", oops::Log::debug());
+            WriteServer writer(timer, path, mesh, datetimes, {1.0, 2.0, 3.0},
+                               /*is_serial=*/false, /*parallel_io=*/true, n_io);
+            writer.write_surf_var<double>("iiceconc", 0, ice_mv, view_ice);
+            writer.write_vol_var<float>("votemper", 0, temp_mv, view_temp);
           }
-        }
+          atlas::mpi::comm().barrier();
 
-        atlas::mpi::comm().barrier();
-        if (atlas::mpi::rank() == 0) {
-          std::remove(path.fullName().asString().c_str());
+          // --- parallel read-back into fresh fields ---
+          auto rt_ice = funcSpace.createField<double>(
+              atlas::option::name("iiceconc") | atlas::option::levels(1));
+          auto rt_temp = funcSpace.createField<float>(
+              atlas::option::name("votemper") | atlas::option::levels(3));
+          auto rt_view_ice = atlas::array::make_view<double, 2>(rt_ice);
+          auto rt_view_temp = atlas::array::make_view<float, 2>(rt_temp);
+
+          {
+            std::shared_ptr<eckit::Timer> timer = std::make_shared<eckit::Timer>(
+                "parallel_server read: ", oops::Log::debug());
+            ReadServer reader(timer, path, mesh, /*parallel_io=*/true, n_io);
+            reader.read_var<double>("iiceconc", 0, rt_view_ice);
+            reader.read_var<float>("votemper", 0, rt_view_temp);
+          }
+
+          // Compare on owned (non-ghost) nodes: the round-trip must be exact.
+          for (size_t inode = 0; inode < num_nodes; ++inode) {
+            if (ghost(inode)) continue;
+            EXPECT(rt_view_ice(inode, 0) == view_ice(inode, 0));
+            for (size_t lev = 0; lev < 3; ++lev) {
+              EXPECT(rt_view_temp(inode, lev) == view_temp(inode, lev));
+            }
+          }
+
+          atlas::mpi::comm().barrier();
+          if (atlas::mpi::rank() == 0) {
+            std::remove(path.fullName().asString().c_str());
+          }
         }
       }
     }

--- a/src/tests/orca-jedi/test_nemo_io_parallel_server.cc
+++ b/src/tests/orca-jedi/test_nemo_io_parallel_server.cc
@@ -1,0 +1,155 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "eckit/testing/Test.h"
+#include "eckit/log/Timer.h"
+#include "eckit/filesystem/PathName.h"
+
+#include "oops/util/DateTime.h"
+#include "oops/util/Logger.h"
+
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/array.h"  // IWYU pragma: keep
+#include "atlas/util/Config.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/mesh.h"  // IWYU pragma: keep
+#include "atlas/grid.h"  // IWYU pragma: keep
+#include "atlas/meshgenerator.h"  // IWYU pragma: keep
+#include "atlas/field/Field.h"
+
+#include "atlas-orca/grid/OrcaGrid.h"
+
+#include "orca-jedi/nemo_io/WriteServer.h"
+#include "orca-jedi/nemo_io/ReadServer.h"
+#include "orca-jedi/nemo_io/AtlasIndex.h"
+
+#include "tests/orca-jedi/OrcaModelTestEnvironment.h"
+
+namespace orcamodel {
+namespace test {
+
+//-----------------------------------------------------------------------------
+
+CASE("parallel WriteServer + ReadServer round-trip") {
+  const size_t nparts = atlas::mpi::size();
+  auto partitioner_names = std::vector<std::string>{"serial", "checkerboard"};
+  if (nparts == 1) {
+    partitioner_names = std::vector<std::string>{"serial"};
+  }
+
+  // Values are keyed on the global buffer index so that a node holds the same
+  // value regardless of which rank owns it. This makes the round-trip exact.
+  const auto surf_val = [](int64_t g) { return static_cast<double>(g) * 0.5 + 1.0; };
+  const auto vol_val = [](int64_t g, size_t lev) {
+    return static_cast<float>(static_cast<double>(g) * 0.25
+                              + static_cast<double>(lev) * 1000.0 + 2.0);
+  };
+
+  for (const std::string& partitioner_name : partitioner_names) {
+    atlas::OrcaGrid grid("ORCA2_T");
+    auto meshgen = atlas::MeshGenerator(grid.meshgenerator());
+    auto partitioner_config = grid.partitioner();
+    partitioner_config.set("type", partitioner_name);
+    auto partitioner = atlas::grid::Partitioner(partitioner_config);
+    auto mesh = meshgen.generate(grid, partitioner);
+    auto funcSpace = atlas::functionspace::NodeColumns(mesh);
+
+    std::unique_ptr<AtlasIndexToBufferIndex> atlas2buffer(
+        AtlasIndexToBufferIndexCreator::create_unique(grid.type(), mesh));
+    auto ghost = atlas::array::make_view<int32_t, 1>(mesh.nodes().ghost());
+
+    // Fields without missing_value metadata so values pass through untouched.
+    auto field_ice = funcSpace.createField<double>(
+        atlas::option::name("iiceconc") | atlas::option::levels(1));
+    auto field_temp = funcSpace.createField<float>(
+        atlas::option::name("votemper") | atlas::option::levels(3));
+    atlas::field::MissingValue ice_mv(field_ice);
+    atlas::field::MissingValue temp_mv(field_temp);
+
+    auto view_ice = atlas::array::make_view<double, 2>(field_ice);
+    auto view_temp = atlas::array::make_view<float, 2>(field_temp);
+
+    const size_t num_nodes = mesh.nodes().size();
+    for (size_t inode = 0; inode < num_nodes; ++inode) {
+      if (ghost(inode)) continue;
+      const int64_t g = (*atlas2buffer)(inode);
+      view_ice(inode, 0) = surf_val(g);
+      for (size_t lev = 0; lev < 3; ++lev) {
+        view_temp(inode, lev) = vol_val(g, lev);
+      }
+    }
+    funcSpace.haloExchange(field_ice);
+    funcSpace.haloExchange(field_temp);
+
+    std::vector<size_t> io_rank_options{0};   // 0 => every rank is an I/O rank
+    if (nparts > 1) io_rank_options.push_back(1);
+
+    for (size_t n_io : io_rank_options) {
+      SECTION(partitioner_name + "_" + std::to_string(nparts)
+              + " n_io=" + std::to_string(n_io)) {
+        const eckit::PathName path(std::string("../testoutput/parallel_roundtrip_")
+            + partitioner_name + "_" + std::to_string(nparts)
+            + "_nio" + std::to_string(n_io) + ".nc");
+        const std::vector<util::DateTime> datetimes{
+            util::DateTime("1970-01-01T00:00:00Z")};
+
+        // --- parallel write (scoped so the backend closes the file) ---
+        {
+          std::shared_ptr<eckit::Timer> timer = std::make_shared<eckit::Timer>(
+              "parallel_server write: ", oops::Log::debug());
+          WriteServer writer(timer, path, mesh, datetimes, {1.0, 2.0, 3.0},
+                             /*is_serial=*/false, /*parallel_io=*/true, n_io);
+          writer.write_surf_var<double>("iiceconc", 0, ice_mv, view_ice);
+          writer.write_vol_var<float>("votemper", 0, temp_mv, view_temp);
+        }
+        atlas::mpi::comm().barrier();
+
+        // --- parallel read-back into fresh fields ---
+        auto rt_ice = funcSpace.createField<double>(
+            atlas::option::name("iiceconc") | atlas::option::levels(1));
+        auto rt_temp = funcSpace.createField<float>(
+            atlas::option::name("votemper") | atlas::option::levels(3));
+        auto rt_view_ice = atlas::array::make_view<double, 2>(rt_ice);
+        auto rt_view_temp = atlas::array::make_view<float, 2>(rt_temp);
+
+        {
+          std::shared_ptr<eckit::Timer> timer = std::make_shared<eckit::Timer>(
+              "parallel_server read: ", oops::Log::debug());
+          ReadServer reader(timer, path, mesh, /*parallel_io=*/true, n_io);
+          reader.read_var<double>("iiceconc", 0, rt_view_ice);
+          reader.read_var<float>("votemper", 0, rt_view_temp);
+        }
+
+        // Compare on owned (non-ghost) nodes: the round-trip must be exact.
+        for (size_t inode = 0; inode < num_nodes; ++inode) {
+          if (ghost(inode)) continue;
+          EXPECT(rt_view_ice(inode, 0) == view_ice(inode, 0));
+          for (size_t lev = 0; lev < 3; ++lev) {
+            EXPECT(rt_view_temp(inode, lev) == view_temp(inode, lev));
+          }
+        }
+
+        atlas::mpi::comm().barrier();
+        if (atlas::mpi::rank() == 0) {
+          std::remove(path.fullName().asString().c_str());
+        }
+      }
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace orcamodel
+
+int main(int argc, char** argv) {
+  return orcamodel::test::run(argc, argv);
+}

--- a/src/tests/orca-jedi/test_nemo_io_read_server.cc
+++ b/src/tests/orca-jedi/test_nemo_io_read_server.cc
@@ -9,18 +9,18 @@
 
 #include "oops/util/DateTime.h"
 
-#include "atlas/parallel/mpi/mpi.h"
-#include "atlas/array.h"
+#include "atlas/parallel/mpi/mpi.h"  // IWYU pragma: keep
+#include "atlas/array.h"  // IWYU pragma: keep
 #include "atlas/util/Config.h"
 #include "atlas/functionspace/NodeColumns.h"
-#include "atlas/mesh.h"
-#include "atlas/grid.h"
-#include "atlas/meshgenerator.h"
+#include "atlas/mesh.h"  // IWYU pragma: keep
+#include "atlas/grid.h"  // IWYU pragma: keep
+#include "atlas/meshgenerator.h"  // IWYU pragma: keep
 #include "atlas/field/Field.h"
 
 #include "atlas-orca/grid/OrcaGrid.h"
 
-#include "eckit/exception/Exceptions.h"
+#include "eckit/exception/Exceptions.h"  // IWYU pragma: keep
 
 #include "orca-jedi/nemo_io/ReadServer.h"
 #include "orca-jedi/nemo_io/NemoFieldReader.h"

--- a/src/tests/orca-jedi/test_nemo_io_redistributor.cc
+++ b/src/tests/orca-jedi/test_nemo_io_redistributor.cc
@@ -1,0 +1,143 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ */
+
+#include <string>
+#include <vector>
+
+#include "eckit/testing/Test.h"
+
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/array.h"  // IWYU pragma: keep
+#include "atlas/grid.h"  // IWYU pragma: keep
+#include "atlas/mesh.h"  // IWYU pragma: keep
+#include "atlas/meshgenerator.h"  // IWYU pragma: keep
+
+#include "atlas-orca/grid/OrcaGrid.h"
+
+#include "orca-jedi/nemo_io/AtlasIndex.h"
+#include "orca-jedi/nemo_io/IoPool.h"
+#include "orca-jedi/nemo_io/Redistributor.h"
+#include "orca-jedi/nemo_io/SlabDecomposition.h"
+
+#include "tests/orca-jedi/OrcaModelTestEnvironment.h"
+
+namespace orcamodel {
+namespace test {
+
+//-----------------------------------------------------------------------------
+
+CASE("YBandDecomposition tiles the grid exactly once") {
+  const size_t nx = 10;
+  const size_t ny = 7;
+  for (size_t n_io : std::vector<size_t>{1, 2, 3, 7}) {
+    YBandDecomposition decomp(nx, ny, n_io);
+    EXPECT(decomp.n_io_ranks() == std::min(n_io, ny));
+
+    // Every global index is owned by exactly the slab that contains it.
+    std::vector<int> covered(nx * ny, 0);
+    for (size_t r = 0; r < decomp.n_io_ranks(); ++r) {
+      const Hyperslab slab = decomp.slab(r);
+      for (size_t g = slab.global_index_begin();
+           g < slab.global_index_begin() + slab.size(); ++g) {
+        EXPECT(decomp.owner(g) == r);
+        covered[g] += 1;
+      }
+    }
+    for (size_t g = 0; g < nx * ny; ++g) {
+      EXPECT(covered[g] == 1);
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+CASE("Redistributor compute<->IO round trip") {
+  auto partitioner_names = std::vector<std::string>{"serial", "checkerboard"};
+  const size_t nparts = atlas::mpi::size();
+  if (nparts == 1) {
+    partitioner_names = std::vector<std::string>{"serial"};
+  }
+
+  const std::string grid_name = "ORCA2_T";
+  const atlas::OrcaGrid grid{grid_name};
+
+  for (const std::string& partitioner_name : partitioner_names) {
+    auto meshgen_config = grid.meshgenerator();
+    atlas::MeshGenerator meshgen(meshgen_config);
+    auto partitioner_config = grid.partitioner();
+    partitioner_config.set("type", partitioner_name);
+    auto partitioner = atlas::grid::Partitioner(partitioner_config);
+    auto mesh = meshgen.generate(grid, partitioner);
+
+    std::unique_ptr<AtlasIndexToBufferIndex> atlas2buffer(
+        AtlasIndexToBufferIndexCreator::create_unique(grid.type(), mesh));
+
+    const size_t num_nodes = mesh.nodes().size();
+
+    // All local points (including ghost nodes) and their global buffer indices.
+    // Ghost nodes are required so that the ORCA halo buffer cells (east/west
+    // wrap and the north fold), which no non-ghost node maps to, are covered.
+    std::vector<size_t> node_index;
+    std::vector<size_t> global_index;
+    for (size_t inode = 0; inode < num_nodes; ++inode) {
+      node_index.emplace_back(inode);
+      global_index.emplace_back(static_cast<size_t>((*atlas2buffer)(inode)));
+    }
+
+    // A value that is a known function of the global index, so we can verify
+    // placement on the I/O side independently of the compute partition.
+    const auto expected = [](size_t g) { return static_cast<double>(g) * 0.5 + 1.0; };
+
+    std::vector<size_t> io_rank_counts{1};
+    if (nparts > 1) io_rank_counts.push_back(nparts);
+
+    for (size_t n_io : io_rank_counts) {
+      const std::string pool_name =
+          "test_pool_" + partitioner_name + "_" + std::to_string(n_io);
+      IoPool pool(atlas::mpi::comm(), n_io, atlas2buffer->nx(), atlas2buffer->ny(),
+                  pool_name);
+      Redistributor redist(atlas::mpi::comm(), pool, node_index, global_index);
+
+      // Fill a per-node buffer for the owned points.
+      std::vector<double> local(num_nodes, -999.0);
+      for (size_t k = 0; k < node_index.size(); ++k) {
+        local[node_index[k]] = expected(global_index[k]);
+      }
+
+      // compute -> IO
+      std::vector<double> slab;
+      redist.to_io(local, slab);
+
+      SECTION(partitioner_name + " n_io=" + std::to_string(n_io) + " slab placement") {
+        if (pool.is_io_rank()) {
+          const Hyperslab h = pool.decomposition().slab(pool.io_rank());
+          EXPECT(slab.size() == h.size());
+          for (size_t kk = 0; kk < slab.size(); ++kk) {
+            EXPECT(slab[kk] == expected(h.global_index_begin() + kk));
+          }
+        } else {
+          EXPECT(slab.empty());
+        }
+      }
+
+      // IO -> compute
+      SECTION(partitioner_name + " n_io=" + std::to_string(n_io) + " round trip") {
+        std::vector<double> local2(num_nodes, -111.0);
+        redist.from_io(slab, local2);
+        for (size_t k = 0; k < node_index.size(); ++k) {
+          EXPECT(local2[node_index[k]] == expected(global_index[k]));
+        }
+      }
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace orcamodel
+
+int main(int argc, char** argv) {
+  return orcamodel::test::run(argc, argv);
+}


### PR DESCRIPTION
## Summary

Adds an optional MPI-parallel path for reading and writing NEMO ORCA field files, so state I/O no longer has to funnel through the root rank. Both read and write are accelerated independently and are **off by default**, so existing behaviour is unchanged unless explicitly enabled. Adds an IO layer abstraction that should make addition of another IO backend (e.g. XIOS) easier if we decide to go that route in the future.

This also swaps the `netCDF-C++` dependency for `netCDF-C` to reduce dependencies.

## Motivation

On large grids (e.g. eORCA12, 75 levels) the previous read-on-root-and-broadcast / gather-on-root-and-write approach makes background-state I/O a serial bottleneck. This change lets a configurable subset of ranks read/write their own y-band of the file collectively via parallel netCDF (HDF5), which scales with the number of I/O ranks and maps cleanly onto Lustre striping.

## What's included

- **New parallel I/O building blocks**:
  - `IoPool` / `SlabDecomposition` - select a spread-out subset of ranks as I/O ranks and split off a sub-communicator; decompose the global grid into per-rank y-bands.
  - `Redistributor` - move field data between the model partition and the I/O y-band decomposition (covers all nodes incl. ghost/halo, tolerating the ORCA north-fold).
  - `IoBackend` - abstract read/write backend seam.
  - `ParallelNetCDFBackend` - concrete backend using `nc_create_par` / `nc_open_par` with collective hyperslab writes/reads.
- **Server rewiring:** `ReadServer` / `WriteServer` gain an opt-in parallel path; the legacy root path is retained as the default and non-MPI fallback.
- **netCDF-C++ → netCDF-C port** of `NemoFieldReader` / `NemoFieldWriter` (removes the `netcdf-cxx4` dependency; serial write now emits netCDF-4).
- **Output tuning:** variable chunking sized to the y-band decomposition, plus MPI-IO / Lustre hints and (opt-in, env-gated) reporting of the requested vs. effective striping so users can confirm what the I/O layer actually did.
- **North-fold/halo handling:** the parallel read/write redistribution skips ORCA north-fold ghost nodes that fall outside the file extent (via a new `maps_to_buffer` check), matching the serial path's ghost handling.

## Configuration

New geometry options (all default to the existing serial behaviour):

| Option | Default | Meaning |
|---|---|---|
| `parallel input` | `false` | Read via parallel netCDF instead of read-on-root. Requires an MPI run and a netCDF-4 input file. |
| `input io ranks` | `0` | Number of I/O ranks for reading (`0` = all ranks). |
| `parallel output` | `false` | Write via parallel netCDF instead of gather-on-root. Requires an MPI run. |
| `output io ranks` | `0` | Number of I/O ranks for writing (`0` = all ranks; tune towards filesystem stripe count). |

## Tests

New MPI-enabled unit tests (MPI1 + MPI2 variants):
- `test_nemo_io_redistributor` - partition to and from y-band redistribution coverage.
- `test_nemo_io_parallel_netcdf` - parallel-netCDF backend write/read round-trip against the NEMO layout.
- `test_nemo_io_parallel_server` - full parallel `WriteServer`/`ReadServer` round-trip on ORCA2_T (serial + checkerboard partitions, halo 0/1).

## Notes / limitations

- The parallel path assumes MPI is initialised (`nc_create_par`); toggles default off, and the serial path remains the non-MPI fallback.
- Parallel input requires netCDF-4/HDF5 input files; netCDF-3 inputs must use the serial reader.

## Issue(s) addressed

Resolves #196

## Impact

Performance impact measurements to follow.

## Checklist

- [ ] I have updated the unit tests to cover the change
- [ ] New functions are documented briefly via Doxygen comments in the code
- [ ] I have linted my code using cpplint
- [ ] I have run the unit tests
- [ ] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments
