### PR TITLE
Feature harden interpolation mask data model

### DIFF
--- a/src/mains/orcamodelRegrid.cc
+++ b/src/mains/orcamodelRegrid.cc
@@ -68,7 +68,7 @@
 ///   nemo variables:
 ///   - {name: sea_ice_area_fraction, nemo field name: iiceconc, model space: surface}
 ///   - {name: sea_water_potential_temperature, nemo field name: votemper, model space: volume}
-///   land sea mask:                # optional: build 3D vol_mask from ancillary
+///   land sea mask:                # optional: build 3D volume_mask from ancillary
 ///     filepath: path/to/target_ancillary.nc
 ///     variable: votemper          # field whose missing values define land
 /// interpolation method:
@@ -108,7 +108,7 @@
 ///
 /// \note The "land sea mask" section is optional within a geometry config.
 ///   It reads a volumetric field from a NetCDF ancillary on the grid,
-///   derives a 3D land-sea mask (vol_mask) from that field's missing values,
+///   derives a 3D land-sea mask (volume_mask) from that field's missing values,
 ///   and stores it in the geometry's extra fields. When present on the
 ///   target geometry, regridded results are automatically re-masked per
 ///   depth level. This also works in the State resolution-change constructor.
@@ -156,7 +156,7 @@ class OrcaModelRegrid : public oops::Application {
     if (conf.has("target geometry")) {
       // ORCA target: build full geometry (enables writing via NemoFieldWriter)
       // If the target geometry config contains a "land sea mask" section,
-      // the Geometry constructor reads the ancillary and populates vol_mask.
+      // the Geometry constructor reads the ancillary and populates volume_mask.
       eckit::LocalConfiguration targetGeomConf(conf, "target geometry");
       targetGeomPtr = std::make_unique<orcamodel::Geometry>(
           targetGeomConf, getComm());
@@ -247,13 +247,13 @@ class OrcaModelRegrid : public oops::Application {
                         << " datatype=" << f.datatype().str() << std::endl;
     }
 
-    // 5b. Apply target vol_mask if the target geometry has one configured.
-    //     The Geometry constructor reads the ancillary and populates vol_mask
+    // 5b. Apply target volume_mask if the target geometry has one configured.
+    //     The Geometry constructor reads the ancillary and populates volume_mask
     //     when a "land sea mask" section is present in the geometry config.
     if (targetGeomPtr
-        && targetGeomPtr->extraFields().has("vol_mask")) {
+        && targetGeomPtr->extraFields().has("volume_mask")) {
       orcamodel::applyMaskToFields(
-          targetGeomPtr->extraFields().field("vol_mask"), result);
+          targetGeomPtr->extraFields().field("volume_mask"), result);
     }
 
     // 6. Write output
@@ -321,7 +321,7 @@ Configuration sections:
     nemo variables:
     - {name: sea_water_potential_temperature, nemo field name: votemper,
        model space: volume}
-    land sea mask:                 #   Optional: build 3D vol_mask from ancillary
+    land sea mask:                 #   Optional: build 3D volume_mask from ancillary
       filepath: /path/to/ancillary.nc  # NetCDF file on this grid
       variable: votemper           #   Field whose missing values define land
 
@@ -351,7 +351,7 @@ Notes:
     target ocean points whose interpolation stencil falls entirely on source land.
     This is analogous to NEMOVAR's sim_ext module.
   - The 'land sea mask' section can be added to any geometry configuration. It reads
-    a volumetric field from an ancillary file and derives a 3D land-sea mask (vol_mask)
+    a volumetric field from an ancillary file and derives a 3D land-sea mask (volume_mask)
     from its missing values. When present on a target geometry, regridded results are
     automatically re-masked per depth level. This also applies in the State
     resolution-change constructor for JEDI DA workflows.

--- a/src/orca-jedi/geometry/Geometry.cc
+++ b/src/orca-jedi/geometry/Geometry.cc
@@ -5,6 +5,7 @@
 #include "orca-jedi/geometry/Geometry.h"
 
 #include <algorithm>
+#include <cmath>
 
 #include "atlas/field/Field.h"
 #include "atlas/field/FieldSet.h"
@@ -132,9 +133,10 @@ Geometry::Geometry(const eckit::Configuration & config,
       const auto& lsm = *params_.landSeaMask.value();
       const std::string maskFile = lsm.filepath.value();
       const std::string maskVar = lsm.variable.value();
+      const std::string maskType = lsm.type.value();
       oops::Log::info() << "Geometry: reading land-sea mask from '"
                         << maskFile << "' variable '" << maskVar
-                        << "'" << std::endl;
+                        << "' (type '" << maskType << "')" << std::endl;
 
       atlas::Field maskField = funcSpace_.createField<float>(
           atlas::option::name(maskVar)
@@ -144,13 +146,23 @@ Geometry::Geometry(const eckit::Configuration & config,
                           eckit::PathName(maskFile), mesh_);
         auto field_view = atlas::array::make_view<float, 2>(maskField);
         reader.read_var<float>(maskVar, 0, field_view);
-        float fill = reader.read_fillvalue<float>(maskVar);
-        maskField.metadata().set("missing_value", fill);
-        maskField.metadata().set("missing_value_type",
-                                 "approximately-equals");
-        maskField.metadata().set("missing_value_epsilon", 1e-6);
+        if (maskType == "missing value") {
+          float fill = reader.read_fillvalue<float>(maskVar);
+          maskField.metadata().set("missing_value", fill);
+          maskField.metadata().set("missing_value_type",
+                                   "approximately-equals");
+          maskField.metadata().set("missing_value_epsilon", 1e-6);
+        }
       }
-      set_volume_mask(maskField);
+      if (maskType == "bitmask") {
+        set_volume_mask_from_bitmask(maskField, lsm.landValue.value());
+      } else if (maskType == "missing value") {
+        set_volume_mask(maskField);
+      } else {
+        throw eckit::BadValue(
+            "orcamodel::Geometry: unknown 'land sea mask' type '" + maskType
+            + "', expected 'missing value' or 'bitmask'", Here());
+      }
       oops::Log::info() << "Geometry: volume_mask derived from '"
                         << maskVar << "'" << std::endl;
     }
@@ -464,26 +476,13 @@ void Geometry::set_gmask(atlas::Field & field) const {
   log_status();
 }
 
-/// \brief Create or update the volume_mask extra field from a volumetric
-///        field's missing values.
+/// \brief Lazily create the volume_mask extra field, initialised to ocean (1)
+///        everywhere (including ghost/halo nodes), and return it.
 ///
-/// If volume_mask does not yet exist in extraFields, it is created lazily with
-/// shape (nNodes, nLevels) and initialised to 1 (ocean) everywhere - including
-/// ghost/halo nodes.  Then, wherever the input field has a missing value on an
-/// owned node, the corresponding (node, level) entry is set to 0 (masked).
-/// Finally a haloExchange synchronises ghost/halo nodes from their owning rank
-/// so the mask reflects the true bathymetry across MPI halos (required for
-/// interpolation stencils that reach into the halo).  Repeated calls accumulate
-/// masking (the union of land across fields); they never un-mask a node.
-///
-/// \param[in] field  A volumetric atlas::Field on the same function space.
-///                   Must have missing_value metadata set.
-void Geometry::set_volume_mask(atlas::Field & field) {
-  oops::Log::debug() << "orcamodel::Geometry setting volume_mask from field "
-                     << field.name() << " missing values" << std::endl;
-
-  // Lazily create volume_mask if it doesn't exist yet, initialised to ocean (1)
-  // everywhere.  Ghost/halo nodes are populated by haloExchange below.
+/// The field has shape (nNodes, nLevels). Ghost/halo nodes are populated to
+/// the correct bathymetry by the haloExchange performed by the callers that
+/// set the mask.
+atlas::Field Geometry::ensure_volume_mask() {
   if (!extraFields_.has("volume_mask")) {
     atlas::Field volume_mask = funcSpace_.createField<int32_t>(
         atlas::option::name("volume_mask")
@@ -499,8 +498,28 @@ void Geometry::set_volume_mask(atlas::Field & field) {
                        << vm.shape(0) << " nodes, "
                        << vm.shape(1) << " levels)." << std::endl;
   }
+  return extraFields_.field("volume_mask");
+}
 
-  atlas::Field volume_mask = extraFields_.field("volume_mask");
+/// \brief Create or update the volume_mask extra field from a volumetric
+///        field's missing values.
+///
+/// volume_mask is created lazily and initialised to 1 (ocean) everywhere -
+/// including ghost/halo nodes.  Then, wherever the input field has a missing
+/// value on an owned node, the corresponding (node, level) entry is set to 0
+/// (masked).  Finally a haloExchange synchronises ghost/halo nodes from their
+/// owning rank so the mask reflects the true bathymetry across MPI halos
+/// (required for interpolation stencils that reach into the halo).  Repeated
+/// calls accumulate masking (the union of land across fields); they never
+/// un-mask a node.
+///
+/// \param[in] field  A volumetric atlas::Field on the same function space.
+///                   Must have missing_value metadata set.
+void Geometry::set_volume_mask(atlas::Field & field) {
+  oops::Log::debug() << "orcamodel::Geometry setting volume_mask from field "
+                     << field.name() << " missing values" << std::endl;
+
+  atlas::Field volume_mask = ensure_volume_mask();
   auto mask_view = atlas::array::make_view<int32_t, 2>(volume_mask);
 
   atlas::field::MissingValue mv(field);
@@ -541,6 +560,66 @@ void Geometry::set_volume_mask(atlas::Field & field) {
                          << field.name()
                          << "' has unsupported datatype, skipping"
                          << std::endl;
+    return;
+  }
+
+  // Synchronise ghost/halo nodes so the mask is halo-consistent.
+  funcSpace_.haloExchange(volume_mask);
+  log_status();
+}
+
+/// \brief Create or update the volume_mask extra field directly from an
+///        explicit land-sea bitmask field.
+///
+/// Unlike set_volume_mask (which derives land from missing values), this reads
+/// the field's values directly: owned (node, level) entries whose value is
+/// approximately equal to \p landValue are treated as land (mask 0); all
+/// others are ocean (mask 1).  As with set_volume_mask, volume_mask is created
+/// lazily, ghost/halo nodes are synchronised via haloExchange, and repeated
+/// calls accumulate masking and never un-mask a node.
+///
+/// \param[in] field      A land-sea mask atlas::Field on the same function
+///                       space (real32 or real64).
+/// \param[in] landValue  The field value that denotes land (default 0).
+void Geometry::set_volume_mask_from_bitmask(atlas::Field & field,
+                                            double landValue) {
+  oops::Log::debug() << "orcamodel::Geometry setting volume_mask from bitmask "
+                     << "field " << field.name() << " (land value "
+                     << landValue << ")" << std::endl;
+
+  atlas::Field volume_mask = ensure_volume_mask();
+  auto mask_view = atlas::array::make_view<int32_t, 2>(volume_mask);
+
+  const auto ghost = atlas::array::make_view<int32_t, 1>(
+      mesh_.nodes().ghost());
+
+  const auto setMask = [&](auto typeVal) {
+    using T = decltype(typeVal);
+    auto field_view = atlas::array::make_view<T, 2>(field);
+    const atlas::idx_t nLevels = std::min(field_view.shape(1),
+                                          mask_view.shape(1));
+    ASSERT(field_view.shape(0) == mask_view.shape(0));
+    const T land = static_cast<T>(landValue);
+    const T half = static_cast<T>(0.5);
+    // Only mask owned nodes; ghost nodes are synchronised via haloExchange.
+    for (atlas::idx_t j = 0; j < field_view.shape(0); ++j) {
+      if (ghost(j)) continue;
+      for (atlas::idx_t k = 0; k < nLevels; ++k) {
+        if (std::abs(field_view(j, k) - land) < half) {
+          mask_view(j, k) = 0;
+        }
+      }
+    }
+  };
+
+  if (field.datatype() == atlas::array::DataType::real64()) {
+    setMask(double{});
+  } else if (field.datatype() == atlas::array::DataType::real32()) {
+    setMask(float{});
+  } else {
+    oops::Log::warning()
+        << "orcamodel::Geometry::set_volume_mask_from_bitmask: field '"
+        << field.name() << "' has unsupported datatype, skipping" << std::endl;
     return;
   }
 

--- a/src/orca-jedi/geometry/Geometry.cc
+++ b/src/orca-jedi/geometry/Geometry.cc
@@ -124,11 +124,11 @@ Geometry::Geometry(const eckit::Configuration & config,
       create_extrafields();
     }
 
-    // If a land-sea mask ancillary is configured, create and populate vol_mask
+    // If a land-sea mask ancillary is configured, create and populate
+    // volume_mask.  This is independent of the BUMP/SABER extra fields: the
+    // mask is added directly to extraFields_ and does not require (nor trigger)
+    // create_extrafields().
     if (params_.landSeaMask.value()) {
-      if (!params_.extraFieldsInit.value().value_or(false)) {
-        create_extrafields();
-      }
       const auto& lsm = *params_.landSeaMask.value();
       const std::string maskFile = lsm.filepath.value();
       const std::string maskVar = lsm.variable.value();
@@ -150,8 +150,8 @@ Geometry::Geometry(const eckit::Configuration & config,
                                  "approximately-equals");
         maskField.metadata().set("missing_value_epsilon", 1e-6);
       }
-      set_vol_mask(maskField);
-      oops::Log::info() << "Geometry: vol_mask derived from '"
+      set_volume_mask(maskField);
+      oops::Log::info() << "Geometry: volume_mask derived from '"
                         << maskVar << "'" << std::endl;
     }
 }
@@ -464,60 +464,56 @@ void Geometry::set_gmask(atlas::Field & field) const {
   log_status();
 }
 
-/// \brief Create or update the vol_mask extra field from a volumetric field's
-///        missing values.
+/// \brief Create or update the volume_mask extra field from a volumetric
+///        field's missing values.
 ///
-/// If vol_mask does not yet exist in extraFields, it is created with shape
-/// (nNodes, nLevels) and initialised to 1 (ocean) for owned nodes and 0 for
-/// ghost/edge nodes.  Then, wherever the input field has a missing value, the
-/// corresponding (node, level) entry is set to 0 (masked).
+/// If volume_mask does not yet exist in extraFields, it is created lazily with
+/// shape (nNodes, nLevels) and initialised to 1 (ocean) everywhere - including
+/// ghost/halo nodes.  Then, wherever the input field has a missing value on an
+/// owned node, the corresponding (node, level) entry is set to 0 (masked).
+/// Finally a haloExchange synchronises ghost/halo nodes from their owning rank
+/// so the mask reflects the true bathymetry across MPI halos (required for
+/// interpolation stencils that reach into the halo).  Repeated calls accumulate
+/// masking (the union of land across fields); they never un-mask a node.
 ///
 /// \param[in] field  A volumetric atlas::Field on the same function space.
 ///                   Must have missing_value metadata set.
-void Geometry::set_vol_mask(atlas::Field & field) {
-  oops::Log::debug() << "orcamodel::Geometry setting vol_mask from field "
+void Geometry::set_volume_mask(atlas::Field & field) {
+  oops::Log::debug() << "orcamodel::Geometry setting volume_mask from field "
                      << field.name() << " missing values" << std::endl;
 
-  // Create vol_mask if it doesn't exist yet
-  if (!extraFields_.has("vol_mask")) {
-    atlas::OrcaGrid orcaGrid = mesh_.grid();
-    int nx = orcaGrid.nx() + orcaGrid.haloWest() + orcaGrid.haloEast();
-    int ny = orcaGrid.ny() + orcaGrid.haloNorth();
-    auto ghost = atlas::array::make_view<int32_t, 1>(
-        mesh_.nodes().ghost());
-    auto ij = atlas::array::make_view<int32_t, 2>(
-        mesh_.nodes().field("ij"));
-
-    atlas::Field vol_mask = funcSpace_.createField<int32_t>(
-        atlas::option::name("vol_mask")
+  // Lazily create volume_mask if it doesn't exist yet, initialised to ocean (1)
+  // everywhere.  Ghost/halo nodes are populated by haloExchange below.
+  if (!extraFields_.has("volume_mask")) {
+    atlas::Field volume_mask = funcSpace_.createField<int32_t>(
+        atlas::option::name("volume_mask")
         | atlas::option::levels(n_levels_));
-    auto vm = atlas::array::make_view<int32_t, 2>(vol_mask);
+    auto vm = atlas::array::make_view<int32_t, 2>(volume_mask);
     for (atlas::idx_t j = 0; j < vm.shape(0); ++j) {
-      int x = ij(j, 0) + 1;
-      int y = ij(j, 1) + 1;
-      int32_t val =
-          (ghost(j) || x >= nx - 1 || y >= ny - 1) ? 0 : 1;
       for (atlas::idx_t k = 0; k < vm.shape(1); ++k) {
-        vm(j, k) = val;
+        vm(j, k) = 1;
       }
     }
-    extraFields_->add(vol_mask);
-    oops::Log::debug() << "orcamodel::Geometry: created vol_mask ("
+    extraFields_->add(volume_mask);
+    oops::Log::debug() << "orcamodel::Geometry: created volume_mask ("
                        << vm.shape(0) << " nodes, "
                        << vm.shape(1) << " levels)." << std::endl;
   }
 
-  atlas::Field vol_mask = extraFields_.field("vol_mask");
-  auto mask_view = atlas::array::make_view<int32_t, 2>(vol_mask);
+  atlas::Field volume_mask = extraFields_.field("volume_mask");
+  auto mask_view = atlas::array::make_view<int32_t, 2>(volume_mask);
 
   atlas::field::MissingValue mv(field);
   if (!mv) {
-    oops::Log::warning() << "orcamodel::Geometry::set_vol_mask: field '"
+    oops::Log::warning() << "orcamodel::Geometry::set_volume_mask: field '"
                          << field.name()
                          << "' has no missing_value metadata, skipping"
                          << std::endl;
     return;
   }
+
+  const auto ghost = atlas::array::make_view<int32_t, 1>(
+      mesh_.nodes().ghost());
 
   const auto setMask = [&](auto typeVal) {
     using T = decltype(typeVal);
@@ -525,9 +521,11 @@ void Geometry::set_vol_mask(atlas::Field & field) {
     const atlas::idx_t nLevels = std::min(field_view.shape(1),
                                           mask_view.shape(1));
     ASSERT(field_view.shape(0) == mask_view.shape(0));
+    // Only mask owned nodes; ghost nodes are synchronised via haloExchange.
     for (atlas::idx_t j = 0; j < field_view.shape(0); ++j) {
+      if (ghost(j)) continue;
       for (atlas::idx_t k = 0; k < nLevels; ++k) {
-        if (mask_view(j, k) == 1 && mv(field_view(j, k))) {
+        if (mv(field_view(j, k))) {
           mask_view(j, k) = 0;
         }
       }
@@ -539,11 +537,15 @@ void Geometry::set_vol_mask(atlas::Field & field) {
   } else if (field.datatype() == atlas::array::DataType::real32()) {
     setMask(float{});
   } else {
-    oops::Log::warning() << "orcamodel::Geometry::set_vol_mask: field '"
+    oops::Log::warning() << "orcamodel::Geometry::set_volume_mask: field '"
                          << field.name()
                          << "' has unsupported datatype, skipping"
                          << std::endl;
+    return;
   }
+
+  // Synchronise ghost/halo nodes so the mask is halo-consistent.
+  funcSpace_.haloExchange(volume_mask);
   log_status();
 }
 

--- a/src/orca-jedi/geometry/Geometry.h
+++ b/src/orca-jedi/geometry/Geometry.h
@@ -76,8 +76,10 @@ class Geometry : public util::Printable,
   void log_status() const;
   void set_gmask(atlas::Field &) const;
   void set_volume_mask(atlas::Field &);
+  void set_volume_mask_from_bitmask(atlas::Field &, double landValue = 0.0);
 
  private:
+  atlas::Field ensure_volume_mask();
   void print(std::ostream &) const;
   const eckit::mpi::Comm & comm_;
   oops::Variables vars_;

--- a/src/orca-jedi/geometry/Geometry.h
+++ b/src/orca-jedi/geometry/Geometry.h
@@ -75,7 +75,7 @@ class Geometry : public util::Printable,
   std::shared_ptr<eckit::Timer> timer() const {return eckit_timer_;}
   void log_status() const;
   void set_gmask(atlas::Field &) const;
-  void set_vol_mask(atlas::Field &);
+  void set_volume_mask(atlas::Field &);
 
  private:
   void print(std::ostream &) const;

--- a/src/orca-jedi/geometry/GeometryParameters.h
+++ b/src/orca-jedi/geometry/GeometryParameters.h
@@ -37,16 +37,30 @@ class NemoFieldParameters : public oops::Parameters {
 
 /// \brief Optional parameters for reading a land-sea mask ancillary.
 ///
-/// When specified in the geometry configuration, a volumetric field is read
-/// from the given NetCDF file and its missing values are used to populate
-/// the 3D volume_mask extra field. This makes the mask available to any code
-/// that uses the geometry (e.g. State resolution-change constructor).
+/// When specified in the geometry configuration, a field is read from the
+/// given NetCDF file and used to populate the 3D volume_mask extra field. Two
+/// modes are supported via "type":
+///   - "missing value" (default): the field is a data field and its missing
+///     values define the land points.
+///   - "bitmask": the field is an explicit land-sea mask; entries approximately
+///     equal to "land value" (default 0) are land, all others are ocean.
+/// This makes the mask available to any code that uses the geometry
+/// (e.g. State resolution-change constructor).
 class LandSeaMaskParameters : public oops::Parameters {
   OOPS_CONCRETE_PARAMETERS(LandSeaMaskParameters, oops::Parameters)
 
  public:
   oops::RequiredParameter<std::string> filepath {"filepath", this};
   oops::RequiredParameter<std::string> variable {"variable", this};
+  oops::Parameter<std::string> type {"type",
+    "How to derive the mask from the variable: 'missing value' (mask where the"
+    " field is missing, the default) or 'bitmask' (use the field values"
+    " directly).",
+    "missing value", this};
+  oops::Parameter<double> landValue {"land value",
+    "For type 'bitmask', field values approximately equal to this are treated"
+    " as land (masked). Default 0.",
+    0.0, this};
 };
 
 class OrcaGeometryParameters : public oops::Parameters {

--- a/src/orca-jedi/geometry/GeometryParameters.h
+++ b/src/orca-jedi/geometry/GeometryParameters.h
@@ -39,7 +39,7 @@ class NemoFieldParameters : public oops::Parameters {
 ///
 /// When specified in the geometry configuration, a volumetric field is read
 /// from the given NetCDF file and its missing values are used to populate
-/// the 3D vol_mask extra field. This makes the mask available to any code
+/// the 3D volume_mask extra field. This makes the mask available to any code
 /// that uses the geometry (e.g. State resolution-change constructor).
 class LandSeaMaskParameters : public oops::Parameters {
   OOPS_CONCRETE_PARAMETERS(LandSeaMaskParameters, oops::Parameters)

--- a/src/orca-jedi/state/State.cc
+++ b/src/orca-jedi/state/State.cc
@@ -147,8 +147,8 @@ State::State(const Geometry & resol, const State & other)
     stateFields_ = regridder.execute(extendedSource);
 
     // 4. Re-mask with target geometry's land-sea mask
-    if (resol.extraFields().has("vol_mask")) {
-      applyMaskToFields(resol.extraFields().field("vol_mask"), stateFields_);
+    if (resol.extraFields().has("volume_mask")) {
+      applyMaskToFields(resol.extraFields().field("volume_mask"), stateFields_);
     }
 
     oops::Log::trace() << "State(ORCA)::State resolution change: "

--- a/src/tests/orca-jedi/test_geometry.cc
+++ b/src/tests/orca-jedi/test_geometry.cc
@@ -172,7 +172,7 @@ CASE("test basic geometry") {
     EXPECT(extraFieldNames.size() == num_matches);
   }
 
-  SECTION("test vol_mask not created without land sea mask config") {
+  SECTION("test volume_mask not created without land sea mask config") {
     eckit::LocalConfiguration config2;
     config2.set("nemo variables", nemo_var_mappings);
     config2.set("grid name", "ORCA2_T");
@@ -180,10 +180,38 @@ CASE("test basic geometry") {
     config2.set("initialise extra fields", true);
     Geometry geometry2(config2, eckit::mpi::comm());
     const atlas::FieldSet& ef = geometry2.extraFields();
-    EXPECT(!ef.has("vol_mask"));
+    EXPECT(!ef.has("volume_mask"));
   }
 
-  SECTION("test set_vol_mask creates and populates vol_mask") {
+  SECTION("test volume_mask is independent of BUMP extra fields") {
+    // No "initialise extra fields": BUMP fields (gmask etc.) are not built,
+    // but set_volume_mask must still be able to create volume_mask.
+    eckit::LocalConfiguration config2;
+    config2.set("nemo variables", nemo_var_mappings);
+    config2.set("grid name", "ORCA2_T");
+    config2.set("number levels", 3);
+    Geometry geometry2(config2, eckit::mpi::comm());
+
+    atlas::Field field =
+        geometry2.functionSpace().createField<double>(
+            atlas::option::name("test_field")
+            | atlas::option::levels(3));
+    const double fill = -999.0;
+    field.metadata().set("missing_value", fill);
+    field.metadata().set("missing_value_type", "equals");
+    auto fview = atlas::array::make_view<double, 2>(field);
+    for (atlas::idx_t j = 0; j < fview.shape(0); ++j) {
+      for (atlas::idx_t k = 0; k < 3; ++k) { fview(j, k) = 1.0; }
+    }
+
+    geometry2.set_volume_mask(field);
+
+    const atlas::FieldSet& ef = geometry2.extraFields();
+    EXPECT(ef.has("volume_mask"));
+    EXPECT(!ef.has("gmask"));
+  }
+
+  SECTION("test set_volume_mask creates and populates volume_mask") {
     eckit::LocalConfiguration config2;
     config2.set("nemo variables", nemo_var_mappings);
     config2.set("grid name", "ORCA2_T");
@@ -191,8 +219,8 @@ CASE("test basic geometry") {
     config2.set("initialise extra fields", true);
     Geometry geometry2(config2, eckit::mpi::comm());
 
-    // vol_mask should not exist yet
-    EXPECT(!geometry2.extraFields().has("vol_mask"));
+    // volume_mask should not exist yet
+    EXPECT(!geometry2.extraFields().has("volume_mask"));
 
     // Create a field with missing values at certain (node,level) entries
     atlas::Field field =
@@ -220,19 +248,100 @@ CASE("test basic geometry") {
     EXPECT(testNode >= 0);
     fview(testNode, 1) = fill;  // mark level 1 as missing
 
-    // set_vol_mask should create and populate the field
-    geometry2.set_vol_mask(field);
+    // set_volume_mask should create and populate the field
+    geometry2.set_volume_mask(field);
 
-    // vol_mask should now exist
-    EXPECT(geometry2.extraFields().has("vol_mask"));
+    // volume_mask should now exist
+    EXPECT(geometry2.extraFields().has("volume_mask"));
     auto vm = atlas::array::make_view<int32_t, 2>(
-        geometry2.extraFields().field("vol_mask"));
+        geometry2.extraFields().field("volume_mask"));
     EXPECT(vm.shape(1) == 3);
 
     // testNode: levels 0,2 should be ocean (1), level 1 masked (0)
     EXPECT(vm(testNode, 0) == 1);
     EXPECT(vm(testNode, 1) == 0);
     EXPECT(vm(testNode, 2) == 1);
+  }
+
+  SECTION("test volume_mask is ocean on ghost nodes when unmasked") {
+    // Halo-aware: with no missing values, every node - including ghost/halo
+    // nodes - must be ocean (1). The old implementation force-zeroed ghost
+    // and edge nodes; the hardened implementation must not.
+    eckit::LocalConfiguration config2;
+    config2.set("nemo variables", nemo_var_mappings);
+    config2.set("grid name", "ORCA2_T");
+    config2.set("number levels", 3);
+    Geometry geometry2(config2, eckit::mpi::comm());
+
+    atlas::Field field =
+        geometry2.functionSpace().createField<double>(
+            atlas::option::name("test_field")
+            | atlas::option::levels(3));
+    const double fill = -999.0;
+    field.metadata().set("missing_value", fill);
+    field.metadata().set("missing_value_type", "equals");
+    auto fview = atlas::array::make_view<double, 2>(field);
+    for (atlas::idx_t j = 0; j < fview.shape(0); ++j) {
+      for (atlas::idx_t k = 0; k < 3; ++k) { fview(j, k) = 1.0; }
+    }
+
+    geometry2.set_volume_mask(field);
+
+    auto vm = atlas::array::make_view<int32_t, 2>(
+        geometry2.extraFields().field("volume_mask"));
+    // Every node ocean, and at least one ghost node exists to exercise the halo.
+    auto ghost = atlas::array::make_view<int32_t, 1>(
+        geometry2.mesh().nodes().ghost());
+    bool sawGhost = false;
+    bool allOcean = true;
+    for (atlas::idx_t j = 0; j < vm.shape(0); ++j) {
+      if (ghost(j)) sawGhost = true;
+      for (atlas::idx_t k = 0; k < vm.shape(1); ++k) {
+        if (vm(j, k) != 1) allOcean = false;
+      }
+    }
+    EXPECT(sawGhost);
+    EXPECT(allOcean);
+  }
+
+  SECTION("test volume_mask halo exchange propagates to ghost nodes") {
+    // Mask every owned node at level 0. After the internal haloExchange, every
+    // node (including ghost/halo nodes, which mirror owned nodes) must be
+    // masked at level 0.
+    eckit::LocalConfiguration config2;
+    config2.set("nemo variables", nemo_var_mappings);
+    config2.set("grid name", "ORCA2_T");
+    config2.set("number levels", 3);
+    Geometry geometry2(config2, eckit::mpi::comm());
+
+    atlas::Field field =
+        geometry2.functionSpace().createField<double>(
+            atlas::option::name("test_field")
+            | atlas::option::levels(3));
+    const double fill = -999.0;
+    field.metadata().set("missing_value", fill);
+    field.metadata().set("missing_value_type", "equals");
+    auto fview = atlas::array::make_view<double, 2>(field);
+    auto ghost = atlas::array::make_view<int32_t, 1>(
+        geometry2.mesh().nodes().ghost());
+    for (atlas::idx_t j = 0; j < fview.shape(0); ++j) {
+      for (atlas::idx_t k = 0; k < 3; ++k) {
+        // Missing at level 0 on owned nodes; ocean elsewhere. Ghost node
+        // field values are intentionally left as-is to prove the mask on
+        // ghosts comes from haloExchange, not from the ghost field values.
+        fview(j, k) = (k == 0 && ghost(j) == 0) ? fill : 1.0;
+      }
+    }
+
+    geometry2.set_volume_mask(field);
+
+    auto vm = atlas::array::make_view<int32_t, 2>(
+        geometry2.extraFields().field("volume_mask"));
+    for (atlas::idx_t j = 0; j < vm.shape(0); ++j) {
+      EXPECT(vm(j, 0) == 0);  // masked on all nodes, incl. ghosts, via halo
+      EXPECT(vm(j, 1) == 1);
+      EXPECT(vm(j, 2) == 1);
+    }
   }
 }
 

--- a/src/tests/orca-jedi/test_geometry.cc
+++ b/src/tests/orca-jedi/test_geometry.cc
@@ -304,6 +304,82 @@ CASE("test basic geometry") {
     EXPECT(allOcean);
   }
 
+  SECTION("test set_volume_mask_from_bitmask marks land by value") {
+    eckit::LocalConfiguration config2;
+    config2.set("nemo variables", nemo_var_mappings);
+    config2.set("grid name", "ORCA2_T");
+    config2.set("number levels", 3);
+    Geometry geometry2(config2, eckit::mpi::comm());
+
+    // Explicit bitmask field: 1 = ocean, 0 = land (NEMO tmask convention).
+    atlas::Field field =
+        geometry2.functionSpace().createField<double>(
+            atlas::option::name("tmask")
+            | atlas::option::levels(3));
+    auto fview = atlas::array::make_view<double, 2>(field);
+    auto ghost = atlas::array::make_view<int32_t, 1>(
+        geometry2.mesh().nodes().ghost());
+    atlas::idx_t oceanNode = -1;
+    atlas::idx_t landNode = -1;
+    for (atlas::idx_t j = 0; j < fview.shape(0); ++j) {
+      const bool isGhost = ghost(j) != 0;
+      // Make even owned nodes ocean, odd owned nodes land at level 0.
+      for (atlas::idx_t k = 0; k < 3; ++k) { fview(j, k) = 1.0; }
+      if (!isGhost && (j % 2 == 1)) {
+        fview(j, 0) = 0.0;  // land at surface
+        if (landNode < 0) landNode = j;
+      } else if (!isGhost && oceanNode < 0) {
+        oceanNode = j;
+      }
+    }
+    EXPECT(oceanNode >= 0);
+    EXPECT(landNode >= 0);
+
+    // land value defaults to 0.
+    geometry2.set_volume_mask_from_bitmask(field);
+
+    EXPECT(geometry2.extraFields().has("volume_mask"));
+    auto vm = atlas::array::make_view<int32_t, 2>(
+        geometry2.extraFields().field("volume_mask"));
+    EXPECT(vm(oceanNode, 0) == 1);
+    EXPECT(vm(landNode, 0) == 0);
+    EXPECT(vm(landNode, 1) == 1);  // only surface flagged land
+  }
+
+  SECTION("test set_volume_mask_from_bitmask honours land value") {
+    eckit::LocalConfiguration config2;
+    config2.set("nemo variables", nemo_var_mappings);
+    config2.set("grid name", "ORCA2_T");
+    config2.set("number levels", 3);
+    Geometry geometry2(config2, eckit::mpi::comm());
+
+    // Inverted convention: 1 = land, 2 = ocean. land value = 1.
+    atlas::Field field =
+        geometry2.functionSpace().createField<float>(
+            atlas::option::name("mask")
+            | atlas::option::levels(3));
+    auto fview = atlas::array::make_view<float, 2>(field);
+    auto ghost = atlas::array::make_view<int32_t, 1>(
+        geometry2.mesh().nodes().ghost());
+    atlas::idx_t landNode = -1;
+    for (atlas::idx_t j = 0; j < fview.shape(0); ++j) {
+      for (atlas::idx_t k = 0; k < 3; ++k) { fview(j, k) = 2.0f; }  // ocean
+      if (ghost(j) == 0 && landNode < 0) {
+        landNode = j;
+        fview(j, 2) = 1.0f;  // land at deepest level
+      }
+    }
+    EXPECT(landNode >= 0);
+
+    geometry2.set_volume_mask_from_bitmask(field, 1.0);
+
+    auto vm = atlas::array::make_view<int32_t, 2>(
+        geometry2.extraFields().field("volume_mask"));
+    EXPECT(vm(landNode, 0) == 1);
+    EXPECT(vm(landNode, 1) == 1);
+    EXPECT(vm(landNode, 2) == 0);  // masked where value == land value (1)
+  }
+
   SECTION("test volume_mask halo exchange propagates to ghost nodes") {
     // Mask every owned node at level 0. After the internal haloExchange, every
     // node (including ghost/halo nodes, which mirror owned nodes) must be

--- a/src/tests/orca-jedi/test_mask_utils.cc
+++ b/src/tests/orca-jedi/test_mask_utils.cc
@@ -85,7 +85,7 @@ CASE("test applyMaskToFields volumetric mask per-level") {
   // Create a volumetric mask (nNodes, 3):
   // level 0: all ocean (1), level 1: mask odd nodes, level 2: all masked (0)
   atlas::Field mask = funcSpace.createField<int32_t>(
-      atlas::option::name("vol_mask") | atlas::option::levels(nLevels));
+      atlas::option::name("volume_mask") | atlas::option::levels(nLevels));
   auto mask_view = atlas::array::make_view<int32_t, 2>(mask);
   for (atlas::idx_t j = 0; j < nNodes; ++j) {
     mask_view(j, 0) = 1;                         // level 0: all ocean
@@ -199,7 +199,7 @@ CASE("test applyMaskToFields vol mask with fewer field levels") {
 
   // Volumetric mask with 5 levels
   atlas::Field mask = funcSpace.createField<int32_t>(
-      atlas::option::name("vol_mask") | atlas::option::levels(5));
+      atlas::option::name("volume_mask") | atlas::option::levels(5));
   auto mask_view = atlas::array::make_view<int32_t, 2>(mask);
   for (atlas::idx_t j = 0; j < nNodes; ++j) {
     for (atlas::idx_t k = 0; k < 5; ++k) {


### PR DESCRIPTION
## Description

Reworks the orca-jedi land-sea mask used to zero-fill invalid points, with two user-facing improvements:

1. **Rename `vol_mask` to `volume_mask`** everywhere (geometry, state, regrid main,mask utilities, tests) for clarity.

2. **Halo-aware masking.** `set_volume_mask` now initialises the mask to ocean (1) everywhere, masks only *owned* nodes from a field's missing values, then `haloExchange`es so ghost/halo nodes reflect true bathymetry from their owning rank. Previously ghost/edge nodes were force-zeroed (a BUMP concern only relevant for the `gmask`) which was wrong for an interpolation source mask.

3. **New: set the mask from an explicit bitmask field read from file.** The `land sea mask` config now takes a `type` (`"missing value"` (default) or `"bitmask"`) and a `land value` (default `0`). For `bitmask`, land is marked where the field value is approximately equal to `land value`, via the new `set_volume_mask_from_bitmask`. This lets users drive the mask directly from a NEMO-style `tmask` rather than relying on missing values.

Mask creation is now lazy and shared through a private `ensure_volume_mask` get-or-create helper; `gmask` is untouched, so BUMP compatibility is preserved.

## Issue(s) addressed

The halo exchange work is groundwork for addressing the first step of #198

## Dependencies

None
 
## Impact

No API break for downstream: `gmask` unchanged. Anything reading the extra field by name must use `volume_mask` (was `vol_mask`). New config keys are optional with back-compatible defaults.

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] New functions are documented briefly via Doxygen comments in the code
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [ ] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments